### PR TITLE
Automate US News ranking scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Make sure you have Node.js and npm installed.
 
 To update the aggregated rankings:
 
-1. The scrapers for QS, THE and ARWU now automatically download the latest CSV files from [universityrankings.ch](https://www.universityrankings.ch) whenever you run the aggregation script. You only need to manually supply the US News CSV if you wish to include that source.
-2. If you do need to replace any files manually, drop them in `frontend/public/data/` using the same filenames (`qs_rankings.csv`, `the_rankings.csv`, `arwu_rankings.csv`, `usnews_rankings.csv`).
+1. The scrapers for QS, THE and ARWU now automatically download the latest CSV files from [universityrankings.ch](https://www.universityrankings.ch). US News rankings can be fetched via `node scripts/usnews-scraper.js`, which crawls the public search API and saves a CSV.
+2. If any automated download fails, you can still drop replacement files in `frontend/public/data/` using the same filenames (`qs_rankings.csv`, `the_rankings.csv`, `arwu_rankings.csv`, `usnews_rankings.csv`).
 
 3. **Generate University Name Mapping (Data Sanitation)**
    Before aggregating, run the matching script to generate or update the university name mapping. This script uses fuzzy matching to identify variations of the same university name across different sources and suggests a standardized name.

--- a/scripts/scrape-rankings.js
+++ b/scripts/scrape-rankings.js
@@ -10,6 +10,7 @@ const { createReadStream } = require('fs'); // Import createReadStream
 const { scrapeQSRankings } = require('./qs-scraper'); // Assuming this now reads from file
 const { scrapeTHERankings } = require('./the-scraper'); // Assuming this now reads from file
 const { scrapeARWURankings } = require('./arwu-scraper'); // Assuming this now reads from file
+const { downloadUSNewsCSV } = require('./usnews-scraper');
 
 // Import aggregation logic
 const { aggregateRankings } = require('./aggregation');
@@ -154,8 +155,10 @@ async function main(limit = 400) {
          }).filter(uni => uni !== null).sort((a, b) => a.rank - b.rank);
          console.log(`Processed ${arwuRankings.length} universities from ARWU.`);
 
+        console.log('Fetching US News rankings...');
+        // Download the latest US News CSV via the helper script
+        await downloadUSNewsCSV(limit);
         console.log('Reading US News rankings from file...');
-        // Keep existing logic for US News CSV as it was manually provided
         const usnewsRankings = await new Promise((resolve, reject) => {
             const results = [];
             createReadStream(path.join(__dirname, '..', 'frontend', 'public', 'data', 'usnews_rankings.csv'))

--- a/scripts/usnews-scraper.js
+++ b/scripts/usnews-scraper.js
@@ -1,0 +1,57 @@
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+
+const OUTPUT_PATH = path.join(__dirname, '..', 'frontend', 'public', 'data', 'usnews_rankings.csv');
+const BASE_URL = 'https://www.usnews.com/education/best-global-universities/api/search';
+
+async function fetchPage(offset, count) {
+  const url = `${BASE_URL}?format=json&offset=${offset}&limit=${count}`;
+  const response = await axios.get(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0',
+      'Accept': 'application/json'
+    }
+  });
+  return response.data;
+}
+
+async function scrapeUSNewsRankings(max = 1500) {
+  const pageSize = 200;
+  let results = [];
+  for (let offset = 0; results.length < max; offset += pageSize) {
+    const data = await fetchPage(offset, pageSize);
+    const items = data && (data.items || data.data);
+    if (!items || items.length === 0) break;
+    for (const item of items) {
+      const rank = item.rank || item.ranking || item.position;
+      const name = item.school?.name || item.name || item.title;
+      const country = item.school?.country || item.country || 'N/A';
+      const score = item.overall_score || item.score || item.overall || 'N/A';
+      if (rank) {
+        results.push({ rank, name, country, score });
+      }
+    }
+  }
+  return results.slice(0, max);
+}
+
+async function downloadUSNewsCSV(limit = 1500) {
+  const data = await scrapeUSNewsRankings(limit);
+    const csvLines = ['Rank,University,Country,Score'];
+    data.forEach(d => {
+      const line = [d.rank, d.name.replace(/,/g, ''), d.country.replace(/,/g, ''), d.score].join(',');
+      csvLines.push(line);
+    });
+    fs.writeFileSync(OUTPUT_PATH, csvLines.join('\n'), 'utf8');
+    console.log(`Saved ${data.length} rows to ${OUTPUT_PATH}`);
+  return data;
+}
+
+if (require.main === module) {
+  downloadUSNewsCSV().catch(err => {
+    console.error('Failed to scrape US News:', err.message);
+  });
+}
+
+module.exports = { scrapeUSNewsRankings, downloadUSNewsCSV };


### PR DESCRIPTION
## Summary
- add a new Node.js script `usnews-scraper.js` to fetch rankings from the US News public API and save them as a CSV file
- update the aggregation script to invoke this scraper automatically
- update documentation with instructions for the new scraper

## Testing
- `npm install`
- `node scripts/usnews-scraper.js` *(fails: upstream connect error)*

------
https://chatgpt.com/codex/tasks/task_e_684263080a108320b33565d3f42d8a3f