### PR TITLE
Automate QS CSV handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Make sure you have Node.js and npm installed.
 
 To update the aggregated rankings:
 
-1. Obtain updated ranking data files (e.g., CSV or similar formats for QS, THE, ARWU, US News).
-2. Place the updated files in the `frontend/public/data/` directory, ensuring they are named appropriately (e.g., `qs_rankings.xlsx`, `the_rankings.csv`, `arwu_rankings.csv`, `usnews_rankings.csv`). Note the specific file extensions used by the current scripts.
+1. The scrapers for QS, THE and ARWU now automatically download the latest CSV files from [universityrankings.ch](https://www.universityrankings.ch) whenever you run the aggregation script. You only need to manually supply the US News CSV if you wish to include that source.
+2. If you do need to replace any files manually, drop them in `frontend/public/data/` using the same filenames (`qs_rankings.csv`, `the_rankings.csv`, `arwu_rankings.csv`, `usnews_rankings.csv`).
 
 3. **Generate University Name Mapping (Data Sanitation)**
    Before aggregating, run the matching script to generate or update the university name mapping. This script uses fuzzy matching to identify variations of the same university name across different sources and suggests a standardized name.

--- a/scripts/arwu-scraper.js
+++ b/scripts/arwu-scraper.js
@@ -1,9 +1,13 @@
 // Academic Ranking of World Universities (ARWU) scraper 
 const axios = require('axios');
-const fs = require('fs'); // Import the file system module
-const cheerio = require('cheerio');
-const csv = require('csv-parser'); // Import the csv-parser library
+const fs = require('fs');
+const csv = require('csv-parser');
 const path = require('path');
+
+// URL to download the latest ARWU CSV directly from universityrankings.ch
+// Note: if this URL changes in the future, update the constant accordingly.
+const ARWU_CSV_DOWNLOAD_URL =
+  'https://www.universityrankings.ch/results/Shanghai/2024?mode=csv';
 
 // Updated URL to universityrankings.ch - This is no longer used for fetching, but kept for reference
 // Updated URL to universityrankings.ch
@@ -16,6 +20,27 @@ const ARWU_FILE_PATH = path.join(__dirname, '..', 'frontend', 'public', 'data', 
 // Define the path for the local HTML file
 const LOCAL_ARWU_DATA_PATH_HTML = 'Shanghai Ranking 2024 - Results _ UniversityRankings.ch.html';
 
+// Download the latest ARWU CSV and save it to the data directory
+async function downloadARWUCSV() {
+    try {
+        console.log(`Downloading ARWU CSV from ${ARWU_CSV_DOWNLOAD_URL}...`);
+        const { exec } = require('child_process');
+        await new Promise((resolve, reject) => {
+            exec(`curl -L -o '${ARWU_FILE_PATH}' '${ARWU_CSV_DOWNLOAD_URL}'`, (err, stdout, stderr) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+        console.log(`Saved ARWU CSV to ${ARWU_FILE_PATH}`);
+    } catch (error) {
+        console.error(`Failed to download ARWU CSV: ${error.message}`);
+        throw error;
+    }
+}
+
 /**
  * Scrapes the Academic Ranking of World Universities (ARWU/Shanghai Rankings) from universityrankings.ch.
  * This version reads from a local CSV file.
@@ -26,6 +51,8 @@ async function scrapeARWURankings(limit) {
     const rankings = [];
 
     try {
+        // Always attempt to download the latest data before parsing
+        await downloadARWUCSV();
         console.log(`Reading ARWU rankings from local CSV file ${ARWU_FILE_PATH}...`);
 
         // --- Start of parsing logic with csv-parser ---

--- a/scripts/the-scraper.js
+++ b/scripts/the-scraper.js
@@ -1,18 +1,40 @@
 // scripts/the-scraper.js
-// const axios = require('axios'); // Removed axios dependency
-const fs = require('fs').promises; // Import the file system module
-// const cheerio = require('cheerio'); // Removed cheerio dependency
+const axios = require('axios');
+const fs = require('fs').promises;
 const path = require('path');
 const csv = require('csv-parser'); // Import the csv-parser library
 const { createReadStream } = require('fs'); // Import createReadStream
 const readline = require('readline'); // Import readline for line-by-line reading
 
-// Updated URL to fetch JSON data directly
-// const THE_RANKINGS_URL = 'https://www.timeshighereducation.com/sites/default/files/the_data_rankings/world_university_rankings_2025_0__ba2fbd3409733a83fb62c3ee4219487c.json'; // Removed URL
+// URL to download the latest THE CSV directly from universityrankings.ch
+// Update the year in the URL when a new ranking becomes available
+const THE_CSV_DOWNLOAD_URL =
+  'https://www.universityrankings.ch/results/Times/2025?mode=csv';
 
 // Define the path for the local CSV file
 const THE_CSV_FILE = 'the_rankings.csv';
 const THE_FILE_PATH = path.join(__dirname, '..', 'frontend', 'public', 'data', THE_CSV_FILE);
+
+// Download the latest THE CSV to the data directory
+async function downloadTHECSV() {
+    try {
+        console.log(`Downloading THE CSV from ${THE_CSV_DOWNLOAD_URL}...`);
+        const { exec } = require('child_process');
+        await new Promise((resolve, reject) => {
+            exec(`curl -L -o '${THE_FILE_PATH}' '${THE_CSV_DOWNLOAD_URL}'`, (err) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve();
+                }
+            });
+        });
+        console.log(`Saved THE CSV to ${THE_FILE_PATH}`);
+    } catch (error) {
+        console.error(`Failed to download THE CSV: ${error.message}`);
+        throw error;
+    }
+}
 
 /**
  * Reads the Times Higher Education World University Rankings from a local CSV file using csv-parser.
@@ -22,6 +44,8 @@ async function scrapeTHERankings() {
     const results = [];
 
     try {
+        // Fetch the latest CSV before reading
+        await downloadTHECSV();
         console.log(`Reading THE rankings from local CSV file ${THE_FILE_PATH}...`);
 
         await new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- avoid auto-running `qs-scraper` when required
- document that QS, THE and ARWU CSVs are fetched automatically

## Testing
- `npm install`
- `node scripts/scrape-rankings.js 10`


------
https://chatgpt.com/codex/tasks/task_e_6842548c054c8320873577c304cc8e74