### PR TITLE
Add country support and filter

### DIFF
--- a/frontend/public/data/aggregated-rankings.json
+++ b/frontend/public/data/aggregated-rankings.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Massachusetts Institute of Technology - MIT",
+    "country": "United States",
     "aggregatedScore": 1710.25,
     "originalRankings": {
       "qs": {
@@ -21,6 +22,7 @@
   },
   {
     "name": "Harvard University",
+    "country": "United States",
     "aggregatedScore": 1710,
     "originalRankings": {
       "qs": {
@@ -41,6 +43,7 @@
   },
   {
     "name": "University of Oxford",
+    "country": "United Kingdom",
     "aggregatedScore": 1708.75,
     "originalRankings": {
       "qs": {
@@ -61,6 +64,7 @@
   },
   {
     "name": "Stanford University",
+    "country": "United States",
     "aggregatedScore": 1708,
     "originalRankings": {
       "qs": {
@@ -81,6 +85,7 @@
   },
   {
     "name": "University of Cambridge",
+    "country": "United Kingdom",
     "aggregatedScore": 1707.25,
     "originalRankings": {
       "qs": {
@@ -101,6 +106,7 @@
   },
   {
     "name": "University of California - Berkeley",
+    "country": "United States",
     "aggregatedScore": 1704.75,
     "originalRankings": {
       "qs": {
@@ -121,6 +127,7 @@
   },
   {
     "name": "Imperial College London",
+    "country": "United Kingdom",
     "aggregatedScore": 1700.25,
     "originalRankings": {
       "qs": {
@@ -141,6 +148,7 @@
   },
   {
     "name": "California Institute of Technology - Caltech",
+    "country": "United States",
     "aggregatedScore": 1700.25,
     "originalRankings": {
       "qs": {
@@ -161,6 +169,7 @@
   },
   {
     "name": "Princeton University",
+    "country": "United States",
     "aggregatedScore": 1699.5,
     "originalRankings": {
       "qs": {
@@ -181,6 +190,7 @@
   },
   {
     "name": "University of Pennsylvania",
+    "country": "United States",
     "aggregatedScore": 1699,
     "originalRankings": {
       "qs": {
@@ -201,6 +211,7 @@
   },
   {
     "name": "University College London",
+    "country": "United Kingdom",
     "aggregatedScore": 1698.75,
     "originalRankings": {
       "qs": {
@@ -221,6 +232,7 @@
   },
   {
     "name": "Yale University",
+    "country": "United States",
     "aggregatedScore": 1698.75,
     "originalRankings": {
       "qs": {
@@ -241,6 +253,7 @@
   },
   {
     "name": "Cornell University",
+    "country": "United States",
     "aggregatedScore": 1695.5,
     "originalRankings": {
       "qs": {
@@ -261,6 +274,7 @@
   },
   {
     "name": "Columbia University",
+    "country": "United States",
     "aggregatedScore": 1695,
     "originalRankings": {
       "qs": {
@@ -281,6 +295,7 @@
   },
   {
     "name": "Tsinghua University",
+    "country": "China",
     "aggregatedScore": 1694.75,
     "originalRankings": {
       "qs": {
@@ -301,6 +316,7 @@
   },
   {
     "name": "University of Chicago",
+    "country": "United States",
     "aggregatedScore": 1694.75,
     "originalRankings": {
       "qs": {
@@ -321,6 +337,7 @@
   },
   {
     "name": "Swiss Federal Institute of Technology Zurich - ETHZ",
+    "country": "Switzerland",
     "aggregatedScore": 1694.25,
     "originalRankings": {
       "qs": {
@@ -341,6 +358,7 @@
   },
   {
     "name": "Johns Hopkins University",
+    "country": "United States",
     "aggregatedScore": 1692.75,
     "originalRankings": {
       "qs": {
@@ -361,6 +379,7 @@
   },
   {
     "name": "Peking University",
+    "country": "China",
     "aggregatedScore": 1691.75,
     "originalRankings": {
       "qs": {
@@ -381,6 +400,7 @@
   },
   {
     "name": "University of Toronto",
+    "country": "Canada",
     "aggregatedScore": 1690,
     "originalRankings": {
       "qs": {
@@ -401,6 +421,7 @@
   },
   {
     "name": "National University of Singapore",
+    "country": "Singapore",
     "aggregatedScore": 1683.5,
     "originalRankings": {
       "qs": {
@@ -421,6 +442,7 @@
   },
   {
     "name": "University of Michigan - Ann Arbor",
+    "country": "United States",
     "aggregatedScore": 1683.5,
     "originalRankings": {
       "qs": {
@@ -441,6 +463,7 @@
   },
   {
     "name": "University of Melbourne",
+    "country": "Australia",
     "aggregatedScore": 1683.25,
     "originalRankings": {
       "qs": {
@@ -461,6 +484,7 @@
   },
   {
     "name": "University of Washington Seattle",
+    "country": "United States",
     "aggregatedScore": 1680.75,
     "originalRankings": {
       "qs": {
@@ -481,6 +505,7 @@
   },
   {
     "name": "University of Edinburgh",
+    "country": "United Kingdom",
     "aggregatedScore": 1678.75,
     "originalRankings": {
       "qs": {
@@ -501,6 +526,7 @@
   },
   {
     "name": "Northwestern University",
+    "country": "United States",
     "aggregatedScore": 1677.75,
     "originalRankings": {
       "qs": {
@@ -521,6 +547,7 @@
   },
   {
     "name": "New York University",
+    "country": "United States",
     "aggregatedScore": 1677.5,
     "originalRankings": {
       "qs": {
@@ -541,6 +568,7 @@
   },
   {
     "name": "University of California - San Diego",
+    "country": "United States",
     "aggregatedScore": 1676,
     "originalRankings": {
       "qs": {
@@ -561,6 +589,7 @@
   },
   {
     "name": "Duke University",
+    "country": "United States",
     "aggregatedScore": 1674,
     "originalRankings": {
       "qs": {
@@ -581,6 +610,7 @@
   },
   {
     "name": "Nanyang Technological University",
+    "country": "Singapore",
     "aggregatedScore": 1671.75,
     "originalRankings": {
       "qs": {
@@ -601,6 +631,7 @@
   },
   {
     "name": "University of Hong Kong",
+    "country": "Hong Kong",
     "aggregatedScore": 1671,
     "originalRankings": {
       "qs": {
@@ -621,6 +652,7 @@
   },
   {
     "name": "University of British Columbia",
+    "country": "Canada",
     "aggregatedScore": 1671,
     "originalRankings": {
       "qs": {
@@ -641,6 +673,7 @@
   },
   {
     "name": "King's College London",
+    "country": "United Kingdom",
     "aggregatedScore": 1671,
     "originalRankings": {
       "qs": {
@@ -661,6 +694,7 @@
   },
   {
     "name": "The University of Tokyo",
+    "country": "Japan",
     "aggregatedScore": 1669.25,
     "originalRankings": {
       "qs": {
@@ -681,6 +715,7 @@
   },
   {
     "name": "Shanghai Jiao Tong University",
+    "country": "China",
     "aggregatedScore": 1665,
     "originalRankings": {
       "qs": {
@@ -701,6 +736,7 @@
   },
   {
     "name": "McGill University",
+    "country": "Canada",
     "aggregatedScore": 1661.25,
     "originalRankings": {
       "qs": {
@@ -721,6 +757,7 @@
   },
   {
     "name": "University of Manchester",
+    "country": "United Kingdom",
     "aggregatedScore": 1660.75,
     "originalRankings": {
       "qs": {
@@ -741,6 +778,7 @@
   },
   {
     "name": "Fudan University",
+    "country": "China",
     "aggregatedScore": 1659.75,
     "originalRankings": {
       "qs": {
@@ -761,6 +799,7 @@
   },
   {
     "name": "Monash University",
+    "country": "Australia",
     "aggregatedScore": 1659.25,
     "originalRankings": {
       "qs": {
@@ -781,6 +820,7 @@
   },
   {
     "name": "University of Texas at Austin",
+    "country": "United States",
     "aggregatedScore": 1658,
     "originalRankings": {
       "qs": {
@@ -801,6 +841,7 @@
   },
   {
     "name": "University of Queensland",
+    "country": "Australia",
     "aggregatedScore": 1657,
     "originalRankings": {
       "qs": {
@@ -821,6 +862,7 @@
   },
   {
     "name": "Chinese University of Hong Kong",
+    "country": "Hong Kong",
     "aggregatedScore": 1656.5,
     "originalRankings": {
       "qs": {
@@ -841,6 +883,7 @@
   },
   {
     "name": "Universit� Paris-Saclay",
+    "country": "France",
     "aggregatedScore": 1656,
     "originalRankings": {
       "qs": {
@@ -861,6 +904,7 @@
   },
   {
     "name": "University of Amsterdam",
+    "country": "Netherlands",
     "aggregatedScore": 1650.5,
     "originalRankings": {
       "qs": {
@@ -881,6 +925,7 @@
   },
   {
     "name": "University of Copenhagen",
+    "country": "Denmark",
     "aggregatedScore": 1644,
     "originalRankings": {
       "qs": {
@@ -901,6 +946,7 @@
   },
   {
     "name": "University of Wisconsin-Madison",
+    "country": "United States",
     "aggregatedScore": 1641.75,
     "originalRankings": {
       "qs": {
@@ -921,6 +967,7 @@
   },
   {
     "name": "Australian National University",
+    "country": "Australia",
     "aggregatedScore": 1640,
     "originalRankings": {
       "qs": {
@@ -941,6 +988,7 @@
   },
   {
     "name": "Washington University in St. Louis",
+    "country": "United States",
     "aggregatedScore": 1637.75,
     "originalRankings": {
       "qs": {
@@ -961,6 +1009,7 @@
   },
   {
     "name": "University of North Carolina at Chapel Hill",
+    "country": "United States",
     "aggregatedScore": 1635.5,
     "originalRankings": {
       "qs": {
@@ -981,6 +1030,7 @@
   },
   {
     "name": "Seoul National University",
+    "country": "South Korea",
     "aggregatedScore": 1633.75,
     "originalRankings": {
       "qs": {
@@ -1001,6 +1051,7 @@
   },
   {
     "name": "Carnegie Mellon University",
+    "country": "United States",
     "aggregatedScore": 1633,
     "originalRankings": {
       "qs": {
@@ -1021,6 +1072,7 @@
   },
   {
     "name": "Kyoto University",
+    "country": "Japan",
     "aggregatedScore": 1632.75,
     "originalRankings": {
       "qs": {
@@ -1041,6 +1093,7 @@
   },
   {
     "name": "City University of Hong Kong",
+    "country": "Hong Kong",
     "aggregatedScore": 1631.75,
     "originalRankings": {
       "qs": {
@@ -1061,6 +1114,7 @@
   },
   {
     "name": "University of Bristol",
+    "country": "United Kingdom",
     "aggregatedScore": 1631,
     "originalRankings": {
       "qs": {
@@ -1081,6 +1135,7 @@
   },
   {
     "name": "University of Glasgow",
+    "country": "United Kingdom",
     "aggregatedScore": 1630.5,
     "originalRankings": {
       "qs": {
@@ -1101,6 +1156,7 @@
   },
   {
     "name": "University of Southern California",
+    "country": "United States",
     "aggregatedScore": 1627.75,
     "originalRankings": {
       "qs": {
@@ -1121,6 +1177,7 @@
   },
   {
     "name": "Hong Kong Polytechnic University",
+    "country": "Hong Kong",
     "aggregatedScore": 1622.5,
     "originalRankings": {
       "qs": {
@@ -1141,6 +1198,7 @@
   },
   {
     "name": "Georgia Institute of Technology",
+    "country": "United States",
     "aggregatedScore": 1618.5,
     "originalRankings": {
       "qs": {
@@ -1161,6 +1219,7 @@
   },
   {
     "name": "University of California - Davis",
+    "country": "United States",
     "aggregatedScore": 1616.75,
     "originalRankings": {
       "qs": {
@@ -1181,6 +1240,7 @@
   },
   {
     "name": "University of Groningen",
+    "country": "Netherlands",
     "aggregatedScore": 1616.25,
     "originalRankings": {
       "qs": {
@@ -1201,6 +1261,7 @@
   },
   {
     "name": "Pennsylvania State University",
+    "country": "United States",
     "aggregatedScore": 1615.75,
     "originalRankings": {
       "qs": {
@@ -1221,6 +1282,7 @@
   },
   {
     "name": "Brown University",
+    "country": "United States",
     "aggregatedScore": 1614.5,
     "originalRankings": {
       "qs": {
@@ -1241,6 +1303,7 @@
   },
   {
     "name": "Lund University",
+    "country": "Sweden",
     "aggregatedScore": 1613.25,
     "originalRankings": {
       "qs": {
@@ -1261,6 +1324,7 @@
   },
   {
     "name": "University of Oslo",
+    "country": "Norway",
     "aggregatedScore": 1609.5,
     "originalRankings": {
       "qs": {
@@ -1281,6 +1345,7 @@
   },
   {
     "name": "University of Western Australia",
+    "country": "Australia",
     "aggregatedScore": 1607.75,
     "originalRankings": {
       "qs": {
@@ -1301,6 +1366,7 @@
   },
   {
     "name": "University of Birmingham",
+    "country": "United Kingdom",
     "aggregatedScore": 1607.75,
     "originalRankings": {
       "qs": {
@@ -1321,6 +1387,7 @@
   },
   {
     "name": "Hong Kong University of Science and Technology",
+    "country": "Hong Kong",
     "aggregatedScore": 1607.5,
     "originalRankings": {
       "qs": {
@@ -1341,6 +1408,7 @@
   },
   {
     "name": "Purdue University",
+    "country": "United States",
     "aggregatedScore": 1603.5,
     "originalRankings": {
       "qs": {
@@ -1361,6 +1429,7 @@
   },
   {
     "name": "University of Helsinki",
+    "country": "Finland",
     "aggregatedScore": 1603.25,
     "originalRankings": {
       "qs": {
@@ -1381,6 +1450,7 @@
   },
   {
     "name": "Erasmus University Rotterdam",
+    "country": "Netherlands",
     "aggregatedScore": 1603.25,
     "originalRankings": {
       "qs": {
@@ -1401,6 +1471,7 @@
   },
   {
     "name": "Delft University of Technology",
+    "country": "Netherlands",
     "aggregatedScore": 1601.5,
     "originalRankings": {
       "qs": {
@@ -1421,6 +1492,7 @@
   },
   {
     "name": "University of Warwick",
+    "country": "United Kingdom",
     "aggregatedScore": 1600.25,
     "originalRankings": {
       "qs": {
@@ -1441,6 +1513,7 @@
   },
   {
     "name": "Aarhus University",
+    "country": "Denmark",
     "aggregatedScore": 1599.5,
     "originalRankings": {
       "qs": {
@@ -1461,6 +1534,7 @@
   },
   {
     "name": "University of Adelaide",
+    "country": "Australia",
     "aggregatedScore": 1599,
     "originalRankings": {
       "qs": {
@@ -1481,6 +1555,7 @@
   },
   {
     "name": "Emory University",
+    "country": "United States",
     "aggregatedScore": 1597.75,
     "originalRankings": {
       "qs": {
@@ -1501,6 +1576,7 @@
   },
   {
     "name": "University of Alberta",
+    "country": "Canada",
     "aggregatedScore": 1596.5,
     "originalRankings": {
       "qs": {
@@ -1521,6 +1597,7 @@
   },
   {
     "name": "Ohio State University",
+    "country": "United States",
     "aggregatedScore": 1595.5,
     "originalRankings": {
       "qs": {
@@ -1541,6 +1618,7 @@
   },
   {
     "name": "Vanderbilt University",
+    "country": "United States",
     "aggregatedScore": 1595.5,
     "originalRankings": {
       "qs": {
@@ -1561,6 +1639,7 @@
   },
   {
     "name": "University of Southampton",
+    "country": "United Kingdom",
     "aggregatedScore": 1595,
     "originalRankings": {
       "qs": {
@@ -1581,6 +1660,7 @@
   },
   {
     "name": "Uppsala University",
+    "country": "Sweden",
     "aggregatedScore": 1594.5,
     "originalRankings": {
       "qs": {
@@ -1601,6 +1681,7 @@
   },
   {
     "name": "University of Nottingham",
+    "country": "United Kingdom",
     "aggregatedScore": 1590.5,
     "originalRankings": {
       "qs": {
@@ -1621,6 +1702,7 @@
   },
   {
     "name": "University of Leeds",
+    "country": "United Kingdom",
     "aggregatedScore": 1588,
     "originalRankings": {
       "qs": {
@@ -1641,6 +1723,7 @@
   },
   {
     "name": "University of Sheffield",
+    "country": "United Kingdom",
     "aggregatedScore": 1583.75,
     "originalRankings": {
       "qs": {
@@ -1661,6 +1744,7 @@
   },
   {
     "name": "University of Basel",
+    "country": "Switzerland",
     "aggregatedScore": 1582.25,
     "originalRankings": {
       "qs": {
@@ -1681,6 +1765,7 @@
   },
   {
     "name": "McMaster University",
+    "country": "Canada",
     "aggregatedScore": 1582.25,
     "originalRankings": {
       "qs": {
@@ -1701,6 +1786,7 @@
   },
   {
     "name": "University of Technology Sydney",
+    "country": "Australia",
     "aggregatedScore": 1580.25,
     "originalRankings": {
       "qs": {
@@ -1721,6 +1807,7 @@
   },
   {
     "name": "University of Bonn",
+    "country": "Germany",
     "aggregatedScore": 1578.75,
     "originalRankings": {
       "qs": {
@@ -1741,6 +1828,7 @@
   },
   {
     "name": "University of Barcelona",
+    "country": "Spain",
     "aggregatedScore": 1576.25,
     "originalRankings": {
       "qs": {
@@ -1761,6 +1849,7 @@
   },
   {
     "name": "Michigan State University",
+    "country": "United States",
     "aggregatedScore": 1575.25,
     "originalRankings": {
       "qs": {
@@ -1781,6 +1870,7 @@
   },
   {
     "name": "University of Geneva",
+    "country": "Switzerland",
     "aggregatedScore": 1575,
     "originalRankings": {
       "qs": {
@@ -1801,6 +1891,7 @@
   },
   {
     "name": "University of Auckland",
+    "country": "New Zealand",
     "aggregatedScore": 1574.75,
     "originalRankings": {
       "qs": {
@@ -1821,6 +1912,7 @@
   },
   {
     "name": "University of Florida",
+    "country": "United States",
     "aggregatedScore": 1574.25,
     "originalRankings": {
       "qs": {
@@ -1841,6 +1933,7 @@
   },
   {
     "name": "Queen Mary - University of London",
+    "country": "United Kingdom",
     "aggregatedScore": 1573.75,
     "originalRankings": {
       "qs": {
@@ -1861,6 +1954,7 @@
   },
   {
     "name": "University of Pittsburgh",
+    "country": "United States",
     "aggregatedScore": 1573.25,
     "originalRankings": {
       "qs": {
@@ -1881,6 +1975,7 @@
   },
   {
     "name": "University of Vienna",
+    "country": "Austria",
     "aggregatedScore": 1571.5,
     "originalRankings": {
       "qs": {
@@ -1901,6 +1996,7 @@
   },
   {
     "name": "University of Liverpool",
+    "country": "United Kingdom",
     "aggregatedScore": 1571.5,
     "originalRankings": {
       "qs": {
@@ -1921,6 +2017,7 @@
   },
   {
     "name": "Yonsei University",
+    "country": "South Korea",
     "aggregatedScore": 1571.25,
     "originalRankings": {
       "qs": {
@@ -1941,6 +2038,7 @@
   },
   {
     "name": "Technical University of Denmark",
+    "country": "Denmark",
     "aggregatedScore": 1570.25,
     "originalRankings": {
       "qs": {
@@ -1961,6 +2059,7 @@
   },
   {
     "name": "Stockholm University",
+    "country": "Sweden",
     "aggregatedScore": 1569,
     "originalRankings": {
       "qs": {
@@ -1981,6 +2080,7 @@
   },
   {
     "name": "University of California - Irvine",
+    "country": "United States",
     "aggregatedScore": 1569,
     "originalRankings": {
       "qs": {
@@ -2001,6 +2101,7 @@
   },
   {
     "name": "Rice University",
+    "country": "United States",
     "aggregatedScore": 1568,
     "originalRankings": {
       "qs": {
@@ -2021,6 +2122,7 @@
   },
   {
     "name": "RWTH Aachen University",
+    "country": "Germany",
     "aggregatedScore": 1559.75,
     "originalRankings": {
       "qs": {
@@ -2041,6 +2143,7 @@
   },
   {
     "name": "University of Bologna",
+    "country": "Italy",
     "aggregatedScore": 1559.75,
     "originalRankings": {
       "qs": {
@@ -2061,6 +2164,7 @@
   },
   {
     "name": "University of Exeter",
+    "country": "United Kingdom",
     "aggregatedScore": 1558.75,
     "originalRankings": {
       "qs": {
@@ -2081,6 +2185,7 @@
   },
   {
     "name": "University of Waterloo",
+    "country": "Canada",
     "aggregatedScore": 1557,
     "originalRankings": {
       "qs": {
@@ -2101,6 +2206,7 @@
   },
   {
     "name": "University of Colorado at Boulder",
+    "country": "United States",
     "aggregatedScore": 1555.75,
     "originalRankings": {
       "qs": {
@@ -2121,6 +2227,7 @@
   },
   {
     "name": "Korea Advanced Institute of Science and Technology - KAIST",
+    "country": "South Korea",
     "aggregatedScore": 1554.25,
     "originalRankings": {
       "qs": {
@@ -2141,6 +2248,7 @@
   },
   {
     "name": "Trinity College Dublin",
+    "country": "Ireland",
     "aggregatedScore": 1554,
     "originalRankings": {
       "qs": {
@@ -2161,6 +2269,7 @@
   },
   {
     "name": "Radboud University of Nijmegen",
+    "country": "Netherlands",
     "aggregatedScore": 1554,
     "originalRankings": {
       "qs": {
@@ -2181,6 +2290,7 @@
   },
   {
     "name": "University of Lausanne",
+    "country": "Switzerland",
     "aggregatedScore": 1553.75,
     "originalRankings": {
       "qs": {
@@ -2201,6 +2311,7 @@
   },
   {
     "name": "Newcastle University - Newcastle-upon-Tyne",
+    "country": "United Kingdom",
     "aggregatedScore": 1550.75,
     "originalRankings": {
       "qs": {
@@ -2221,6 +2332,7 @@
   },
   {
     "name": "Tongji University",
+    "country": "China",
     "aggregatedScore": 1549.75,
     "originalRankings": {
       "qs": {
@@ -2241,6 +2353,7 @@
   },
   {
     "name": "Sungkyunkwan University",
+    "country": "South Korea",
     "aggregatedScore": 1549.5,
     "originalRankings": {
       "qs": {
@@ -2261,6 +2374,7 @@
   },
   {
     "name": "University of Freiburg",
+    "country": "Germany",
     "aggregatedScore": 1549.5,
     "originalRankings": {
       "qs": {
@@ -2281,6 +2395,7 @@
   },
   {
     "name": "Harbin Institute of Technology",
+    "country": "China",
     "aggregatedScore": 1546,
     "originalRankings": {
       "qs": {
@@ -2301,6 +2416,7 @@
   },
   {
     "name": "University of Cape Town",
+    "country": "South Africa",
     "aggregatedScore": 1545.25,
     "originalRankings": {
       "qs": {
@@ -2321,6 +2437,7 @@
   },
   {
     "name": "Texas A&M University",
+    "country": "United States",
     "aggregatedScore": 1545,
     "originalRankings": {
       "qs": {
@@ -2341,6 +2458,7 @@
   },
   {
     "name": "University of Hamburg",
+    "country": "Germany",
     "aggregatedScore": 1544.75,
     "originalRankings": {
       "qs": {
@@ -2361,6 +2479,7 @@
   },
   {
     "name": "National Taiwan University",
+    "country": "Taiwan",
     "aggregatedScore": 1543.75,
     "originalRankings": {
       "qs": {
@@ -2381,6 +2500,7 @@
   },
   {
     "name": "King Saud University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 1541.5,
     "originalRankings": {
       "qs": {
@@ -2401,6 +2521,7 @@
   },
   {
     "name": "University of Arizona",
+    "country": "United States",
     "aggregatedScore": 1538.5,
     "originalRankings": {
       "qs": {
@@ -2421,6 +2542,7 @@
   },
   {
     "name": "University of G�ttingen",
+    "country": "Germany",
     "aggregatedScore": 1538.25,
     "originalRankings": {
       "qs": {
@@ -2441,6 +2563,7 @@
   },
   {
     "name": "Macquarie University",
+    "country": "Australia",
     "aggregatedScore": 1536.25,
     "originalRankings": {
       "qs": {
@@ -2461,6 +2584,7 @@
   },
   {
     "name": "Sun Yat-Sen University",
+    "country": "China",
     "aggregatedScore": 1534.75,
     "originalRankings": {
       "qs": {
@@ -2481,6 +2605,7 @@
   },
   {
     "name": "University of Rochester",
+    "country": "United States",
     "aggregatedScore": 1534,
     "originalRankings": {
       "qs": {
@@ -2501,6 +2626,7 @@
   },
   {
     "name": "Cardiff University",
+    "country": "United Kingdom",
     "aggregatedScore": 1531.75,
     "originalRankings": {
       "qs": {
@@ -2521,6 +2647,7 @@
   },
   {
     "name": "Case Western Reserve University",
+    "country": "United States",
     "aggregatedScore": 1530,
     "originalRankings": {
       "qs": {
@@ -2541,6 +2668,7 @@
   },
   {
     "name": "Arizona State University",
+    "country": "United States",
     "aggregatedScore": 1529.5,
     "originalRankings": {
       "qs": {
@@ -2561,6 +2689,7 @@
   },
   {
     "name": "Tohoku University",
+    "country": "Japan",
     "aggregatedScore": 1527.5,
     "originalRankings": {
       "qs": {
@@ -2581,6 +2710,7 @@
   },
   {
     "name": "University of Calgary",
+    "country": "Canada",
     "aggregatedScore": 1523.25,
     "originalRankings": {
       "qs": {
@@ -2601,6 +2731,7 @@
   },
   {
     "name": "Korea University",
+    "country": "South Korea",
     "aggregatedScore": 1523,
     "originalRankings": {
       "qs": {
@@ -2621,6 +2752,7 @@
   },
   {
     "name": "Karlsruhe Institute of Technology",
+    "country": "Germany",
     "aggregatedScore": 1522.75,
     "originalRankings": {
       "qs": {
@@ -2641,6 +2773,7 @@
   },
   {
     "name": "Osaka University",
+    "country": "Japan",
     "aggregatedScore": 1521.25,
     "originalRankings": {
       "qs": {
@@ -2661,6 +2794,7 @@
   },
   {
     "name": "Tianjin University",
+    "country": "China",
     "aggregatedScore": 1520.75,
     "originalRankings": {
       "qs": {
@@ -2681,6 +2815,7 @@
   },
   {
     "name": "University of Padua",
+    "country": "Italy",
     "aggregatedScore": 1520.25,
     "originalRankings": {
       "qs": {
@@ -2701,6 +2836,7 @@
   },
   {
     "name": "Xi'an Jiaotong University",
+    "country": "China",
     "aggregatedScore": 1519.75,
     "originalRankings": {
       "qs": {
@@ -2721,6 +2857,7 @@
   },
   {
     "name": "Beijing Normal University",
+    "country": "China",
     "aggregatedScore": 1518.75,
     "originalRankings": {
       "qs": {
@@ -2741,6 +2878,7 @@
   },
   {
     "name": "King Abdulaziz University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 1518.5,
     "originalRankings": {
       "qs": {
@@ -2761,6 +2899,7 @@
   },
   {
     "name": "Deakin University",
+    "country": "Australia",
     "aggregatedScore": 1518.25,
     "originalRankings": {
       "qs": {
@@ -2781,6 +2920,7 @@
   },
   {
     "name": "Technical University of Berlin",
+    "country": "Germany",
     "aggregatedScore": 1517.25,
     "originalRankings": {
       "qs": {
@@ -2801,6 +2941,7 @@
   },
   {
     "name": "University of Virginia",
+    "country": "United States",
     "aggregatedScore": 1515.75,
     "originalRankings": {
       "qs": {
@@ -2821,6 +2962,7 @@
   },
   {
     "name": "Tel Aviv University",
+    "country": "Israel",
     "aggregatedScore": 1515.25,
     "originalRankings": {
       "qs": {
@@ -2841,6 +2983,7 @@
   },
   {
     "name": "Curtin University",
+    "country": "Australia",
     "aggregatedScore": 1514.75,
     "originalRankings": {
       "qs": {
@@ -2861,6 +3004,7 @@
   },
   {
     "name": "Universit� Libre de Bruxelles",
+    "country": "Belgium",
     "aggregatedScore": 1514.25,
     "originalRankings": {
       "qs": {
@@ -2881,6 +3025,7 @@
   },
   {
     "name": "University of Ottawa",
+    "country": "Canada",
     "aggregatedScore": 1512.5,
     "originalRankings": {
       "qs": {
@@ -2901,6 +3046,7 @@
   },
   {
     "name": "Queensland University of Technology",
+    "country": "Australia",
     "aggregatedScore": 1512.5,
     "originalRankings": {
       "qs": {
@@ -2921,6 +3067,7 @@
   },
   {
     "name": "Nagoya University",
+    "country": "Japan",
     "aggregatedScore": 1507,
     "originalRankings": {
       "qs": {
@@ -2941,6 +3088,7 @@
   },
   {
     "name": "Polytechnic University of Milan",
+    "country": "Italy",
     "aggregatedScore": 1504.75,
     "originalRankings": {
       "qs": {
@@ -2961,6 +3109,7 @@
   },
   {
     "name": "Indiana University at Bloomington",
+    "country": "United States",
     "aggregatedScore": 1504.75,
     "originalRankings": {
       "qs": {
@@ -2981,6 +3130,7 @@
   },
   {
     "name": "Western University",
+    "country": "Canada",
     "aggregatedScore": 1504,
     "originalRankings": {
       "qs": {
@@ -3001,6 +3151,7 @@
   },
   {
     "name": "University of Cologne",
+    "country": "Germany",
     "aggregatedScore": 1503.75,
     "originalRankings": {
       "qs": {
@@ -3021,6 +3172,7 @@
   },
   {
     "name": "Lancaster University",
+    "country": "United Kingdom",
     "aggregatedScore": 1501.75,
     "originalRankings": {
       "qs": {
@@ -3041,6 +3193,7 @@
   },
   {
     "name": "Sichuan University",
+    "country": "China",
     "aggregatedScore": 1499.25,
     "originalRankings": {
       "qs": {
@@ -3061,6 +3214,7 @@
   },
   {
     "name": "University of California - Santa Cruz",
+    "country": "United States",
     "aggregatedScore": 1495,
     "originalRankings": {
       "qs": {
@@ -3081,6 +3235,7 @@
   },
   {
     "name": "RMIT University",
+    "country": "Australia",
     "aggregatedScore": 1494.75,
     "originalRankings": {
       "qs": {
@@ -3101,6 +3256,7 @@
   },
   {
     "name": "University of Wollongong",
+    "country": "Australia",
     "aggregatedScore": 1494,
     "originalRankings": {
       "qs": {
@@ -3121,6 +3277,7 @@
   },
   {
     "name": "Tokyo Institute of Technology",
+    "country": "Japan",
     "aggregatedScore": 1493.5,
     "originalRankings": {
       "qs": {
@@ -3141,6 +3298,7 @@
   },
   {
     "name": "University of York",
+    "country": "United Kingdom",
     "aggregatedScore": 1493.25,
     "originalRankings": {
       "qs": {
@@ -3161,6 +3319,7 @@
   },
   {
     "name": "University College Dublin",
+    "country": "Ireland",
     "aggregatedScore": 1492,
     "originalRankings": {
       "qs": {
@@ -3181,6 +3340,7 @@
   },
   {
     "name": "University of Milan",
+    "country": "Italy",
     "aggregatedScore": 1491.5,
     "originalRankings": {
       "qs": {
@@ -3201,6 +3361,7 @@
   },
   {
     "name": "University of Sussex",
+    "country": "United Kingdom",
     "aggregatedScore": 1489,
     "originalRankings": {
       "qs": {
@@ -3221,6 +3382,7 @@
   },
   {
     "name": "Nankai University",
+    "country": "China",
     "aggregatedScore": 1482.25,
     "originalRankings": {
       "qs": {
@@ -3241,6 +3403,7 @@
   },
   {
     "name": "Hebrew University of Jerusalem",
+    "country": "Israel",
     "aggregatedScore": 1480.5,
     "originalRankings": {
       "qs": {
@@ -3261,6 +3424,7 @@
   },
   {
     "name": "University of M�nster",
+    "country": "Germany",
     "aggregatedScore": 1477,
     "originalRankings": {
       "qs": {
@@ -3281,6 +3445,7 @@
   },
   {
     "name": "Tufts University",
+    "country": "United States",
     "aggregatedScore": 1476,
     "originalRankings": {
       "qs": {
@@ -3301,6 +3466,7 @@
   },
   {
     "name": "University of Antwerp",
+    "country": "Belgium",
     "aggregatedScore": 1475,
     "originalRankings": {
       "qs": {
@@ -3321,6 +3487,7 @@
   },
   {
     "name": "University of Leicester",
+    "country": "United Kingdom",
     "aggregatedScore": 1469.5,
     "originalRankings": {
       "qs": {
@@ -3341,6 +3508,7 @@
   },
   {
     "name": "Queen's University Belfast",
+    "country": "United Kingdom",
     "aggregatedScore": 1469.25,
     "originalRankings": {
       "qs": {
@@ -3361,6 +3529,7 @@
   },
   {
     "name": "Norwegian University of Science and Technology",
+    "country": "Norway",
     "aggregatedScore": 1466.5,
     "originalRankings": {
       "qs": {
@@ -3381,6 +3550,7 @@
   },
   {
     "name": "University of Utah",
+    "country": "United States",
     "aggregatedScore": 1466.5,
     "originalRankings": {
       "qs": {
@@ -3401,6 +3571,7 @@
   },
   {
     "name": "University of St. Andrews",
+    "country": "United Kingdom",
     "aggregatedScore": 1466.25,
     "originalRankings": {
       "qs": {
@@ -3421,6 +3592,7 @@
   },
   {
     "name": "University of Macau",
+    "country": "Macao",
     "aggregatedScore": 1465.25,
     "originalRankings": {
       "qs": {
@@ -3441,6 +3613,7 @@
   },
   {
     "name": "Griffith University",
+    "country": "Australia",
     "aggregatedScore": 1463.25,
     "originalRankings": {
       "qs": {
@@ -3461,6 +3634,7 @@
   },
   {
     "name": "Zhejiang University of Technology",
+    "country": "China",
     "aggregatedScore": 1462.25,
     "originalRankings": {
       "qs": {
@@ -3481,6 +3655,7 @@
   },
   {
     "name": "University of Bergen",
+    "country": "Switzerland",
     "aggregatedScore": 1461.75,
     "originalRankings": {
       "qs": {
@@ -3501,6 +3676,7 @@
   },
   {
     "name": "University of W�rzburg",
+    "country": "Germany",
     "aggregatedScore": 1461.75,
     "originalRankings": {
       "qs": {
@@ -3521,6 +3697,7 @@
   },
   {
     "name": "University of Aberdeen",
+    "country": "United Kingdom",
     "aggregatedScore": 1461,
     "originalRankings": {
       "qs": {
@@ -3541,6 +3718,7 @@
   },
   {
     "name": "Aalto University",
+    "country": "Finland",
     "aggregatedScore": 1460.75,
     "originalRankings": {
       "qs": {
@@ -3561,6 +3739,7 @@
   },
   {
     "name": "Xiamen University",
+    "country": "China",
     "aggregatedScore": 1459.25,
     "originalRankings": {
       "qs": {
@@ -3581,6 +3760,7 @@
   },
   {
     "name": "Southeast University",
+    "country": "China",
     "aggregatedScore": 1459,
     "originalRankings": {
       "qs": {
@@ -3601,6 +3781,7 @@
   },
   {
     "name": "Hunan University",
+    "country": "China",
     "aggregatedScore": 1457.5,
     "originalRankings": {
       "qs": {
@@ -3621,6 +3802,7 @@
   },
   {
     "name": "North Carolina State University",
+    "country": "United States",
     "aggregatedScore": 1456,
     "originalRankings": {
       "qs": {
@@ -3641,6 +3823,7 @@
   },
   {
     "name": "Northeastern University",
+    "country": "United States",
     "aggregatedScore": 1456,
     "originalRankings": {
       "qs": {
@@ -3661,6 +3844,7 @@
   },
   {
     "name": "Kyushu University",
+    "country": "Japan",
     "aggregatedScore": 1455.75,
     "originalRankings": {
       "qs": {
@@ -3681,6 +3865,7 @@
   },
   {
     "name": "Dartmouth College",
+    "country": "United States",
     "aggregatedScore": 1454.25,
     "originalRankings": {
       "qs": {
@@ -3701,6 +3886,7 @@
   },
   {
     "name": "La Trobe University",
+    "country": "Australia",
     "aggregatedScore": 1449,
     "originalRankings": {
       "qs": {
@@ -3721,6 +3907,7 @@
   },
   {
     "name": "Queen's University",
+    "country": "Canada",
     "aggregatedScore": 1448.75,
     "originalRankings": {
       "qs": {
@@ -3741,6 +3928,7 @@
   },
   {
     "name": "University of Electronic Science and Technology of China",
+    "country": "China",
     "aggregatedScore": 1448.25,
     "originalRankings": {
       "qs": {
@@ -3761,6 +3949,7 @@
   },
   {
     "name": "University of Newcastle - Australia",
+    "country": "Australia",
     "aggregatedScore": 1445.75,
     "originalRankings": {
       "qs": {
@@ -3781,6 +3970,7 @@
   },
   {
     "name": "University of Miami",
+    "country": "United States",
     "aggregatedScore": 1445.5,
     "originalRankings": {
       "qs": {
@@ -3801,6 +3991,7 @@
   },
   {
     "name": "Ulsan National Institute of Science and Technology",
+    "country": "South Korea",
     "aggregatedScore": 1444,
     "originalRankings": {
       "qs": {
@@ -3821,6 +4012,7 @@
   },
   {
     "name": "Beihang University",
+    "country": "China",
     "aggregatedScore": 1442,
     "originalRankings": {
       "qs": {
@@ -3841,6 +4033,7 @@
   },
   {
     "name": "Vrije Universiteit Brussel",
+    "country": "Belgium",
     "aggregatedScore": 1440.75,
     "originalRankings": {
       "qs": {
@@ -3861,6 +4054,7 @@
   },
   {
     "name": "University of Naples Federico II",
+    "country": "Italy",
     "aggregatedScore": 1440.75,
     "originalRankings": {
       "qs": {
@@ -3881,6 +4075,7 @@
   },
   {
     "name": "University of Southern Denmark",
+    "country": "Denmark",
     "aggregatedScore": 1436.5,
     "originalRankings": {
       "qs": {
@@ -3901,6 +4096,7 @@
   },
   {
     "name": "Linkoping University",
+    "country": "Sweden",
     "aggregatedScore": 1435.75,
     "originalRankings": {
       "qs": {
@@ -3921,6 +4117,7 @@
   },
   {
     "name": "Autonomous University of Madrid",
+    "country": "Spain",
     "aggregatedScore": 1430.5,
     "originalRankings": {
       "qs": {
@@ -3941,6 +4138,7 @@
   },
   {
     "name": "University of Pisa",
+    "country": "Italy",
     "aggregatedScore": 1430,
     "originalRankings": {
       "qs": {
@@ -3961,6 +4159,7 @@
   },
   {
     "name": "University of Tasmania",
+    "country": "Australia",
     "aggregatedScore": 1429.75,
     "originalRankings": {
       "qs": {
@@ -3981,6 +4180,7 @@
   },
   {
     "name": "University of Witwatersrand",
+    "country": "South Africa",
     "aggregatedScore": 1429,
     "originalRankings": {
       "qs": {
@@ -4001,6 +4201,7 @@
   },
   {
     "name": "University of Illinois at Chicago",
+    "country": "United States",
     "aggregatedScore": 1428.75,
     "originalRankings": {
       "qs": {
@@ -4021,6 +4222,7 @@
   },
   {
     "name": "George Washington University",
+    "country": "United States",
     "aggregatedScore": 1426.25,
     "originalRankings": {
       "qs": {
@@ -4041,6 +4243,7 @@
   },
   {
     "name": "Nanjing University of Technology",
+    "country": "China",
     "aggregatedScore": 1426,
     "originalRankings": {
       "qs": {
@@ -4061,6 +4264,7 @@
   },
   {
     "name": "University of Reading",
+    "country": "United Kingdom",
     "aggregatedScore": 1424.25,
     "originalRankings": {
       "qs": {
@@ -4081,6 +4285,7 @@
   },
   {
     "name": "Hanyang University",
+    "country": "South Korea",
     "aggregatedScore": 1422.5,
     "originalRankings": {
       "qs": {
@@ -4101,6 +4306,7 @@
   },
   {
     "name": "Hokkaido University",
+    "country": "Japan",
     "aggregatedScore": 1421.25,
     "originalRankings": {
       "qs": {
@@ -4121,6 +4327,7 @@
   },
   {
     "name": "University of California - Riverside",
+    "country": "United States",
     "aggregatedScore": 1419.25,
     "originalRankings": {
       "qs": {
@@ -4141,6 +4348,7 @@
   },
   {
     "name": "University of East Anglia",
+    "country": "United Kingdom",
     "aggregatedScore": 1417,
     "originalRankings": {
       "qs": {
@@ -4161,6 +4369,7 @@
   },
   {
     "name": "Aix-Marseille University",
+    "country": "France",
     "aggregatedScore": 1416.75,
     "originalRankings": {
       "qs": {
@@ -4181,6 +4390,7 @@
   },
   {
     "name": "University of Notre Dame",
+    "country": "United States",
     "aggregatedScore": 1414.5,
     "originalRankings": {
       "qs": {
@@ -4201,6 +4411,7 @@
   },
   {
     "name": "Shenzhen University",
+    "country": "China",
     "aggregatedScore": 1413,
     "originalRankings": {
       "qs": {
@@ -4221,6 +4432,7 @@
   },
   {
     "name": "Vita-Salute San Raffaele University",
+    "country": "Italy",
     "aggregatedScore": 1412.25,
     "originalRankings": {
       "qs": {
@@ -4241,6 +4453,7 @@
   },
   {
     "name": "Charles University Prague",
+    "country": "Czech Republic",
     "aggregatedScore": 1412,
     "originalRankings": {
       "qs": {
@@ -4261,6 +4474,7 @@
   },
   {
     "name": "East China Normal University",
+    "country": "China",
     "aggregatedScore": 1410.75,
     "originalRankings": {
       "qs": {
@@ -4281,6 +4495,7 @@
   },
   {
     "name": "University of Surrey",
+    "country": "United Kingdom",
     "aggregatedScore": 1408.75,
     "originalRankings": {
       "qs": {
@@ -4301,6 +4516,7 @@
   },
   {
     "name": "University of Twente",
+    "country": "Netherlands",
     "aggregatedScore": 1405.75,
     "originalRankings": {
       "qs": {
@@ -4321,6 +4537,7 @@
   },
   {
     "name": "University of Tennessee - Knoxville",
+    "country": "United States",
     "aggregatedScore": 1405.25,
     "originalRankings": {
       "qs": {
@@ -4341,6 +4558,7 @@
   },
   {
     "name": "Dalhousie University",
+    "country": "Canada",
     "aggregatedScore": 1405,
     "originalRankings": {
       "qs": {
@@ -4361,6 +4579,7 @@
   },
   {
     "name": "Aalborg University",
+    "country": "Denmark",
     "aggregatedScore": 1403.25,
     "originalRankings": {
       "qs": {
@@ -4381,6 +4600,7 @@
   },
   {
     "name": "State University of New York at Stony Brook",
+    "country": "United States",
     "aggregatedScore": 1402.5,
     "originalRankings": {
       "qs": {
@@ -4401,6 +4621,7 @@
   },
   {
     "name": "University of Otago",
+    "country": "New Zealand",
     "aggregatedScore": 1399.5,
     "originalRankings": {
       "qs": {
@@ -4421,6 +4642,7 @@
   },
   {
     "name": "University of Florence",
+    "country": "Italy",
     "aggregatedScore": 1394.25,
     "originalRankings": {
       "qs": {
@@ -4441,6 +4663,7 @@
   },
   {
     "name": "University of Innsbruck",
+    "country": "Austria",
     "aggregatedScore": 1393,
     "originalRankings": {
       "qs": {
@@ -4461,6 +4684,7 @@
   },
   {
     "name": "Chongqing University",
+    "country": "China",
     "aggregatedScore": 1390.75,
     "originalRankings": {
       "qs": {
@@ -4481,6 +4705,7 @@
   },
   {
     "name": "Complutense University of Madrid",
+    "country": "Spain",
     "aggregatedScore": 1390,
     "originalRankings": {
       "qs": {
@@ -4501,6 +4726,7 @@
   },
   {
     "name": "Georgetown University",
+    "country": "United States",
     "aggregatedScore": 1384,
     "originalRankings": {
       "qs": {
@@ -4521,6 +4747,7 @@
   },
   {
     "name": "Simon Fraser University",
+    "country": "Canada",
     "aggregatedScore": 1380,
     "originalRankings": {
       "qs": {
@@ -4541,6 +4768,7 @@
   },
   {
     "name": "University of Li�ge",
+    "country": "Belgium",
     "aggregatedScore": 1380,
     "originalRankings": {
       "qs": {
@@ -4561,6 +4789,7 @@
   },
   {
     "name": "University of Victoria",
+    "country": "Canada",
     "aggregatedScore": 1378.25,
     "originalRankings": {
       "qs": {
@@ -4581,6 +4810,7 @@
   },
   {
     "name": "University College Cork",
+    "country": "Ireland",
     "aggregatedScore": 1378,
     "originalRankings": {
       "qs": {
@@ -4601,6 +4831,7 @@
   },
   {
     "name": "Sejong University",
+    "country": "South Korea",
     "aggregatedScore": 1377.5,
     "originalRankings": {
       "qs": {
@@ -4621,6 +4852,7 @@
   },
   {
     "name": "Dalian University of Technology",
+    "country": "China",
     "aggregatedScore": 1376.75,
     "originalRankings": {
       "qs": {
@@ -4641,6 +4873,7 @@
   },
   {
     "name": "University of Potsdam",
+    "country": "Germany",
     "aggregatedScore": 1374.75,
     "originalRankings": {
       "qs": {
@@ -4661,6 +4894,7 @@
   },
   {
     "name": "Colorado State University",
+    "country": "United States",
     "aggregatedScore": 1373.5,
     "originalRankings": {
       "qs": {
@@ -4681,6 +4915,7 @@
   },
   {
     "name": "University of Iowa",
+    "country": "United States",
     "aggregatedScore": 1369,
     "originalRankings": {
       "qs": {
@@ -4701,6 +4936,7 @@
   },
   {
     "name": "University of Navarra",
+    "country": "Spain",
     "aggregatedScore": 1365.75,
     "originalRankings": {
       "qs": {
@@ -4721,6 +4957,7 @@
   },
   {
     "name": "University of Valencia",
+    "country": "Spain",
     "aggregatedScore": 1362.75,
     "originalRankings": {
       "qs": {
@@ -4741,6 +4978,7 @@
   },
   {
     "name": "Laval University",
+    "country": "Canada",
     "aggregatedScore": 1358.75,
     "originalRankings": {
       "qs": {
@@ -4761,6 +4999,7 @@
   },
   {
     "name": "University of Oulu",
+    "country": "Finland",
     "aggregatedScore": 1358,
     "originalRankings": {
       "qs": {
@@ -4781,6 +5020,7 @@
   },
   {
     "name": "Shanghai University",
+    "country": "China",
     "aggregatedScore": 1357.75,
     "originalRankings": {
       "qs": {
@@ -4801,6 +5041,7 @@
   },
   {
     "name": "University of Milan - Bicocca",
+    "country": "Italy",
     "aggregatedScore": 1357.75,
     "originalRankings": {
       "qs": {
@@ -4821,6 +5062,7 @@
   },
   {
     "name": "University of South Australia",
+    "country": "Australia",
     "aggregatedScore": 1357.25,
     "originalRankings": {
       "qs": {
@@ -4841,6 +5083,7 @@
   },
   {
     "name": "University of Trento",
+    "country": "Italy",
     "aggregatedScore": 1355.25,
     "originalRankings": {
       "qs": {
@@ -4861,6 +5104,7 @@
   },
   {
     "name": "University of Kansas",
+    "country": "United States",
     "aggregatedScore": 1353.25,
     "originalRankings": {
       "qs": {
@@ -4881,6 +5125,7 @@
   },
   {
     "name": "University of Kiel",
+    "country": "Germany",
     "aggregatedScore": 1353.25,
     "originalRankings": {
       "qs": {
@@ -4901,6 +5146,7 @@
   },
   {
     "name": "University of Tehran",
+    "country": "Iran",
     "aggregatedScore": 1351,
     "originalRankings": {
       "qs": {
@@ -4921,6 +5167,7 @@
   },
   {
     "name": "State University of New York at Buffalo",
+    "country": "United States",
     "aggregatedScore": 1351,
     "originalRankings": {
       "qs": {
@@ -4941,6 +5188,7 @@
   },
   {
     "name": "University of Pavia",
+    "country": "Italy",
     "aggregatedScore": 1350.25,
     "originalRankings": {
       "qs": {
@@ -4961,6 +5209,7 @@
   },
   {
     "name": "Boston University",
+    "country": "United States",
     "aggregatedScore": 1348.25,
     "originalRankings": {
       "qs": {
@@ -4981,6 +5230,7 @@
   },
   {
     "name": "University of Rome - Tor Vergata",
+    "country": "Italy",
     "aggregatedScore": 1346.25,
     "originalRankings": {
       "qs": {
@@ -5001,6 +5251,7 @@
   },
   {
     "name": "University of Johannesburg",
+    "country": "South Africa",
     "aggregatedScore": 1344.5,
     "originalRankings": {
       "qs": {
@@ -5021,6 +5272,7 @@
   },
   {
     "name": "Florida State University",
+    "country": "United States",
     "aggregatedScore": 1342.25,
     "originalRankings": {
       "qs": {
@@ -5041,6 +5293,7 @@
   },
   {
     "name": "Beijing University of Technology",
+    "country": "China",
     "aggregatedScore": 1341.75,
     "originalRankings": {
       "qs": {
@@ -5061,6 +5314,7 @@
   },
   {
     "name": "University of Dundee",
+    "country": "United Kingdom",
     "aggregatedScore": 1341.75,
     "originalRankings": {
       "qs": {
@@ -5081,6 +5335,7 @@
   },
   {
     "name": "University of Connecticut",
+    "country": "United States",
     "aggregatedScore": 1341.75,
     "originalRankings": {
       "qs": {
@@ -5101,6 +5356,7 @@
   },
   {
     "name": "University of Delaware",
+    "country": "United States",
     "aggregatedScore": 1340.75,
     "originalRankings": {
       "qs": {
@@ -5121,6 +5377,7 @@
   },
   {
     "name": "Kyung Hee University",
+    "country": "South Korea",
     "aggregatedScore": 1338.25,
     "originalRankings": {
       "qs": {
@@ -5141,6 +5398,7 @@
   },
   {
     "name": "University of Tartu",
+    "country": "Estonia",
     "aggregatedScore": 1336.25,
     "originalRankings": {
       "qs": {
@@ -5161,6 +5419,7 @@
   },
   {
     "name": "University Claude Bernard - Lyon I",
+    "country": "France",
     "aggregatedScore": 1335.25,
     "originalRankings": {
       "qs": {
@@ -5181,6 +5440,7 @@
   },
   {
     "name": "University of Hawaii at Manoa",
+    "country": "United States",
     "aggregatedScore": 1333,
     "originalRankings": {
       "qs": {
@@ -5201,6 +5461,7 @@
   },
   {
     "name": "National Tsinghua University",
+    "country": "Taiwan",
     "aggregatedScore": 1332,
     "originalRankings": {
       "qs": {
@@ -5221,6 +5482,7 @@
   },
   {
     "name": "University of Turin",
+    "country": "Italy",
     "aggregatedScore": 1329.25,
     "originalRankings": {
       "qs": {
@@ -5241,6 +5503,7 @@
   },
   {
     "name": "Swansea University",
+    "country": "United Kingdom",
     "aggregatedScore": 1327.5,
     "originalRankings": {
       "qs": {
@@ -5261,6 +5524,7 @@
   },
   {
     "name": "Victoria University of Wellington",
+    "country": "New Zealand",
     "aggregatedScore": 1325,
     "originalRankings": {
       "qs": {
@@ -5281,6 +5545,7 @@
   },
   {
     "name": "James Cook University",
+    "country": "Australia",
     "aggregatedScore": 1322.5,
     "originalRankings": {
       "qs": {
@@ -5301,6 +5566,7 @@
   },
   {
     "name": "University of Colorado at Denver",
+    "country": "United States",
     "aggregatedScore": 1322.5,
     "originalRankings": {
       "qs": {
@@ -5321,6 +5587,7 @@
   },
   {
     "name": "University of Strathclyde",
+    "country": "United Kingdom",
     "aggregatedScore": 1321,
     "originalRankings": {
       "qs": {
@@ -5341,6 +5608,7 @@
   },
   {
     "name": "Hong Kong Baptist University",
+    "country": "Hong Kong",
     "aggregatedScore": 1318.5,
     "originalRankings": {
       "qs": {
@@ -5361,6 +5629,7 @@
   },
   {
     "name": "University of Genoa",
+    "country": "Italy",
     "aggregatedScore": 1317,
     "originalRankings": {
       "qs": {
@@ -5381,6 +5650,7 @@
   },
   {
     "name": "University of South Florida",
+    "country": "United States",
     "aggregatedScore": 1311,
     "originalRankings": {
       "qs": {
@@ -5401,6 +5671,7 @@
   },
   {
     "name": "University of Duisburg-Essen",
+    "country": "Germany",
     "aggregatedScore": 1297.5,
     "originalRankings": {
       "qs": {
@@ -5421,6 +5692,7 @@
   },
   {
     "name": "Washington State University",
+    "country": "United States",
     "aggregatedScore": 1296,
     "originalRankings": {
       "qs": {
@@ -5441,6 +5713,7 @@
   },
   {
     "name": "University of Luxembourg",
+    "country": "Luxembourg",
     "aggregatedScore": 1295.75,
     "originalRankings": {
       "qs": {
@@ -5461,6 +5734,7 @@
   },
   {
     "name": "University of Houston",
+    "country": "United States",
     "aggregatedScore": 1293.75,
     "originalRankings": {
       "qs": {
@@ -5481,6 +5755,7 @@
   },
   {
     "name": "University of Manitoba",
+    "country": "Canada",
     "aggregatedScore": 1292.25,
     "originalRankings": {
       "qs": {
@@ -5501,6 +5776,7 @@
   },
   {
     "name": "University of Granada",
+    "country": "Spain",
     "aggregatedScore": 1291,
     "originalRankings": {
       "qs": {
@@ -5521,6 +5797,7 @@
   },
   {
     "name": "University of Georgia",
+    "country": "United States",
     "aggregatedScore": 1290.25,
     "originalRankings": {
       "qs": {
@@ -5541,6 +5818,7 @@
   },
   {
     "name": "University of Sharjah",
+    "country": "United Arab Emirates",
     "aggregatedScore": 1288,
     "originalRankings": {
       "qs": {
@@ -5561,6 +5839,7 @@
   },
   {
     "name": "Jagiellonian University",
+    "country": "Poland",
     "aggregatedScore": 1286,
     "originalRankings": {
       "qs": {
@@ -5581,6 +5860,7 @@
   },
   {
     "name": "Umea University",
+    "country": "Sweden",
     "aggregatedScore": 1285,
     "originalRankings": {
       "qs": {
@@ -5601,6 +5881,7 @@
   },
   {
     "name": "United Arab Emirates University",
+    "country": "United Arab Emirates",
     "aggregatedScore": 1283.75,
     "originalRankings": {
       "qs": {
@@ -5621,6 +5902,7 @@
   },
   {
     "name": "Iowa State University",
+    "country": "United States",
     "aggregatedScore": 1283.25,
     "originalRankings": {
       "qs": {
@@ -5641,6 +5923,7 @@
   },
   {
     "name": "Cairo University",
+    "country": "Egypt",
     "aggregatedScore": 1281.5,
     "originalRankings": {
       "qs": {
@@ -5661,6 +5944,7 @@
   },
   {
     "name": "University of Warsaw",
+    "country": "Poland",
     "aggregatedScore": 1277.5,
     "originalRankings": {
       "qs": {
@@ -5681,6 +5965,7 @@
   },
   {
     "name": "Polytechnic University of Turin",
+    "country": "Italy",
     "aggregatedScore": 1274.25,
     "originalRankings": {
       "qs": {
@@ -5701,6 +5986,7 @@
   },
   {
     "name": "King Khalid University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 1273.75,
     "originalRankings": {
       "qs": {
@@ -5721,6 +6007,7 @@
   },
   {
     "name": "Temple University",
+    "country": "United States",
     "aggregatedScore": 1270.25,
     "originalRankings": {
       "qs": {
@@ -5741,6 +6028,7 @@
   },
   {
     "name": "University of Missouri - Columbia",
+    "country": "United States",
     "aggregatedScore": 1260,
     "originalRankings": {
       "qs": {
@@ -5761,6 +6049,7 @@
   },
   {
     "name": "Sharif University of Technology",
+    "country": "Iran",
     "aggregatedScore": 1247.25,
     "originalRankings": {
       "qs": {
@@ -5781,6 +6070,7 @@
   },
   {
     "name": "University of Kentucky",
+    "country": "United States",
     "aggregatedScore": 1246.75,
     "originalRankings": {
       "qs": {
@@ -5801,6 +6091,7 @@
   },
   {
     "name": "Brunel University",
+    "country": "United Kingdom",
     "aggregatedScore": 1240.75,
     "originalRankings": {
       "qs": {
@@ -5821,6 +6112,7 @@
   },
   {
     "name": "University of Pretoria",
+    "country": "South Africa",
     "aggregatedScore": 1238.5,
     "originalRankings": {
       "qs": {
@@ -5841,6 +6133,7 @@
   },
   {
     "name": "University of Nebraska - Lincoln",
+    "country": "United States",
     "aggregatedScore": 1237.25,
     "originalRankings": {
       "qs": {
@@ -5861,6 +6154,7 @@
   },
   {
     "name": "Drexel University",
+    "country": "United States",
     "aggregatedScore": 1237,
     "originalRankings": {
       "qs": {
@@ -5881,6 +6175,7 @@
   },
   {
     "name": "Edith Cowan University",
+    "country": "Australia",
     "aggregatedScore": 1230.75,
     "originalRankings": {
       "qs": {
@@ -5901,6 +6196,7 @@
   },
   {
     "name": "American University of Beirut",
+    "country": "Lebanon",
     "aggregatedScore": 1229,
     "originalRankings": {
       "qs": {
@@ -5921,6 +6217,7 @@
   },
   {
     "name": "Tulane University",
+    "country": "United States",
     "aggregatedScore": 1227,
     "originalRankings": {
       "qs": {
@@ -5941,6 +6238,7 @@
   },
   {
     "name": "University of Texas at Dallas",
+    "country": "United States",
     "aggregatedScore": 1222.75,
     "originalRankings": {
       "qs": {
@@ -5961,6 +6259,7 @@
   },
   {
     "name": "Florida International University",
+    "country": "United States",
     "aggregatedScore": 1220.5,
     "originalRankings": {
       "qs": {
@@ -5981,6 +6280,7 @@
   },
   {
     "name": "University of Central Florida",
+    "country": "United States",
     "aggregatedScore": 1218.5,
     "originalRankings": {
       "qs": {
@@ -6001,6 +6301,7 @@
   },
   {
     "name": "University of KwaZulu-Natal",
+    "country": "South Africa",
     "aggregatedScore": 1214.75,
     "originalRankings": {
       "qs": {
@@ -6021,6 +6322,7 @@
   },
   {
     "name": "University of Oregon",
+    "country": "United States",
     "aggregatedScore": 1213,
     "originalRankings": {
       "qs": {
@@ -6041,6 +6343,7 @@
   },
   {
     "name": "Nanjing University of Science and Technology",
+    "country": "South Korea",
     "aggregatedScore": 1211.75,
     "originalRankings": {
       "qs": {
@@ -6061,6 +6364,7 @@
   },
   {
     "name": "University of the Basque Country",
+    "country": "Spain",
     "aggregatedScore": 1211.5,
     "originalRankings": {
       "qs": {
@@ -6081,6 +6385,7 @@
   },
   {
     "name": "Humboldt University of Berlin",
+    "country": "Germany",
     "aggregatedScore": 1200.9375,
     "originalRankings": {
       "qs": {
@@ -6098,6 +6403,7 @@
   },
   {
     "name": "Free University of Berlin",
+    "country": "Germany",
     "aggregatedScore": 1198.96875,
     "originalRankings": {
       "qs": {
@@ -6115,6 +6421,7 @@
   },
   {
     "name": "University of Brescia",
+    "country": "Italy",
     "aggregatedScore": 1186.5,
     "originalRankings": {
       "qs": {
@@ -6135,6 +6442,7 @@
   },
   {
     "name": "University of Vermont",
+    "country": "Italy",
     "aggregatedScore": 1182.75,
     "originalRankings": {
       "qs": {
@@ -6155,6 +6463,7 @@
   },
   {
     "name": "Wake Forest University",
+    "country": "United States",
     "aggregatedScore": 1181.75,
     "originalRankings": {
       "qs": {
@@ -6175,6 +6484,7 @@
   },
   {
     "name": "Federal University of Rio Grande do Sul",
+    "country": "Brazil",
     "aggregatedScore": 1180,
     "originalRankings": {
       "qs": {
@@ -6195,6 +6505,7 @@
   },
   {
     "name": "Wuhan University of Technology",
+    "country": "China",
     "aggregatedScore": 1178.25,
     "originalRankings": {
       "qs": {
@@ -6215,6 +6526,7 @@
   },
   {
     "name": "COMSATS University Islamabad",
+    "country": "Pakistan",
     "aggregatedScore": 1161.75,
     "originalRankings": {
       "qs": {
@@ -6235,6 +6547,7 @@
   },
   {
     "name": "China University of Petroleum (Beijing)",
+    "country": "China",
     "aggregatedScore": 1154.75,
     "originalRankings": {
       "qs": {
@@ -6255,6 +6568,7 @@
   },
   {
     "name": "Australian Catholic University",
+    "country": "Australia",
     "aggregatedScore": 1146,
     "originalRankings": {
       "qs": {
@@ -6275,6 +6589,7 @@
   },
   {
     "name": "University of Trieste",
+    "country": "Italy",
     "aggregatedScore": 1142,
     "originalRankings": {
       "qs": {
@@ -6295,6 +6610,7 @@
   },
   {
     "name": "Louisiana State University",
+    "country": "United States",
     "aggregatedScore": 1130.25,
     "originalRankings": {
       "qs": {
@@ -6315,6 +6631,7 @@
   },
   {
     "name": "University of Bari",
+    "country": "United Kingdom",
     "aggregatedScore": 1128.5,
     "originalRankings": {
       "qs": {
@@ -6335,6 +6652,7 @@
   },
   {
     "name": "Wayne State University",
+    "country": "United States",
     "aggregatedScore": 1122.5,
     "originalRankings": {
       "qs": {
@@ -6355,6 +6673,7 @@
   },
   {
     "name": "Syracuse University",
+    "country": "United States",
     "aggregatedScore": 1116.75,
     "originalRankings": {
       "qs": {
@@ -6375,6 +6694,7 @@
   },
   {
     "name": "University of Ljubljana",
+    "country": "Slovenia",
     "aggregatedScore": 1113.5,
     "originalRankings": {
       "qs": {
@@ -6395,6 +6715,7 @@
   },
   {
     "name": "Karolinska Institute",
+    "country": "Sweden",
     "aggregatedScore": 1105.059375,
     "originalRankings": {
       "the": {
@@ -6412,6 +6733,7 @@
   },
   {
     "name": "Mansoura University",
+    "country": "Egypt",
     "aggregatedScore": 1090.25,
     "originalRankings": {
       "qs": {
@@ -6432,6 +6754,7 @@
   },
   {
     "name": "North-West University",
+    "country": "South Africa",
     "aggregatedScore": 1055.5,
     "originalRankings": {
       "qs": {
@@ -6452,6 +6775,7 @@
   },
   {
     "name": "Quaid-i-Azam University",
+    "country": "Pakistan",
     "aggregatedScore": 1017.40625,
     "originalRankings": {
       "qs": {
@@ -6469,6 +6793,7 @@
   },
   {
     "name": "Medical University of Vienna",
+    "country": "Austria",
     "aggregatedScore": 1003.9968749999999,
     "originalRankings": {
       "the": {
@@ -6486,6 +6811,7 @@
   },
   {
     "name": "Duy Tan University",
+    "country": "Viet Nam",
     "aggregatedScore": 952.875,
     "originalRankings": {
       "qs": {
@@ -6503,6 +6829,7 @@
   },
   {
     "name": "Utrecht University",
+    "country": "Netherlands",
     "aggregatedScore": 949.5500000000001,
     "originalRankings": {
       "qs": {
@@ -6520,6 +6847,7 @@
   },
   {
     "name": "University of Zurich",
+    "country": "Switzerland",
     "aggregatedScore": 942.9875000000001,
     "originalRankings": {
       "qs": {
@@ -6537,6 +6865,7 @@
   },
   {
     "name": "University of California - Los Angeles",
+    "country": "United States",
     "aggregatedScore": 940.1875,
     "originalRankings": {
       "qs": {
@@ -6554,6 +6883,7 @@
   },
   {
     "name": "PSL Research University Paris",
+    "country": "France",
     "aggregatedScore": 934.9375,
     "originalRankings": {
       "qs": {
@@ -6571,6 +6901,7 @@
   },
   {
     "name": "Technical University of M�nchen",
+    "country": "Germany",
     "aggregatedScore": 934.5,
     "originalRankings": {
       "qs": {
@@ -6588,6 +6919,7 @@
   },
   {
     "name": "Swiss Federal Institute of Technology Lausanne - EPFL",
+    "country": "Switzerland",
     "aggregatedScore": 931.875,
     "originalRankings": {
       "qs": {
@@ -6605,6 +6937,7 @@
   },
   {
     "name": "Bogazici University",
+    "country": "Turkey",
     "aggregatedScore": 926.84375,
     "originalRankings": {
       "qs": {
@@ -6622,6 +6955,7 @@
   },
   {
     "name": "University of M�nchen",
+    "country": "Germany",
     "aggregatedScore": 925.96875,
     "originalRankings": {
       "qs": {
@@ -6639,6 +6973,7 @@
   },
   {
     "name": "Prince Sultan University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 925.3125,
     "originalRankings": {
       "qs": {
@@ -6656,6 +6991,7 @@
   },
   {
     "name": "China Medical University - Taiwan",
+    "country": "Taiwan",
     "aggregatedScore": 920.4343749999999,
     "originalRankings": {
       "the": {
@@ -6673,6 +7009,7 @@
   },
   {
     "name": "University of Illinois at Urbana-Champaign",
+    "country": "United States",
     "aggregatedScore": 919.40625,
     "originalRankings": {
       "qs": {
@@ -6690,6 +7027,7 @@
   },
   {
     "name": "University of New South Wales",
+    "country": "Australia",
     "aggregatedScore": 917.4375,
     "originalRankings": {
       "qs": {
@@ -6707,6 +7045,7 @@
   },
   {
     "name": "Sorbonne University",
+    "country": "France",
     "aggregatedScore": 917.21875,
     "originalRankings": {
       "qs": {
@@ -6724,6 +7063,7 @@
   },
   {
     "name": "University of Heidelberg",
+    "country": "Germany",
     "aggregatedScore": 917,
     "originalRankings": {
       "qs": {
@@ -6741,6 +7081,7 @@
   },
   {
     "name": "Catholic University of Leuven",
+    "country": "Belgium",
     "aggregatedScore": 916.34375,
     "originalRankings": {
       "qs": {
@@ -6758,6 +7099,7 @@
   },
   {
     "name": "Ton Duc Thang University",
+    "country": "Viet Nam",
     "aggregatedScore": 915.03125,
     "originalRankings": {
       "qs": {
@@ -6775,6 +7117,7 @@
   },
   {
     "name": "London School of Economics",
+    "country": "United Kingdom",
     "aggregatedScore": 901.6875,
     "originalRankings": {
       "qs": {
@@ -6792,6 +7135,7 @@
   },
   {
     "name": "Medical University of Graz",
+    "country": "Austria",
     "aggregatedScore": 901.1843749999999,
     "originalRankings": {
       "the": {
@@ -6809,6 +7153,7 @@
   },
   {
     "name": "George Mason University",
+    "country": "United States",
     "aggregatedScore": 894.6218749999999,
     "originalRankings": {
       "the": {
@@ -6826,6 +7171,7 @@
   },
   {
     "name": "Moscow State University",
+    "country": "Russia",
     "aggregatedScore": 890.53125,
     "originalRankings": {
       "qs": {
@@ -6843,6 +7189,7 @@
   },
   {
     "name": "University of California - Santa Barbara",
+    "country": "United States",
     "aggregatedScore": 889,
     "originalRankings": {
       "qs": {
@@ -6860,6 +7207,7 @@
   },
   {
     "name": "University of Minnesota - Twin Cities",
+    "country": "United States",
     "aggregatedScore": 882.875,
     "originalRankings": {
       "qs": {
@@ -6877,6 +7225,7 @@
   },
   {
     "name": "KTH - Royal Institute of Technology",
+    "country": "Sweden",
     "aggregatedScore": 875.65625,
     "originalRankings": {
       "qs": {
@@ -6894,6 +7243,7 @@
   },
   {
     "name": "Wageningen University & Research Center",
+    "country": "Netherlands",
     "aggregatedScore": 875,
     "originalRankings": {
       "qs": {
@@ -6911,6 +7261,7 @@
   },
   {
     "name": "Medical University of Innsbruck",
+    "country": "Austria",
     "aggregatedScore": 874.4968749999999,
     "originalRankings": {
       "the": {
@@ -6928,6 +7279,7 @@
   },
   {
     "name": "University of Maryland at College Park",
+    "country": "United States",
     "aggregatedScore": 871.71875,
     "originalRankings": {
       "qs": {
@@ -6945,6 +7297,7 @@
   },
   {
     "name": "University of Sao Paulo",
+    "country": "Brazil",
     "aggregatedScore": 870.84375,
     "originalRankings": {
       "qs": {
@@ -6962,6 +7315,7 @@
   },
   {
     "name": "Fuzhou University",
+    "country": "China",
     "aggregatedScore": 867.9343749999999,
     "originalRankings": {
       "the": {
@@ -6979,6 +7333,7 @@
   },
   {
     "name": "Institut Polytechnique de Paris",
+    "country": "France",
     "aggregatedScore": 865.15625,
     "originalRankings": {
       "qs": {
@@ -6996,6 +7351,7 @@
   },
   {
     "name": "University of Rome - La Sapienza",
+    "country": "Italy",
     "aggregatedScore": 865.15625,
     "originalRankings": {
       "qs": {
@@ -7013,6 +7369,7 @@
   },
   {
     "name": "University of Montreal",
+    "country": "Canada",
     "aggregatedScore": 861.4375,
     "originalRankings": {
       "qs": {
@@ -7030,6 +7387,7 @@
   },
   {
     "name": "Humanitas University",
+    "country": "Italy",
     "aggregatedScore": 857.8718749999999,
     "originalRankings": {
       "the": {
@@ -7047,6 +7405,7 @@
   },
   {
     "name": "Northeastern University in China",
+    "country": "China",
     "aggregatedScore": 853.2781249999999,
     "originalRankings": {
       "the": {
@@ -7064,6 +7423,7 @@
   },
   {
     "name": "University of T�bingen",
+    "country": "Germany",
     "aggregatedScore": 853.125,
     "originalRankings": {
       "qs": {
@@ -7081,6 +7441,7 @@
   },
   {
     "name": "G�teborg University",
+    "country": "Sweden",
     "aggregatedScore": 848.09375,
     "originalRankings": {
       "qs": {
@@ -7098,6 +7459,7 @@
   },
   {
     "name": "Qingdao University",
+    "country": "China",
     "aggregatedScore": 847.8093749999999,
     "originalRankings": {
       "the": {
@@ -7115,6 +7477,7 @@
   },
   {
     "name": "VU University Amsterdam",
+    "country": "Netherlands",
     "aggregatedScore": 845.46875,
     "originalRankings": {
       "qs": {
@@ -7132,6 +7495,7 @@
   },
   {
     "name": "Central South University",
+    "country": "China",
     "aggregatedScore": 843.0187500000001,
     "originalRankings": {
       "qs": {
@@ -7149,6 +7513,7 @@
   },
   {
     "name": "Shandong University",
+    "country": "China",
     "aggregatedScore": 839.5187500000001,
     "originalRankings": {
       "qs": {
@@ -7166,6 +7531,7 @@
   },
   {
     "name": "Taif University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 838.6218749999999,
     "originalRankings": {
       "the": {
@@ -7183,6 +7549,7 @@
   },
   {
     "name": "Huazhong University of Science and Technology",
+    "country": "China",
     "aggregatedScore": 837.375,
     "originalRankings": {
       "qs": {
@@ -7200,6 +7567,7 @@
   },
   {
     "name": "Paris Cit� University",
+    "country": "France",
     "aggregatedScore": 837.375,
     "originalRankings": {
       "qs": {
@@ -7217,6 +7585,7 @@
   },
   {
     "name": "University of Buenos Aires",
+    "country": "Argentina",
     "aggregatedScore": 836.4562500000001,
     "originalRankings": {
       "qs": {
@@ -7234,6 +7603,7 @@
   },
   {
     "name": "University of Massachusetts - Amherst",
+    "country": "United States",
     "aggregatedScore": 834.09375,
     "originalRankings": {
       "qs": {
@@ -7251,6 +7621,7 @@
   },
   {
     "name": "University of Durham",
+    "country": "United Kingdom",
     "aggregatedScore": 833.65625,
     "originalRankings": {
       "qs": {
@@ -7268,6 +7639,7 @@
   },
   {
     "name": "University of Maastricht",
+    "country": "Netherlands",
     "aggregatedScore": 833.4375,
     "originalRankings": {
       "qs": {
@@ -7285,6 +7657,7 @@
   },
   {
     "name": "Southern University of Science and Technology",
+    "country": "China",
     "aggregatedScore": 832.34375,
     "originalRankings": {
       "qs": {
@@ -7302,6 +7675,7 @@
   },
   {
     "name": "Jiangnan University",
+    "country": "China",
     "aggregatedScore": 830.3093749999999,
     "originalRankings": {
       "the": {
@@ -7319,6 +7693,7 @@
   },
   {
     "name": "Catholic University of Louvain",
+    "country": "Belgium",
     "aggregatedScore": 829.9375,
     "originalRankings": {
       "qs": {
@@ -7336,6 +7711,7 @@
   },
   {
     "name": "Scuola Normale Superiore di Pisa",
+    "country": "Italy",
     "aggregatedScore": 828.7781249999999,
     "originalRankings": {
       "the": {
@@ -7353,6 +7729,7 @@
   },
   {
     "name": "Technical University of Dresden",
+    "country": "Germany",
     "aggregatedScore": 826.4375,
     "originalRankings": {
       "qs": {
@@ -7370,6 +7747,7 @@
   },
   {
     "name": "University of Erlangen-N�rnberg",
+    "country": "Germany",
     "aggregatedScore": 819.65625,
     "originalRankings": {
       "qs": {
@@ -7387,6 +7765,7 @@
   },
   {
     "name": "Guangzhou University",
+    "country": "China",
     "aggregatedScore": 814.1218749999999,
     "originalRankings": {
       "the": {
@@ -7404,6 +7783,7 @@
   },
   {
     "name": "Nanjing Forestry University",
+    "country": "China",
     "aggregatedScore": 812.8093749999999,
     "originalRankings": {
       "the": {
@@ -7421,6 +7801,7 @@
   },
   {
     "name": "Rush University",
+    "country": "United States",
     "aggregatedScore": 812.3718749999999,
     "originalRankings": {
       "the": {
@@ -7438,6 +7819,7 @@
   },
   {
     "name": "University of Frankfurt am Main",
+    "country": "Germany",
     "aggregatedScore": 812,
     "originalRankings": {
       "qs": {
@@ -7455,6 +7837,7 @@
   },
   {
     "name": "Xidian University",
+    "country": "China",
     "aggregatedScore": 810.6218749999999,
     "originalRankings": {
       "the": {
@@ -7472,6 +7855,7 @@
   },
   {
     "name": "Autonomous University of Barcelona",
+    "country": "Spain",
     "aggregatedScore": 808.9375,
     "originalRankings": {
       "qs": {
@@ -7489,6 +7873,7 @@
   },
   {
     "name": "Zhengzhou University",
+    "country": "China",
     "aggregatedScore": 803.2062500000001,
     "originalRankings": {
       "qs": {
@@ -7506,6 +7891,7 @@
   },
   {
     "name": "Baylor University",
+    "country": "United States",
     "aggregatedScore": 802.3093749999999,
     "originalRankings": {
       "the": {
@@ -7523,6 +7909,7 @@
   },
   {
     "name": "University of Malaya",
+    "country": "Malaysia",
     "aggregatedScore": 800.84375,
     "originalRankings": {
       "qs": {
@@ -7540,6 +7927,7 @@
   },
   {
     "name": "Eindhoven University of Technology",
+    "country": "Netherlands",
     "aggregatedScore": 798.65625,
     "originalRankings": {
       "qs": {
@@ -7557,6 +7945,7 @@
   },
   {
     "name": "South China University of Technology",
+    "country": "China",
     "aggregatedScore": 795.375,
     "originalRankings": {
       "qs": {
@@ -7574,6 +7963,7 @@
   },
   {
     "name": "Ecole Normale Sup�rieure de Lyon",
+    "country": "France",
     "aggregatedScore": 794.9375,
     "originalRankings": {
       "qs": {
@@ -7591,6 +7981,7 @@
   },
   {
     "name": "Chalmers University of Technology",
+    "country": "Sweden",
     "aggregatedScore": 794.5,
     "originalRankings": {
       "qs": {
@@ -7608,6 +7999,7 @@
   },
   {
     "name": "University Pompeu Fabra",
+    "country": "Spain",
     "aggregatedScore": 794.28125,
     "originalRankings": {
       "qs": {
@@ -7625,6 +8017,7 @@
   },
   {
     "name": "Swinburne University of Technology",
+    "country": "Australia",
     "aggregatedScore": 794.0625,
     "originalRankings": {
       "qs": {
@@ -7642,6 +8035,7 @@
   },
   {
     "name": "Jilin University",
+    "country": "China",
     "aggregatedScore": 788.5500000000001,
     "originalRankings": {
       "qs": {
@@ -7659,6 +8053,7 @@
   },
   {
     "name": "Grenoble Alpes University",
+    "country": "France",
     "aggregatedScore": 784.65625,
     "originalRankings": {
       "qs": {
@@ -7676,6 +8071,7 @@
   },
   {
     "name": "Vienna University of Technology",
+    "country": "Austria",
     "aggregatedScore": 783.34375,
     "originalRankings": {
       "qs": {
@@ -7693,6 +8089,7 @@
   },
   {
     "name": "University of Qatar",
+    "country": "Qatar",
     "aggregatedScore": 776.34375,
     "originalRankings": {
       "qs": {
@@ -7710,6 +8107,7 @@
   },
   {
     "name": "Virginia Polytechnic Institute and State University",
+    "country": "United States",
     "aggregatedScore": 772.625,
     "originalRankings": {
       "qs": {
@@ -7727,6 +8125,7 @@
   },
   {
     "name": "University of Science and Technology Beijing",
+    "country": "China",
     "aggregatedScore": 769.7375000000001,
     "originalRankings": {
       "qs": {
@@ -7744,6 +8143,7 @@
   },
   {
     "name": "University of International Business and Economics",
+    "country": "China",
     "aggregatedScore": 769.7156249999999,
     "originalRankings": {
       "the": {
@@ -7761,6 +8161,7 @@
   },
   {
     "name": "Indian Institute of Science",
+    "country": "India",
     "aggregatedScore": 767.8125,
     "originalRankings": {
       "qs": {
@@ -7778,6 +8179,7 @@
   },
   {
     "name": "University of Stuttgart",
+    "country": "Germany",
     "aggregatedScore": 767.15625,
     "originalRankings": {
       "qs": {
@@ -7795,6 +8197,7 @@
   },
   {
     "name": "University of Porto",
+    "country": "Portugal",
     "aggregatedScore": 764.09375,
     "originalRankings": {
       "qs": {
@@ -7812,6 +8215,7 @@
   },
   {
     "name": "Technical University of Darmstadt",
+    "country": "Germany",
     "aggregatedScore": 761.25,
     "originalRankings": {
       "qs": {
@@ -7829,6 +8233,7 @@
   },
   {
     "name": "University of Bochum",
+    "country": "Germany",
     "aggregatedScore": 760.15625,
     "originalRankings": {
       "qs": {
@@ -7846,6 +8251,7 @@
   },
   {
     "name": "Northwestern Polytechnical University",
+    "country": "China",
     "aggregatedScore": 759.9375,
     "originalRankings": {
       "qs": {
@@ -7863,6 +8269,7 @@
   },
   {
     "name": "Technion - Israel Institute of Technology",
+    "country": "Israel",
     "aggregatedScore": 759.28125,
     "originalRankings": {
       "qs": {
@@ -7880,6 +8287,7 @@
   },
   {
     "name": "University of Mainz",
+    "country": "Germany",
     "aggregatedScore": 759.0625,
     "originalRankings": {
       "qs": {
@@ -7897,6 +8305,7 @@
   },
   {
     "name": "Jiangsu University",
+    "country": "China",
     "aggregatedScore": 755.0593749999999,
     "originalRankings": {
       "the": {
@@ -7914,6 +8323,7 @@
   },
   {
     "name": "Tsukuba University",
+    "country": "Japan",
     "aggregatedScore": 753.375,
     "originalRankings": {
       "qs": {
@@ -7931,6 +8341,7 @@
   },
   {
     "name": "Zhejiang Normal University",
+    "country": "China",
     "aggregatedScore": 752.8718749999999,
     "originalRankings": {
       "the": {
@@ -7948,6 +8359,7 @@
   },
   {
     "name": "South China Agricultural University",
+    "country": "China",
     "aggregatedScore": 749.1750000000001,
     "originalRankings": {
       "qs": {
@@ -7965,6 +8377,7 @@
   },
   {
     "name": "University of Montpellier",
+    "country": "France",
     "aggregatedScore": 748.78125,
     "originalRankings": {
       "qs": {
@@ -7982,6 +8395,7 @@
   },
   {
     "name": "King Fahd University of Petroleum & Minerals",
+    "country": "Saudi Arabia",
     "aggregatedScore": 742.65625,
     "originalRankings": {
       "qs": {
@@ -7999,6 +8413,7 @@
   },
   {
     "name": "State University of Campinas",
+    "country": "Brazil",
     "aggregatedScore": 741.34375,
     "originalRankings": {
       "qs": {
@@ -8016,6 +8431,7 @@
   },
   {
     "name": "University of Western Sydney",
+    "country": "Australia",
     "aggregatedScore": 740.90625,
     "originalRankings": {
       "qs": {
@@ -8033,6 +8449,7 @@
   },
   {
     "name": "University of Stellenbosch",
+    "country": "South Africa",
     "aggregatedScore": 738.28125,
     "originalRankings": {
       "qs": {
@@ -8050,6 +8467,7 @@
   },
   {
     "name": "Khalifa University",
+    "country": "United Arab Emirates",
     "aggregatedScore": 736.96875,
     "originalRankings": {
       "qs": {
@@ -8067,6 +8485,7 @@
   },
   {
     "name": "Al Azhar University",
+    "country": "Egypt",
     "aggregatedScore": 736.2468749999999,
     "originalRankings": {
       "the": {
@@ -8084,6 +8503,7 @@
   },
   {
     "name": "China University of Geosciences Wuhan",
+    "country": "China",
     "aggregatedScore": 733.6437500000001,
     "originalRankings": {
       "qs": {
@@ -8101,6 +8521,7 @@
   },
   {
     "name": "National Yang Ming Chiao Tung University",
+    "country": "Taiwan",
     "aggregatedScore": 733.25,
     "originalRankings": {
       "qs": {
@@ -8118,6 +8539,7 @@
   },
   {
     "name": "University of Jena",
+    "country": "Germany",
     "aggregatedScore": 731.71875,
     "originalRankings": {
       "qs": {
@@ -8135,6 +8557,7 @@
   },
   {
     "name": "Oregon State University",
+    "country": "United States",
     "aggregatedScore": 730.5812500000001,
     "originalRankings": {
       "qs": {
@@ -8152,6 +8575,7 @@
   },
   {
     "name": "Flinders University",
+    "country": "Australia",
     "aggregatedScore": 729.53125,
     "originalRankings": {
       "qs": {
@@ -8169,6 +8593,7 @@
   },
   {
     "name": "University of Ulm",
+    "country": "Germany",
     "aggregatedScore": 726.03125,
     "originalRankings": {
       "qs": {
@@ -8186,6 +8611,7 @@
   },
   {
     "name": "Keio University",
+    "country": "Japan",
     "aggregatedScore": 718.15625,
     "originalRankings": {
       "qs": {
@@ -8203,6 +8629,7 @@
   },
   {
     "name": "University of Saskatchewan",
+    "country": "Canada",
     "aggregatedScore": 717.71875,
     "originalRankings": {
       "qs": {
@@ -8220,6 +8647,7 @@
   },
   {
     "name": "National Autonomous University of Mexico",
+    "country": "Mexico",
     "aggregatedScore": 716.84375,
     "originalRankings": {
       "qs": {
@@ -8237,6 +8665,7 @@
   },
   {
     "name": "University of Cincinnati",
+    "country": "United States",
     "aggregatedScore": 716.3625000000001,
     "originalRankings": {
       "qs": {
@@ -8254,6 +8683,7 @@
   },
   {
     "name": "Macau University of Science and Technology",
+    "country": "Macao",
     "aggregatedScore": 712.46875,
     "originalRankings": {
       "qs": {
@@ -8271,6 +8701,7 @@
   },
   {
     "name": "National Cheng Kung University",
+    "country": "Taiwan",
     "aggregatedScore": 712.25,
     "originalRankings": {
       "qs": {
@@ -8288,6 +8719,7 @@
   },
   {
     "name": "University of Kent at Canterbury",
+    "country": "United Kingdom",
     "aggregatedScore": 708.96875,
     "originalRankings": {
       "qs": {
@@ -8305,6 +8737,7 @@
   },
   {
     "name": "University of Bordeaux",
+    "country": "France",
     "aggregatedScore": 707.875,
     "originalRankings": {
       "qs": {
@@ -8322,6 +8755,7 @@
   },
   {
     "name": "National University of Malaysia",
+    "country": "Malaysia",
     "aggregatedScore": 707.21875,
     "originalRankings": {
       "qs": {
@@ -8339,6 +8773,7 @@
   },
   {
     "name": "Catholic University of the Sacred Heart",
+    "country": "Italy",
     "aggregatedScore": 706.34375,
     "originalRankings": {
       "qs": {
@@ -8356,6 +8791,7 @@
   },
   {
     "name": "University of Science - Malaysia",
+    "country": "Malaysia",
     "aggregatedScore": 705.46875,
     "originalRankings": {
       "qs": {
@@ -8373,6 +8809,7 @@
   },
   {
     "name": "University of Canterbury",
+    "country": "New Zealand",
     "aggregatedScore": 702.1875,
     "originalRankings": {
       "qs": {
@@ -8390,6 +8827,7 @@
   },
   {
     "name": "York University",
+    "country": "Canada",
     "aggregatedScore": 701.96875,
     "originalRankings": {
       "qs": {
@@ -8407,6 +8845,7 @@
   },
   {
     "name": "Nanjing Agricultural University",
+    "country": "China",
     "aggregatedScore": 699.5187500000001,
     "originalRankings": {
       "qs": {
@@ -8424,6 +8863,7 @@
   },
   {
     "name": "University of Hannover",
+    "country": "Germany",
     "aggregatedScore": 698.90625,
     "originalRankings": {
       "qs": {
@@ -8441,6 +8881,7 @@
   },
   {
     "name": "Pontifical Catholic University of Chile",
+    "country": "Chile",
     "aggregatedScore": 695.1875,
     "originalRankings": {
       "qs": {
@@ -8458,6 +8899,7 @@
   },
   {
     "name": "University of Athens",
+    "country": "Greece",
     "aggregatedScore": 695.1875,
     "originalRankings": {
       "qs": {
@@ -8475,6 +8917,7 @@
   },
   {
     "name": "Renmin University of China",
+    "country": "China",
     "aggregatedScore": 694.2687500000001,
     "originalRankings": {
       "qs": {
@@ -8492,6 +8935,7 @@
   },
   {
     "name": "Moscow Institute of Physics and Technology",
+    "country": "Russia",
     "aggregatedScore": 692.34375,
     "originalRankings": {
       "qs": {
@@ -8509,6 +8953,7 @@
   },
   {
     "name": "University of Konstanz",
+    "country": "Germany",
     "aggregatedScore": 690.15625,
     "originalRankings": {
       "qs": {
@@ -8526,6 +8971,7 @@
   },
   {
     "name": "National University of Ireland - Galway",
+    "country": "Ireland",
     "aggregatedScore": 688.625,
     "originalRankings": {
       "qs": {
@@ -8543,6 +8989,7 @@
   },
   {
     "name": "Loughborough University",
+    "country": "United Kingdom",
     "aggregatedScore": 688.40625,
     "originalRankings": {
       "qs": {
@@ -8560,6 +9007,7 @@
   },
   {
     "name": "University of Bayreuth",
+    "country": "Germany",
     "aggregatedScore": 687.75,
     "originalRankings": {
       "qs": {
@@ -8577,6 +9025,7 @@
   },
   {
     "name": "University of Coimbra",
+    "country": "Portugal",
     "aggregatedScore": 681.625,
     "originalRankings": {
       "qs": {
@@ -8594,6 +9043,7 @@
   },
   {
     "name": "University of Tampere",
+    "country": "Finland",
     "aggregatedScore": 680.09375,
     "originalRankings": {
       "qs": {
@@ -8611,6 +9061,7 @@
   },
   {
     "name": "Ben-Gurion University of the Negev",
+    "country": "Israel",
     "aggregatedScore": 678.125,
     "originalRankings": {
       "qs": {
@@ -8628,6 +9079,7 @@
   },
   {
     "name": "Jinan University - Guangdong",
+    "country": "China",
     "aggregatedScore": 676.15625,
     "originalRankings": {
       "qs": {
@@ -8645,6 +9097,7 @@
   },
   {
     "name": "Soochow University",
+    "country": "China",
     "aggregatedScore": 673.75,
     "originalRankings": {
       "qs": {
@@ -8662,6 +9115,7 @@
   },
   {
     "name": "University of Giessen",
+    "country": "Germany",
     "aggregatedScore": 672.875,
     "originalRankings": {
       "qs": {
@@ -8679,6 +9133,7 @@
   },
   {
     "name": "Huazhong Agricultural University",
+    "country": "China",
     "aggregatedScore": 672.8312500000001,
     "originalRankings": {
       "qs": {
@@ -8696,6 +9151,7 @@
   },
   {
     "name": "Tilburg University",
+    "country": "Netherlands",
     "aggregatedScore": 672.4375,
     "originalRankings": {
       "qs": {
@@ -8713,6 +9169,7 @@
   },
   {
     "name": "Beijing University of Chemical Technology",
+    "country": "China",
     "aggregatedScore": 671.5625,
     "originalRankings": {
       "qs": {
@@ -8730,6 +9187,7 @@
   },
   {
     "name": "University of D�sseldorf",
+    "country": "Germany",
     "aggregatedScore": 671.5625,
     "originalRankings": {
       "qs": {
@@ -8747,6 +9205,7 @@
   },
   {
     "name": "University of Lugano",
+    "country": "Switzerland",
     "aggregatedScore": 670.6875,
     "originalRankings": {
       "qs": {
@@ -8764,6 +9223,7 @@
   },
   {
     "name": "University of Essex",
+    "country": "United Kingdom",
     "aggregatedScore": 666.96875,
     "originalRankings": {
       "qs": {
@@ -8781,6 +9241,7 @@
   },
   {
     "name": "Murdoch University",
+    "country": "Australia",
     "aggregatedScore": 663.90625,
     "originalRankings": {
       "qs": {
@@ -8798,6 +9259,7 @@
   },
   {
     "name": "University of Southern Queensland",
+    "country": "Australia",
     "aggregatedScore": 661.71875,
     "originalRankings": {
       "qs": {
@@ -8815,6 +9277,7 @@
   },
   {
     "name": "University of Guelph",
+    "country": "Canada",
     "aggregatedScore": 659.53125,
     "originalRankings": {
       "qs": {
@@ -8832,6 +9295,7 @@
   },
   {
     "name": "University of Aveiro",
+    "country": "Portugal",
     "aggregatedScore": 658.875,
     "originalRankings": {
       "qs": {
@@ -8849,6 +9313,7 @@
   },
   {
     "name": "University of Zagreb",
+    "country": "Croatia",
     "aggregatedScore": 653.1437500000001,
     "originalRankings": {
       "qs": {
@@ -8866,6 +9331,7 @@
   },
   {
     "name": "University of Bremen",
+    "country": "Germany",
     "aggregatedScore": 651.65625,
     "originalRankings": {
       "qs": {
@@ -8883,6 +9349,7 @@
   },
   {
     "name": "University of South Carolina",
+    "country": "United States",
     "aggregatedScore": 649.6875,
     "originalRankings": {
       "qs": {
@@ -8900,6 +9367,7 @@
   },
   {
     "name": "Federal University of Rio de Janeiro",
+    "country": "Brazil",
     "aggregatedScore": 649.03125,
     "originalRankings": {
       "qs": {
@@ -8917,6 +9385,7 @@
   },
   {
     "name": "Masaryk University",
+    "country": "Czech Republic",
     "aggregatedScore": 648.15625,
     "originalRankings": {
       "qs": {
@@ -8934,6 +9403,7 @@
   },
   {
     "name": "Kyungpook National University",
+    "country": "South Korea",
     "aggregatedScore": 646.40625,
     "originalRankings": {
       "qs": {
@@ -8951,6 +9421,7 @@
   },
   {
     "name": "Ain Shams University",
+    "country": "Egypt",
     "aggregatedScore": 645.9250000000001,
     "originalRankings": {
       "qs": {
@@ -8968,6 +9439,7 @@
   },
   {
     "name": "Brandeis University",
+    "country": "United States",
     "aggregatedScore": 645.3125,
     "originalRankings": {
       "qs": {
@@ -8985,6 +9457,7 @@
   },
   {
     "name": "Pusan National University",
+    "country": "South Korea",
     "aggregatedScore": 644.65625,
     "originalRankings": {
       "qs": {
@@ -9002,6 +9475,7 @@
   },
   {
     "name": "Chulalongkorn University",
+    "country": "Thailand",
     "aggregatedScore": 643.5625,
     "originalRankings": {
       "qs": {
@@ -9019,6 +9493,7 @@
   },
   {
     "name": "Ocean University of China",
+    "country": "China",
     "aggregatedScore": 643.5187500000001,
     "originalRankings": {
       "qs": {
@@ -9036,6 +9511,7 @@
   },
   {
     "name": "University of Waikato",
+    "country": "New Zealand",
     "aggregatedScore": 642.25,
     "originalRankings": {
       "qs": {
@@ -9053,6 +9529,7 @@
   },
   {
     "name": "Polytechnic University of Valencia",
+    "country": "Spain",
     "aggregatedScore": 642.03125,
     "originalRankings": {
       "qs": {
@@ -9070,6 +9547,7 @@
   },
   {
     "name": "University of Fribourg",
+    "country": "Switzerland",
     "aggregatedScore": 641.375,
     "originalRankings": {
       "qs": {
@@ -9087,6 +9565,7 @@
   },
   {
     "name": "University of Belgrade",
+    "country": "Serbia",
     "aggregatedScore": 640.0187500000001,
     "originalRankings": {
       "qs": {
@@ -9104,6 +9583,7 @@
   },
   {
     "name": "Koc University",
+    "country": "Turkey",
     "aggregatedScore": 638.75,
     "originalRankings": {
       "qs": {
@@ -9121,6 +9601,7 @@
   },
   {
     "name": "Lebanese American University",
+    "country": "Lebanon",
     "aggregatedScore": 638.75,
     "originalRankings": {
       "qs": {
@@ -9138,6 +9619,7 @@
   },
   {
     "name": "Virginia Commonwealth University",
+    "country": "United States",
     "aggregatedScore": 638.75,
     "originalRankings": {
       "qs": {
@@ -9155,6 +9637,7 @@
   },
   {
     "name": "Heriot-Watt University",
+    "country": "United Kingdom",
     "aggregatedScore": 637.65625,
     "originalRankings": {
       "qs": {
@@ -9172,6 +9655,7 @@
   },
   {
     "name": "ISCTE-University Institute of Lisbon",
+    "country": "Portugal",
     "aggregatedScore": 636.5625,
     "originalRankings": {
       "qs": {
@@ -9189,6 +9673,7 @@
   },
   {
     "name": "Bangor University",
+    "country": "United Kingdom",
     "aggregatedScore": 633.71875,
     "originalRankings": {
       "qs": {
@@ -9206,6 +9691,7 @@
   },
   {
     "name": "Princess Nourah bint Abdulrahman University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 632.1875,
     "originalRankings": {
       "qs": {
@@ -9223,6 +9709,7 @@
   },
   {
     "name": "University of Cyprus",
+    "country": "Cyprus",
     "aggregatedScore": 630.4375,
     "originalRankings": {
       "qs": {
@@ -9240,6 +9727,7 @@
   },
   {
     "name": "National Taiwan University of Science and Technology",
+    "country": "Taiwan",
     "aggregatedScore": 629.78125,
     "originalRankings": {
       "qs": {
@@ -9257,6 +9745,7 @@
   },
   {
     "name": "Colorado School of Mines",
+    "country": "United States",
     "aggregatedScore": 627.8125,
     "originalRankings": {
       "qs": {
@@ -9274,6 +9763,7 @@
   },
   {
     "name": "Rensselaer Polytechnic Institute",
+    "country": "United States",
     "aggregatedScore": 627.8125,
     "originalRankings": {
       "qs": {
@@ -9291,6 +9781,7 @@
   },
   {
     "name": "University of Marburg",
+    "country": "Germany",
     "aggregatedScore": 627.8125,
     "originalRankings": {
       "qs": {
@@ -9308,6 +9799,7 @@
   },
   {
     "name": "University of New Mexico",
+    "country": "United States",
     "aggregatedScore": 626.4562500000001,
     "originalRankings": {
       "qs": {
@@ -9325,6 +9817,7 @@
   },
   {
     "name": "Birkbeck - University of London",
+    "country": "United Kingdom",
     "aggregatedScore": 626.28125,
     "originalRankings": {
       "qs": {
@@ -9342,6 +9835,7 @@
   },
   {
     "name": "Higher School of Economics",
+    "country": "Russia",
     "aggregatedScore": 625.84375,
     "originalRankings": {
       "qs": {
@@ -9359,6 +9853,7 @@
   },
   {
     "name": "Concordia University",
+    "country": "Canada",
     "aggregatedScore": 624.75,
     "originalRankings": {
       "qs": {
@@ -9376,6 +9871,7 @@
   },
   {
     "name": "Istanbul Technical University",
+    "country": "Turkey",
     "aggregatedScore": 622.34375,
     "originalRankings": {
       "qs": {
@@ -9393,6 +9889,7 @@
   },
   {
     "name": "University of Oklahoma - Norman",
+    "country": "United States",
     "aggregatedScore": 621.6437500000001,
     "originalRankings": {
       "qs": {
@@ -9410,6 +9907,7 @@
   },
   {
     "name": "Massey University",
+    "country": "New Zealand",
     "aggregatedScore": 619.5,
     "originalRankings": {
       "qs": {
@@ -9427,6 +9925,7 @@
   },
   {
     "name": "East China University of Science and Technology",
+    "country": "China",
     "aggregatedScore": 619.0625,
     "originalRankings": {
       "qs": {
@@ -9444,6 +9943,7 @@
   },
   {
     "name": "Hasselt University",
+    "country": "Belgium",
     "aggregatedScore": 616.21875,
     "originalRankings": {
       "qs": {
@@ -9461,6 +9961,7 @@
   },
   {
     "name": "Tokyo Medical and Dental University",
+    "country": "Japan",
     "aggregatedScore": 614.6875,
     "originalRankings": {
       "qs": {
@@ -9478,6 +9979,7 @@
   },
   {
     "name": "Nanjing University of Aeronautics and Astronautics",
+    "country": "China",
     "aggregatedScore": 614.6875,
     "originalRankings": {
       "qs": {
@@ -9495,6 +9997,7 @@
   },
   {
     "name": "Kobe University",
+    "country": "Japan",
     "aggregatedScore": 613.8125,
     "originalRankings": {
       "qs": {
@@ -9512,6 +10015,7 @@
   },
   {
     "name": "Mahidol University",
+    "country": "Thailand",
     "aggregatedScore": 613.15625,
     "originalRankings": {
       "qs": {
@@ -9529,6 +10033,7 @@
   },
   {
     "name": "Hiroshima University",
+    "country": "Japan",
     "aggregatedScore": 611.84375,
     "originalRankings": {
       "qs": {
@@ -9546,6 +10051,7 @@
   },
   {
     "name": "Waseda University",
+    "country": "Japan",
     "aggregatedScore": 610.3125,
     "originalRankings": {
       "qs": {
@@ -9563,6 +10069,7 @@
   },
   {
     "name": "University of Catania",
+    "country": "Italy",
     "aggregatedScore": 609.1750000000001,
     "originalRankings": {
       "qs": {
@@ -9580,6 +10087,7 @@
   },
   {
     "name": "New University of Lisbon",
+    "country": "Portugal",
     "aggregatedScore": 608.78125,
     "originalRankings": {
       "qs": {
@@ -9597,6 +10105,7 @@
   },
   {
     "name": "Chung-Ang University",
+    "country": "South Korea",
     "aggregatedScore": 608.5625,
     "originalRankings": {
       "qs": {
@@ -9614,6 +10123,7 @@
   },
   {
     "name": "University of Jyvaskyla",
+    "country": "Finland",
     "aggregatedScore": 608.5625,
     "originalRankings": {
       "qs": {
@@ -9631,6 +10141,7 @@
   },
   {
     "name": "University of Lorraine",
+    "country": "France",
     "aggregatedScore": 605.9375,
     "originalRankings": {
       "qs": {
@@ -9648,6 +10159,7 @@
   },
   {
     "name": "University of Canberra",
+    "country": "Australia",
     "aggregatedScore": 605.5,
     "originalRankings": {
       "qs": {
@@ -9665,6 +10177,7 @@
   },
   {
     "name": "Auckland University of Technology",
+    "country": "New Zealand",
     "aggregatedScore": 603.53125,
     "originalRankings": {
       "qs": {
@@ -9682,6 +10195,7 @@
   },
   {
     "name": "University of Hull",
+    "country": "United Kingdom",
     "aggregatedScore": 602.65625,
     "originalRankings": {
       "qs": {
@@ -9699,6 +10213,7 @@
   },
   {
     "name": "University of Lille",
+    "country": "France",
     "aggregatedScore": 601.5625,
     "originalRankings": {
       "qs": {
@@ -9716,6 +10231,7 @@
   },
   {
     "name": "Alexandria University",
+    "country": "Egypt",
     "aggregatedScore": 601.0812500000001,
     "originalRankings": {
       "qs": {
@@ -9733,6 +10249,7 @@
   },
   {
     "name": "University of Northumbria at Newcastle",
+    "country": "United Kingdom",
     "aggregatedScore": 598.5,
     "originalRankings": {
       "qs": {
@@ -9750,6 +10267,7 @@
   },
   {
     "name": "University of Leiden",
+    "country": "Netherlands",
     "aggregatedScore": 597.1875,
     "originalRankings": {
       "qs": {
@@ -9767,6 +10285,7 @@
   },
   {
     "name": "University of Iceland",
+    "country": "Iceland",
     "aggregatedScore": 595.875,
     "originalRankings": {
       "qs": {
@@ -9784,6 +10303,7 @@
   },
   {
     "name": "University of Stirling",
+    "country": "United Kingdom",
     "aggregatedScore": 594.78125,
     "originalRankings": {
       "qs": {
@@ -9801,6 +10321,7 @@
   },
   {
     "name": "Amirkabir University of Technology",
+    "country": "Iran",
     "aggregatedScore": 594.5625,
     "originalRankings": {
       "qs": {
@@ -9818,6 +10339,7 @@
   },
   {
     "name": "Umm Al-Qura University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 593.25,
     "originalRankings": {
       "qs": {
@@ -9835,6 +10357,7 @@
   },
   {
     "name": "University of Seville",
+    "country": "Spain",
     "aggregatedScore": 592.59375,
     "originalRankings": {
       "qs": {
@@ -9852,6 +10375,7 @@
   },
   {
     "name": "Dublin City University",
+    "country": "Ireland",
     "aggregatedScore": 590.625,
     "originalRankings": {
       "qs": {
@@ -9869,6 +10393,7 @@
   },
   {
     "name": "Bar-Ilan University",
+    "country": "Israel",
     "aggregatedScore": 590.625,
     "originalRankings": {
       "qs": {
@@ -9886,6 +10411,7 @@
   },
   {
     "name": "University of Linz",
+    "country": "Austria",
     "aggregatedScore": 590.40625,
     "originalRankings": {
       "qs": {
@@ -9903,6 +10429,7 @@
   },
   {
     "name": "Royal Holloway - University of London",
+    "country": "United Kingdom",
     "aggregatedScore": 589.3125,
     "originalRankings": {
       "qs": {
@@ -9920,6 +10447,7 @@
   },
   {
     "name": "National Sun Yat-Sen University",
+    "country": "Taiwan",
     "aggregatedScore": 587.5625,
     "originalRankings": {
       "qs": {
@@ -9937,6 +10465,7 @@
   },
   {
     "name": "Iran University of Science and Technology Tehran",
+    "country": "Iran",
     "aggregatedScore": 587.34375,
     "originalRankings": {
       "qs": {
@@ -9954,6 +10483,7 @@
   },
   {
     "name": "Sao Paulo State University",
+    "country": "Brazil",
     "aggregatedScore": 586.6875,
     "originalRankings": {
       "qs": {
@@ -9971,6 +10501,7 @@
   },
   {
     "name": "Cankaya University",
+    "country": "Turkey",
     "aggregatedScore": 586.6312499999999,
     "originalRankings": {
       "the": {
@@ -9985,6 +10516,7 @@
   },
   {
     "name": "Ulsan University",
+    "country": "South Korea",
     "aggregatedScore": 584.0625,
     "originalRankings": {
       "qs": {
@@ -10002,6 +10534,7 @@
   },
   {
     "name": "Ewha Womans University",
+    "country": "South Korea",
     "aggregatedScore": 581.875,
     "originalRankings": {
       "qs": {
@@ -10019,6 +10552,7 @@
   },
   {
     "name": "University of Minho",
+    "country": "Portugal",
     "aggregatedScore": 581.875,
     "originalRankings": {
       "qs": {
@@ -10036,6 +10570,7 @@
   },
   {
     "name": "Taipei Medical University",
+    "country": "Taiwan",
     "aggregatedScore": 581.875,
     "originalRankings": {
       "qs": {
@@ -10053,6 +10588,7 @@
   },
   {
     "name": "University of Limerick",
+    "country": "Ireland",
     "aggregatedScore": 579.6875,
     "originalRankings": {
       "qs": {
@@ -10070,6 +10606,7 @@
   },
   {
     "name": "University of Rennes I",
+    "country": "France",
     "aggregatedScore": 579.6875,
     "originalRankings": {
       "qs": {
@@ -10087,6 +10624,7 @@
   },
   {
     "name": "University of Delhi",
+    "country": "India",
     "aggregatedScore": 578.15625,
     "originalRankings": {
       "qs": {
@@ -10104,6 +10642,7 @@
   },
   {
     "name": "University of C�te d'Azur",
+    "country": "France",
     "aggregatedScore": 577.5,
     "originalRankings": {
       "qs": {
@@ -10121,6 +10660,7 @@
   },
   {
     "name": "Lanzhou University of Technology",
+    "country": "China",
     "aggregatedScore": 577.4562500000001,
     "originalRankings": {
       "qs": {
@@ -10138,6 +10678,7 @@
   },
   {
     "name": "University of Eastern Finland",
+    "country": "Finland",
     "aggregatedScore": 576.625,
     "originalRankings": {
       "qs": {
@@ -10155,6 +10696,7 @@
   },
   {
     "name": "Carleton University",
+    "country": "Canada",
     "aggregatedScore": 575.3125,
     "originalRankings": {
       "qs": {
@@ -10172,6 +10714,7 @@
   },
   {
     "name": "University of Santiago de Compostela",
+    "country": "Spain",
     "aggregatedScore": 573.125,
     "originalRankings": {
       "qs": {
@@ -10189,6 +10732,7 @@
   },
   {
     "name": "University of Putra Malaysia",
+    "country": "Malaysia",
     "aggregatedScore": 572.46875,
     "originalRankings": {
       "qs": {
@@ -10206,6 +10750,7 @@
   },
   {
     "name": "Jordan University",
+    "country": "Jordan",
     "aggregatedScore": 569.40625,
     "originalRankings": {
       "qs": {
@@ -10223,6 +10768,7 @@
   },
   {
     "name": "Polytechnic University of Catalonia",
+    "country": "Spain",
     "aggregatedScore": 568.75,
     "originalRankings": {
       "qs": {
@@ -10240,6 +10786,7 @@
   },
   {
     "name": "University of Graz",
+    "country": "Austria",
     "aggregatedScore": 568.75,
     "originalRankings": {
       "qs": {
@@ -10257,6 +10804,7 @@
   },
   {
     "name": "Kafrelsheikh University",
+    "country": "Egypt",
     "aggregatedScore": 568.6312499999999,
     "originalRankings": {
       "the": {
@@ -10271,6 +10819,7 @@
   },
   {
     "name": "Texas Technical University",
+    "country": "United States",
     "aggregatedScore": 566.5625,
     "originalRankings": {
       "qs": {
@@ -10288,6 +10837,7 @@
   },
   {
     "name": "University of Siegen",
+    "country": "Italy",
     "aggregatedScore": 564.375,
     "originalRankings": {
       "qs": {
@@ -10305,6 +10855,7 @@
   },
   {
     "name": "Rutgers - The State University of New Jersey",
+    "country": "United States",
     "aggregatedScore": 562.1875,
     "originalRankings": {
       "qs": {
@@ -10322,6 +10873,7 @@
   },
   {
     "name": "University of Hohenheim",
+    "country": "Germany",
     "aggregatedScore": 562.1875,
     "originalRankings": {
       "qs": {
@@ -10339,6 +10891,7 @@
   },
   {
     "name": "The Manchester Metropolitan University",
+    "country": "United Kingdom",
     "aggregatedScore": 562.1875,
     "originalRankings": {
       "qs": {
@@ -10356,6 +10909,7 @@
   },
   {
     "name": "Institut National des Sciences Appliqu�es de Toulouse",
+    "country": "France",
     "aggregatedScore": 561.3125,
     "originalRankings": {
       "qs": {
@@ -10373,6 +10927,7 @@
   },
   {
     "name": "Aristotle University of Thessaloniki",
+    "country": "Greece",
     "aggregatedScore": 560.65625,
     "originalRankings": {
       "qs": {
@@ -10390,6 +10945,7 @@
   },
   {
     "name": "Free University of Bozen-Bolzano",
+    "country": "Italy",
     "aggregatedScore": 560,
     "originalRankings": {
       "qs": {
@@ -10407,6 +10963,7 @@
   },
   {
     "name": "Graz University of Technology",
+    "country": "Austria",
     "aggregatedScore": 559.5625,
     "originalRankings": {
       "qs": {
@@ -10424,6 +10981,7 @@
   },
   {
     "name": "Konkuk University",
+    "country": "South Korea",
     "aggregatedScore": 557.8125,
     "originalRankings": {
       "qs": {
@@ -10441,6 +10999,7 @@
   },
   {
     "name": "Chang Gung University",
+    "country": "Taiwan",
     "aggregatedScore": 555.625,
     "originalRankings": {
       "qs": {
@@ -10458,6 +11017,7 @@
   },
   {
     "name": "University of Salamanca",
+    "country": "Spain",
     "aggregatedScore": 553.875,
     "originalRankings": {
       "qs": {
@@ -10475,6 +11035,7 @@
   },
   {
     "name": "Sunway University",
+    "country": "Malaysia",
     "aggregatedScore": 553.875,
     "originalRankings": {
       "qs": {
@@ -10492,6 +11053,7 @@
   },
   {
     "name": "Technical University of Braunschweig",
+    "country": "Germany",
     "aggregatedScore": 551.25,
     "originalRankings": {
       "qs": {
@@ -10509,6 +11071,7 @@
   },
   {
     "name": "Donghua University - Shanghai",
+    "country": "China",
     "aggregatedScore": 551.25,
     "originalRankings": {
       "qs": {
@@ -10526,6 +11089,7 @@
   },
   {
     "name": "Georgia State University",
+    "country": "United States",
     "aggregatedScore": 551.25,
     "originalRankings": {
       "qs": {
@@ -10543,6 +11107,7 @@
   },
   {
     "name": "St. Louis University",
+    "country": "United States",
     "aggregatedScore": 551.25,
     "originalRankings": {
       "qs": {
@@ -10560,6 +11125,7 @@
   },
   {
     "name": "National University of Sciences and Technology - Islamabad",
+    "country": "Pakistan",
     "aggregatedScore": 550.8125,
     "originalRankings": {
       "qs": {
@@ -10577,6 +11143,7 @@
   },
   {
     "name": "University of Ulster",
+    "country": "United Kingdom",
     "aggregatedScore": 549.5,
     "originalRankings": {
       "qs": {
@@ -10594,6 +11161,7 @@
   },
   {
     "name": "University of Plymouth",
+    "country": "United Kingdom",
     "aggregatedScore": 549.0625,
     "originalRankings": {
       "qs": {
@@ -10611,6 +11179,7 @@
   },
   {
     "name": "E�tv�s Lorand University",
+    "country": "Hungary",
     "aggregatedScore": 548.40625,
     "originalRankings": {
       "qs": {
@@ -10628,6 +11197,7 @@
   },
   {
     "name": "Polytechnic University of Bari",
+    "country": "Italy",
     "aggregatedScore": 544.90625,
     "originalRankings": {
       "qs": {
@@ -10645,6 +11215,7 @@
   },
   {
     "name": "University of Greenwich",
+    "country": "United Kingdom",
     "aggregatedScore": 542.5,
     "originalRankings": {
       "qs": {
@@ -10662,6 +11233,7 @@
   },
   {
     "name": "Vellore Institute of Technology",
+    "country": "India",
     "aggregatedScore": 542.5,
     "originalRankings": {
       "qs": {
@@ -10679,6 +11251,7 @@
   },
   {
     "name": "Technical University of Dortmund",
+    "country": "Germany",
     "aggregatedScore": 540.3125,
     "originalRankings": {
       "qs": {
@@ -10696,6 +11269,7 @@
   },
   {
     "name": "Asia University",
+    "country": "Taiwan",
     "aggregatedScore": 540.3125,
     "originalRankings": {
       "qs": {
@@ -10713,6 +11287,7 @@
   },
   {
     "name": "National Technical University of Athens",
+    "country": "Greece",
     "aggregatedScore": 535.9375,
     "originalRankings": {
       "qs": {
@@ -10730,6 +11305,7 @@
   },
   {
     "name": "University of Bradford",
+    "country": "United Kingdom",
     "aggregatedScore": 533.75,
     "originalRankings": {
       "qs": {
@@ -10747,6 +11323,7 @@
   },
   {
     "name": "University of Portsmouth",
+    "country": "United Kingdom",
     "aggregatedScore": 533.75,
     "originalRankings": {
       "qs": {
@@ -10764,6 +11341,7 @@
   },
   {
     "name": "Marche Polytechnic University",
+    "country": "Italy",
     "aggregatedScore": 529.375,
     "originalRankings": {
       "qs": {
@@ -10781,6 +11359,7 @@
   },
   {
     "name": "University of Nantes",
+    "country": "France",
     "aggregatedScore": 529.375,
     "originalRankings": {
       "qs": {
@@ -10798,6 +11377,7 @@
   },
   {
     "name": "Kansas State University",
+    "country": "United States",
     "aggregatedScore": 529.375,
     "originalRankings": {
       "qs": {
@@ -10815,6 +11395,7 @@
   },
   {
     "name": "Oklahoma State University",
+    "country": "United States",
     "aggregatedScore": 529.375,
     "originalRankings": {
       "qs": {
@@ -10832,6 +11413,7 @@
   },
   {
     "name": "Memorial University of Newfoundland",
+    "country": "Canada",
     "aggregatedScore": 527.1875,
     "originalRankings": {
       "qs": {
@@ -10849,6 +11431,7 @@
   },
   {
     "name": "University of Technology - Petronas",
+    "country": "Malaysia",
     "aggregatedScore": 525.375,
     "originalRankings": {
       "qs": {
@@ -10863,6 +11446,7 @@
   },
   {
     "name": "Federal University of Minas Gerais",
+    "country": "Brazil",
     "aggregatedScore": 525,
     "originalRankings": {
       "qs": {
@@ -10880,6 +11464,7 @@
   },
   {
     "name": "University of Maryland Baltimore County",
+    "country": "United States",
     "aggregatedScore": 525,
     "originalRankings": {
       "qs": {
@@ -10897,6 +11482,7 @@
   },
   {
     "name": "University Carlos III de Madrid",
+    "country": "Spain",
     "aggregatedScore": 521.9375,
     "originalRankings": {
       "qs": {
@@ -10914,6 +11500,7 @@
   },
   {
     "name": "New Jersey Institute of Technology",
+    "country": "United States",
     "aggregatedScore": 520.625,
     "originalRankings": {
       "qs": {
@@ -10931,6 +11518,7 @@
   },
   {
     "name": "Nottingham Trent University",
+    "country": "United Kingdom",
     "aggregatedScore": 520.40625,
     "originalRankings": {
       "qs": {
@@ -10948,6 +11536,7 @@
   },
   {
     "name": "Rockefeller University",
+    "country": "United States",
     "aggregatedScore": 519.28125,
     "originalRankings": {
       "arwu": {
@@ -10962,6 +11551,7 @@
   },
   {
     "name": "University of Salzburg",
+    "country": "Austria",
     "aggregatedScore": 518.4375,
     "originalRankings": {
       "qs": {
@@ -10979,6 +11569,7 @@
   },
   {
     "name": "University of Crete",
+    "country": "Greece",
     "aggregatedScore": 518.4375,
     "originalRankings": {
       "qs": {
@@ -10996,6 +11587,7 @@
   },
   {
     "name": "Liverpool John Moores University",
+    "country": "United Kingdom",
     "aggregatedScore": 518.4375,
     "originalRankings": {
       "qs": {
@@ -11013,6 +11605,7 @@
   },
   {
     "name": "Icahn School of Medicine at Mount Sinai",
+    "country": "United States",
     "aggregatedScore": 515.90625,
     "originalRankings": {
       "arwu": {
@@ -11027,6 +11620,7 @@
   },
   {
     "name": "Yeshiva University",
+    "country": "United States",
     "aggregatedScore": 515.2125000000001,
     "originalRankings": {
       "qs": {
@@ -11041,6 +11635,7 @@
   },
   {
     "name": "University of Modena",
+    "country": "Italy",
     "aggregatedScore": 514.0625,
     "originalRankings": {
       "qs": {
@@ -11058,6 +11653,7 @@
   },
   {
     "name": "Ajou University",
+    "country": "South Korea",
     "aggregatedScore": 511.875,
     "originalRankings": {
       "qs": {
@@ -11075,6 +11671,7 @@
   },
   {
     "name": "Inha University",
+    "country": "South Korea",
     "aggregatedScore": 511.875,
     "originalRankings": {
       "qs": {
@@ -11092,6 +11689,7 @@
   },
   {
     "name": "University of Rovira i Virgili",
+    "country": "Spain",
     "aggregatedScore": 511.875,
     "originalRankings": {
       "qs": {
@@ -11109,6 +11707,7 @@
   },
   {
     "name": "Novosibirsk State University",
+    "country": "Russia",
     "aggregatedScore": 509.46875,
     "originalRankings": {
       "qs": {
@@ -11126,6 +11725,7 @@
   },
   {
     "name": "University of Messina",
+    "country": "Italy",
     "aggregatedScore": 507.5,
     "originalRankings": {
       "qs": {
@@ -11143,6 +11743,7 @@
   },
   {
     "name": "University of Ferrara",
+    "country": "Italy",
     "aggregatedScore": 507.5,
     "originalRankings": {
       "qs": {
@@ -11160,6 +11761,7 @@
   },
   {
     "name": "State University of New York at Albany",
+    "country": "United States",
     "aggregatedScore": 507.5,
     "originalRankings": {
       "qs": {
@@ -11177,6 +11779,7 @@
   },
   {
     "name": "University of Parma",
+    "country": "Italy",
     "aggregatedScore": 507.5,
     "originalRankings": {
       "qs": {
@@ -11194,6 +11797,7 @@
   },
   {
     "name": "Yeungnam University",
+    "country": "South Korea",
     "aggregatedScore": 507.5,
     "originalRankings": {
       "qs": {
@@ -11211,6 +11815,7 @@
   },
   {
     "name": "Auburn University",
+    "country": "United States",
     "aggregatedScore": 507.5,
     "originalRankings": {
       "qs": {
@@ -11228,6 +11833,7 @@
   },
   {
     "name": "University of Tabriz",
+    "country": "Iran",
     "aggregatedScore": 507.28125,
     "originalRankings": {
       "qs": {
@@ -11245,6 +11851,7 @@
   },
   {
     "name": "University of Technology - Malaysia",
+    "country": "Malaysia",
     "aggregatedScore": 504.375,
     "originalRankings": {
       "qs": {
@@ -11259,6 +11866,7 @@
   },
   {
     "name": "Weizmann Institute of Science",
+    "country": "Israel",
     "aggregatedScore": 503.71875,
     "originalRankings": {
       "arwu": {
@@ -11273,6 +11881,7 @@
   },
   {
     "name": "Lappeenranta University of Technology",
+    "country": "Finland",
     "aggregatedScore": 503.4375,
     "originalRankings": {
       "qs": {
@@ -11287,6 +11896,7 @@
   },
   {
     "name": "University of the Punjab",
+    "country": "Pakistan",
     "aggregatedScore": 503.34375,
     "originalRankings": {
       "qs": {
@@ -11304,6 +11914,7 @@
   },
   {
     "name": "Qassim University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 500.9375,
     "originalRankings": {
       "qs": {
@@ -11321,6 +11932,7 @@
   },
   {
     "name": "University of Haifa",
+    "country": "Israel",
     "aggregatedScore": 496.5625,
     "originalRankings": {
       "qs": {
@@ -11338,6 +11950,7 @@
   },
   {
     "name": "National University of Ireland - Maynooth",
+    "country": "Ireland",
     "aggregatedScore": 496.5625,
     "originalRankings": {
       "qs": {
@@ -11355,6 +11968,7 @@
   },
   {
     "name": "University of Salerno",
+    "country": "Italy",
     "aggregatedScore": 496.5625,
     "originalRankings": {
       "qs": {
@@ -11372,6 +11986,7 @@
   },
   {
     "name": "Middle East Technical University",
+    "country": "Turkey",
     "aggregatedScore": 494.25,
     "originalRankings": {
       "qs": {
@@ -11386,6 +12001,7 @@
   },
   {
     "name": "University of Alcal� de Henares",
+    "country": "Spain",
     "aggregatedScore": 492.1875,
     "originalRankings": {
       "qs": {
@@ -11403,6 +12019,7 @@
   },
   {
     "name": "Bauman Moscow State Technical University",
+    "country": "Russia",
     "aggregatedScore": 491.8125,
     "originalRankings": {
       "qs": {
@@ -11417,6 +12034,7 @@
   },
   {
     "name": "London School of Hygiene & Tropical Medicine",
+    "country": "United Kingdom",
     "aggregatedScore": 491.34375,
     "originalRankings": {
       "arwu": {
@@ -11431,6 +12049,7 @@
   },
   {
     "name": "Hacettepe University",
+    "country": "Turkey",
     "aggregatedScore": 487.8125,
     "originalRankings": {
       "qs": {
@@ -11448,6 +12067,7 @@
   },
   {
     "name": "Lehigh University",
+    "country": "United States",
     "aggregatedScore": 487.8125,
     "originalRankings": {
       "qs": {
@@ -11465,6 +12085,7 @@
   },
   {
     "name": "Daegu Gyeongbuk Institute of Science and Technology",
+    "country": "South Korea",
     "aggregatedScore": 486.5625,
     "originalRankings": {
       "qs": {
@@ -11479,6 +12100,7 @@
   },
   {
     "name": "King Abdullah University of Science and Technology",
+    "country": "Saudi Arabia",
     "aggregatedScore": 485.90625,
     "originalRankings": {
       "arwu": {
@@ -11493,6 +12115,7 @@
   },
   {
     "name": "University of Palermo",
+    "country": "Italy",
     "aggregatedScore": 485.625,
     "originalRankings": {
       "qs": {
@@ -11510,6 +12133,7 @@
   },
   {
     "name": "Okayama University",
+    "country": "Japan",
     "aggregatedScore": 485.625,
     "originalRankings": {
       "qs": {
@@ -11527,6 +12151,7 @@
   },
   {
     "name": "Chonnam National University",
+    "country": "South Korea",
     "aggregatedScore": 485.625,
     "originalRankings": {
       "qs": {
@@ -11544,6 +12169,7 @@
   },
   {
     "name": "Jordan University of Science and Technology",
+    "country": "United Arab Emirates",
     "aggregatedScore": 484.96875,
     "originalRankings": {
       "qs": {
@@ -11561,6 +12187,7 @@
   },
   {
     "name": "University of Mannheim",
+    "country": "Germany",
     "aggregatedScore": 484.875,
     "originalRankings": {
       "qs": {
@@ -11575,6 +12202,7 @@
   },
   {
     "name": "Abu Dhabi University",
+    "country": "United Arab Emirates",
     "aggregatedScore": 483.75,
     "originalRankings": {
       "qs": {
@@ -11589,6 +12217,7 @@
   },
   {
     "name": "King Faisal University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 483.4375,
     "originalRankings": {
       "qs": {
@@ -11606,6 +12235,7 @@
   },
   {
     "name": "City University London",
+    "country": "United Kingdom",
     "aggregatedScore": 481.6875,
     "originalRankings": {
       "qs": {
@@ -11620,6 +12250,7 @@
   },
   {
     "name": "Ecole des Ponts ParisTech",
+    "country": "France",
     "aggregatedScore": 481.125,
     "originalRankings": {
       "qs": {
@@ -11634,6 +12265,7 @@
   },
   {
     "name": "University of New Brunswick",
+    "country": "Canada",
     "aggregatedScore": 479.0625,
     "originalRankings": {
       "qs": {
@@ -11651,6 +12283,7 @@
   },
   {
     "name": "Chonbuk National University",
+    "country": "South Korea",
     "aggregatedScore": 479.0625,
     "originalRankings": {
       "qs": {
@@ -11668,6 +12301,7 @@
   },
   {
     "name": "Baylor College of Medicine",
+    "country": "United States",
     "aggregatedScore": 478.96875,
     "originalRankings": {
       "arwu": {
@@ -11682,6 +12316,7 @@
   },
   {
     "name": "Federal University of Sao Paulo",
+    "country": "Brazil",
     "aggregatedScore": 476.875,
     "originalRankings": {
       "qs": {
@@ -11699,6 +12334,7 @@
   },
   {
     "name": "Norwegian University of Life Sciences",
+    "country": "Norway",
     "aggregatedScore": 476.875,
     "originalRankings": {
       "qs": {
@@ -11716,6 +12352,7 @@
   },
   {
     "name": "Catholic University of Korea",
+    "country": "South Korea",
     "aggregatedScore": 474.6875,
     "originalRankings": {
       "qs": {
@@ -11733,6 +12370,7 @@
   },
   {
     "name": "University of Alaska - Fairbanks",
+    "country": "United States",
     "aggregatedScore": 474.6875,
     "originalRankings": {
       "qs": {
@@ -11750,6 +12388,7 @@
   },
   {
     "name": "Gwangju Institute of Science and Technology",
+    "country": "South Korea",
     "aggregatedScore": 471,
     "originalRankings": {
       "qs": {
@@ -11764,6 +12403,7 @@
   },
   {
     "name": "Prince Mohammad Bin Fahd University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 470.25,
     "originalRankings": {
       "qs": {
@@ -11778,6 +12418,7 @@
   },
   {
     "name": "Aston University",
+    "country": "United Kingdom",
     "aggregatedScore": 468.375,
     "originalRankings": {
       "qs": {
@@ -11792,6 +12433,7 @@
   },
   {
     "name": "Anna University",
+    "country": "India",
     "aggregatedScore": 466.5,
     "originalRankings": {
       "qs": {
@@ -11806,6 +12448,7 @@
   },
   {
     "name": "Monterrey Institute of Technology and Higher Education",
+    "country": "Mexico",
     "aggregatedScore": 466.125,
     "originalRankings": {
       "qs": {
@@ -11820,6 +12463,7 @@
   },
   {
     "name": "Sabanci University",
+    "country": "Turkey",
     "aggregatedScore": 450.9375,
     "originalRankings": {
       "qs": {
@@ -11834,6 +12478,7 @@
   },
   {
     "name": "Czech University of Life Sciences Prague",
+    "country": "Czech Republic",
     "aggregatedScore": 450.625,
     "originalRankings": {
       "qs": {
@@ -11851,6 +12496,7 @@
   },
   {
     "name": "Lincoln University",
+    "country": "New Zealand",
     "aggregatedScore": 450,
     "originalRankings": {
       "qs": {
@@ -11865,6 +12511,7 @@
   },
   {
     "name": "University of Brunei Darussalam",
+    "country": "Brunei",
     "aggregatedScore": 447.375,
     "originalRankings": {
       "qs": {
@@ -11879,6 +12526,7 @@
   },
   {
     "name": "School of Oriental and African Studies - University of London",
+    "country": "United Kingdom",
     "aggregatedScore": 443.0625,
     "originalRankings": {
       "qs": {
@@ -11893,6 +12541,7 @@
   },
   {
     "name": "University of Hertfordshire",
+    "country": "United Kingdom",
     "aggregatedScore": 441.875,
     "originalRankings": {
       "qs": {
@@ -11910,6 +12559,7 @@
   },
   {
     "name": "University of Alabama",
+    "country": "United States",
     "aggregatedScore": 441.875,
     "originalRankings": {
       "qs": {
@@ -11927,6 +12577,7 @@
   },
   {
     "name": "Peoples' Friendship University of Russia",
+    "country": "Russia",
     "aggregatedScore": 441.5625,
     "originalRankings": {
       "qs": {
@@ -11941,6 +12592,7 @@
   },
   {
     "name": "Missouri University of Science and Technology",
+    "country": "United States",
     "aggregatedScore": 439.5,
     "originalRankings": {
       "qs": {
@@ -11955,6 +12607,7 @@
   },
   {
     "name": "Tomsk State University",
+    "country": "Russia",
     "aggregatedScore": 438.75,
     "originalRankings": {
       "qs": {
@@ -11969,6 +12622,7 @@
   },
   {
     "name": "American University of Sharjah",
+    "country": "United Arab Emirates",
     "aggregatedScore": 438.5625,
     "originalRankings": {
       "qs": {
@@ -11983,6 +12637,7 @@
   },
   {
     "name": "Sciences Po - Paris",
+    "country": "France",
     "aggregatedScore": 435.1875,
     "originalRankings": {
       "qs": {
@@ -11997,6 +12652,7 @@
   },
   {
     "name": "Illinois Institute of Technology",
+    "country": "United States",
     "aggregatedScore": 435,
     "originalRankings": {
       "qs": {
@@ -12011,6 +12667,7 @@
   },
   {
     "name": "National Taiwan Normal University",
+    "country": "Taiwan",
     "aggregatedScore": 434.8125,
     "originalRankings": {
       "qs": {
@@ -12025,6 +12682,7 @@
   },
   {
     "name": "Al Ain University",
+    "country": "United Arab Emirates",
     "aggregatedScore": 434.8125,
     "originalRankings": {
       "qs": {
@@ -12039,6 +12697,7 @@
   },
   {
     "name": "Sultan Qaboos University",
+    "country": "Oman",
     "aggregatedScore": 432.9375,
     "originalRankings": {
       "qs": {
@@ -12053,6 +12712,7 @@
   },
   {
     "name": "University of Maryland at Baltimore",
+    "country": "United States",
     "aggregatedScore": 431.71875,
     "originalRankings": {
       "arwu": {
@@ -12067,6 +12727,7 @@
   },
   {
     "name": "Zayed University",
+    "country": "United Arab Emirates",
     "aggregatedScore": 431.25,
     "originalRankings": {
       "qs": {
@@ -12081,6 +12742,7 @@
   },
   {
     "name": "University of Cantabria",
+    "country": "Italy",
     "aggregatedScore": 430.9375,
     "originalRankings": {
       "qs": {
@@ -12098,6 +12760,7 @@
   },
   {
     "name": "Indian Institute of Technology Indore",
+    "country": "India",
     "aggregatedScore": 430.125,
     "originalRankings": {
       "qs": {
@@ -12112,6 +12775,7 @@
   },
   {
     "name": "Bond University",
+    "country": "Australia",
     "aggregatedScore": 428.25,
     "originalRankings": {
       "qs": {
@@ -12126,6 +12790,7 @@
   },
   {
     "name": "Shoolini University of Biotechnology and Management Sciences",
+    "country": "India",
     "aggregatedScore": 428.25,
     "originalRankings": {
       "qs": {
@@ -12140,6 +12805,7 @@
   },
   {
     "name": "Central Queensland University",
+    "country": "Australia",
     "aggregatedScore": 426.75,
     "originalRankings": {
       "qs": {
@@ -12154,6 +12820,7 @@
   },
   {
     "name": "National Research Nuclear University",
+    "country": "Russia",
     "aggregatedScore": 426.375,
     "originalRankings": {
       "qs": {
@@ -12168,6 +12835,7 @@
   },
   {
     "name": "University of Huddersfield",
+    "country": "United Kingdom",
     "aggregatedScore": 425.625,
     "originalRankings": {
       "qs": {
@@ -12182,6 +12850,7 @@
   },
   {
     "name": "University of Indonesia",
+    "country": "Indonesia",
     "aggregatedScore": 424.6875,
     "originalRankings": {
       "qs": {
@@ -12196,6 +12865,7 @@
   },
   {
     "name": "American University in Cairo",
+    "country": "Egypt",
     "aggregatedScore": 423.9375,
     "originalRankings": {
       "qs": {
@@ -12210,6 +12880,7 @@
   },
   {
     "name": "American University of the Middle East",
+    "country": "Kuwait",
     "aggregatedScore": 423.75,
     "originalRankings": {
       "qs": {
@@ -12224,6 +12895,7 @@
   },
   {
     "name": "Imam Abdulrahman Bin Faisal University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 423.375,
     "originalRankings": {
       "qs": {
@@ -12238,6 +12910,7 @@
   },
   {
     "name": "Oxford Brookes University",
+    "country": "United Kingdom",
     "aggregatedScore": 422.8125,
     "originalRankings": {
       "qs": {
@@ -12252,6 +12925,7 @@
   },
   {
     "name": "Charles Darwin University",
+    "country": "Australia",
     "aggregatedScore": 421.875,
     "originalRankings": {
       "qs": {
@@ -12266,6 +12940,7 @@
   },
   {
     "name": "South Ural State University",
+    "country": "Russia",
     "aggregatedScore": 417.71250000000003,
     "originalRankings": {
       "qs": {
@@ -12280,6 +12955,7 @@
   },
   {
     "name": "University of Windsor",
+    "country": "Canada",
     "aggregatedScore": 417,
     "originalRankings": {
       "qs": {
@@ -12294,6 +12970,7 @@
   },
   {
     "name": "ShanghaiTech University",
+    "country": "China",
     "aggregatedScore": 416.71875,
     "originalRankings": {
       "arwu": {
@@ -12308,6 +12985,7 @@
   },
   {
     "name": "Oregon Health and Science University",
+    "country": "United States",
     "aggregatedScore": 415.63124999999997,
     "originalRankings": {
       "the": {
@@ -12322,6 +13000,7 @@
   },
   {
     "name": "University of Tunis El Manar",
+    "country": "Tunisia",
     "aggregatedScore": 415.625,
     "originalRankings": {
       "qs": {
@@ -12339,6 +13018,7 @@
   },
   {
     "name": "Peter the Great St Petersburg Polytechnic University",
+    "country": "Russia",
     "aggregatedScore": 414.75,
     "originalRankings": {
       "qs": {
@@ -12353,6 +13033,7 @@
   },
   {
     "name": "Southern Cross University",
+    "country": "Australia",
     "aggregatedScore": 411.5625,
     "originalRankings": {
       "qs": {
@@ -12367,6 +13048,7 @@
   },
   {
     "name": "Bilkent University",
+    "country": "Turkey",
     "aggregatedScore": 411.375,
     "originalRankings": {
       "qs": {
@@ -12381,6 +13063,7 @@
   },
   {
     "name": "University of Texas Health Science Center at San Antonio",
+    "country": "United States",
     "aggregatedScore": 410.90625,
     "originalRankings": {
       "arwu": {
@@ -12395,6 +13078,7 @@
   },
   {
     "name": "University Panth�on-Sorbonne (Paris I)",
+    "country": "France",
     "aggregatedScore": 410.25,
     "originalRankings": {
       "qs": {
@@ -12409,6 +13093,7 @@
   },
   {
     "name": "Isfahan University of Technology",
+    "country": "Iran",
     "aggregatedScore": 409.125,
     "originalRankings": {
       "qs": {
@@ -12423,6 +13108,7 @@
   },
   {
     "name": "University of Vigo",
+    "country": "Spain",
     "aggregatedScore": 409.0625,
     "originalRankings": {
       "qs": {
@@ -12440,6 +13126,7 @@
   },
   {
     "name": "Ca' Foscari University of Venice",
+    "country": "Italy",
     "aggregatedScore": 406.875,
     "originalRankings": {
       "qs": {
@@ -12454,6 +13141,7 @@
   },
   {
     "name": "Stevens Institute of Technology",
+    "country": "United States",
     "aggregatedScore": 406.875,
     "originalRankings": {
       "qs": {
@@ -12468,6 +13156,7 @@
   },
   {
     "name": "University of Mississippi",
+    "country": "United States",
     "aggregatedScore": 406.27500000000003,
     "originalRankings": {
       "qs": {
@@ -12482,6 +13171,7 @@
   },
   {
     "name": "Southern Medical University",
+    "country": "China",
     "aggregatedScore": 406.25624999999997,
     "originalRankings": {
       "the": {
@@ -12496,6 +13186,7 @@
   },
   {
     "name": "University of Klagenfurt",
+    "country": "Austria",
     "aggregatedScore": 405,
     "originalRankings": {
       "qs": {
@@ -12510,6 +13201,7 @@
   },
   {
     "name": "Abo Akademi University",
+    "country": "Finland",
     "aggregatedScore": 403.125,
     "originalRankings": {
       "qs": {
@@ -12524,6 +13216,7 @@
   },
   {
     "name": "Coventry University",
+    "country": "United Kingdom",
     "aggregatedScore": 402.1875,
     "originalRankings": {
       "qs": {
@@ -12538,6 +13231,7 @@
   },
   {
     "name": "Victoria University - Melbourne",
+    "country": "Australia",
     "aggregatedScore": 399.375,
     "originalRankings": {
       "qs": {
@@ -12552,6 +13246,7 @@
   },
   {
     "name": "Indian Institute of Technology - Guwahati",
+    "country": "India",
     "aggregatedScore": 398.8125,
     "originalRankings": {
       "qs": {
@@ -12566,6 +13261,7 @@
   },
   {
     "name": "Tashkent Institute Irrigation and Agricultural Mechanization Engineers",
+    "country": "Uzbekistan",
     "aggregatedScore": 398.25,
     "originalRankings": {
       "qs": {
@@ -12580,6 +13276,7 @@
   },
   {
     "name": "Charles Sturt University",
+    "country": "Australia",
     "aggregatedScore": 398.125,
     "originalRankings": {
       "qs": {
@@ -12597,6 +13294,7 @@
   },
   {
     "name": "University of Regina",
+    "country": "Canada",
     "aggregatedScore": 398.125,
     "originalRankings": {
       "qs": {
@@ -12614,6 +13312,7 @@
   },
   {
     "name": "Bournemouth University",
+    "country": "United Kingdom",
     "aggregatedScore": 393.75,
     "originalRankings": {
       "qs": {
@@ -12628,6 +13327,7 @@
   },
   {
     "name": "Goldsmiths College - University of London",
+    "country": "United Kingdom",
     "aggregatedScore": 391.875,
     "originalRankings": {
       "qs": {
@@ -12642,6 +13342,7 @@
   },
   {
     "name": "Hannover Medical School",
+    "country": "Germany",
     "aggregatedScore": 388.96875,
     "originalRankings": {
       "arwu": {
@@ -12656,6 +13357,7 @@
   },
   {
     "name": "Kazan Federal University",
+    "country": "Russia",
     "aggregatedScore": 388.125,
     "originalRankings": {
       "qs": {
@@ -12670,6 +13372,7 @@
   },
   {
     "name": "Swedish University of Agricultural Sciences",
+    "country": "Sweden",
     "aggregatedScore": 387.50624999999997,
     "originalRankings": {
       "the": {
@@ -12684,6 +13387,7 @@
   },
   {
     "name": "Manipal University",
+    "country": "India",
     "aggregatedScore": 387.1875,
     "originalRankings": {
       "qs": {
@@ -12701,6 +13405,7 @@
   },
   {
     "name": "Roma Tre University",
+    "country": "Italy",
     "aggregatedScore": 387.1875,
     "originalRankings": {
       "qs": {
@@ -12718,6 +13423,7 @@
   },
   {
     "name": "Pontifical Catholic University of Rio de Janeiro",
+    "country": "Brazil",
     "aggregatedScore": 386.25,
     "originalRankings": {
       "qs": {
@@ -12732,6 +13438,7 @@
   },
   {
     "name": "Eastern Mediterranean University",
+    "country": "Cyprus",
     "aggregatedScore": 386.25,
     "originalRankings": {
       "qs": {
@@ -12746,6 +13453,7 @@
   },
   {
     "name": "Tallinn University of Technology",
+    "country": "Estonia",
     "aggregatedScore": 384.375,
     "originalRankings": {
       "qs": {
@@ -12760,6 +13468,7 @@
   },
   {
     "name": "Uit the Arctic University of Norway",
+    "country": "Norway",
     "aggregatedScore": 384.375,
     "originalRankings": {
       "qs": {
@@ -12774,6 +13483,7 @@
   },
   {
     "name": "Middlesex University",
+    "country": "United Kingdom",
     "aggregatedScore": 384.375,
     "originalRankings": {
       "qs": {
@@ -12788,6 +13498,7 @@
   },
   {
     "name": "Beirut Arab University",
+    "country": "Lebanon",
     "aggregatedScore": 380.625,
     "originalRankings": {
       "qs": {
@@ -12802,6 +13513,7 @@
   },
   {
     "name": "University of Tenaga Nasional",
+    "country": "Malaysia",
     "aggregatedScore": 380.625,
     "originalRankings": {
       "qs": {
@@ -12816,6 +13528,7 @@
   },
   {
     "name": "Symbiosis International University",
+    "country": "India",
     "aggregatedScore": 380.625,
     "originalRankings": {
       "qs": {
@@ -12830,6 +13543,7 @@
   },
   {
     "name": "Aberystwyth University",
+    "country": "United Kingdom",
     "aggregatedScore": 376.875,
     "originalRankings": {
       "qs": {
@@ -12844,6 +13558,7 @@
   },
   {
     "name": "University of C�rdoba",
+    "country": "Spain",
     "aggregatedScore": 376.25,
     "originalRankings": {
       "qs": {
@@ -12861,6 +13576,7 @@
   },
   {
     "name": "University of Lahore",
+    "country": "Pakistan",
     "aggregatedScore": 376.25,
     "originalRankings": {
       "qs": {
@@ -12878,6 +13594,7 @@
   },
   {
     "name": "University of Central Lancashire",
+    "country": "United Kingdom",
     "aggregatedScore": 376.25,
     "originalRankings": {
       "qs": {
@@ -12895,6 +13612,7 @@
   },
   {
     "name": "Ramon Llull University",
+    "country": "Spain",
     "aggregatedScore": 375.9375,
     "originalRankings": {
       "qs": {
@@ -12909,6 +13627,7 @@
   },
   {
     "name": "Westlake University",
+    "country": "China",
     "aggregatedScore": 371.90625,
     "originalRankings": {
       "arwu": {
@@ -12923,6 +13642,7 @@
   },
   {
     "name": "Keele University",
+    "country": "United Kingdom",
     "aggregatedScore": 371.25,
     "originalRankings": {
       "qs": {
@@ -12937,6 +13657,7 @@
   },
   {
     "name": "Central China Normal University (Huazhong Normal University)",
+    "country": "China",
     "aggregatedScore": 370.21875,
     "originalRankings": {
       "arwu": {
@@ -12951,6 +13672,7 @@
   },
   {
     "name": "University of Petroleum and Energy Studies",
+    "country": "India",
     "aggregatedScore": 369.375,
     "originalRankings": {
       "qs": {
@@ -12965,6 +13687,7 @@
   },
   {
     "name": "Edinburgh Napier University",
+    "country": "United Kingdom",
     "aggregatedScore": 369.375,
     "originalRankings": {
       "qs": {
@@ -12979,6 +13702,7 @@
   },
   {
     "name": "De Montfort University",
+    "country": "United Kingdom",
     "aggregatedScore": 367.5,
     "originalRankings": {
       "qs": {
@@ -12993,6 +13717,7 @@
   },
   {
     "name": "American University",
+    "country": "United States",
     "aggregatedScore": 367.5,
     "originalRankings": {
       "qs": {
@@ -13007,6 +13732,7 @@
   },
   {
     "name": "National University of Science and Technology MISiS",
+    "country": "Russia",
     "aggregatedScore": 367.5,
     "originalRankings": {
       "qs": {
@@ -13021,6 +13747,7 @@
   },
   {
     "name": "Lahore University of Management Sciences",
+    "country": "Pakistan",
     "aggregatedScore": 363,
     "originalRankings": {
       "qs": {
@@ -13035,6 +13762,7 @@
   },
   {
     "name": "University of the West of England - Bristol",
+    "country": "United Kingdom",
     "aggregatedScore": 361.875,
     "originalRankings": {
       "qs": {
@@ -13049,6 +13777,7 @@
   },
   {
     "name": "University of Malaysia - Pahang",
+    "country": "Malaysia",
     "aggregatedScore": 361.875,
     "originalRankings": {
       "qs": {
@@ -13063,6 +13792,7 @@
   },
   {
     "name": "University of Engineering and Technology Taxila",
+    "country": "Pakistan",
     "aggregatedScore": 360,
     "originalRankings": {
       "qs": {
@@ -13077,6 +13807,7 @@
   },
   {
     "name": "Applied Science Private University of Jordan",
+    "country": "Jordan",
     "aggregatedScore": 360,
     "originalRankings": {
       "qs": {
@@ -13091,6 +13822,7 @@
   },
   {
     "name": "University of Quebec",
+    "country": "Canada",
     "aggregatedScore": 360,
     "originalRankings": {
       "qs": {
@@ -13105,6 +13837,7 @@
   },
   {
     "name": "Jamia Millia Islamia University",
+    "country": "India",
     "aggregatedScore": 360,
     "originalRankings": {
       "qs": {
@@ -13119,6 +13852,7 @@
   },
   {
     "name": "Yangzhou University",
+    "country": "China",
     "aggregatedScore": 359.38124999999997,
     "originalRankings": {
       "the": {
@@ -13133,6 +13867,7 @@
   },
   {
     "name": "Capital University of Medical Sciences",
+    "country": "China",
     "aggregatedScore": 359.38124999999997,
     "originalRankings": {
       "the": {
@@ -13147,6 +13882,7 @@
   },
   {
     "name": "University of Technology Brunei",
+    "country": "Brunei",
     "aggregatedScore": 357.9375,
     "originalRankings": {
       "qs": {
@@ -13161,6 +13897,7 @@
   },
   {
     "name": "University of Debrecen",
+    "country": "Hungary",
     "aggregatedScore": 355.6875,
     "originalRankings": {
       "qs": {
@@ -13175,6 +13912,7 @@
   },
   {
     "name": "Sogang University",
+    "country": "South Korea",
     "aggregatedScore": 355.3125,
     "originalRankings": {
       "qs": {
@@ -13189,6 +13927,7 @@
   },
   {
     "name": "Tomsk Polytechnic University",
+    "country": "Russia",
     "aggregatedScore": 355.3125,
     "originalRankings": {
       "qs": {
@@ -13203,6 +13942,7 @@
   },
   {
     "name": "Jawaharlal Nehru University",
+    "country": "India",
     "aggregatedScore": 354.5625,
     "originalRankings": {
       "qs": {
@@ -13217,6 +13957,7 @@
   },
   {
     "name": "Management and Science University",
+    "country": "Malaysia",
     "aggregatedScore": 354.5625,
     "originalRankings": {
       "qs": {
@@ -13231,6 +13972,7 @@
   },
   {
     "name": "University of Mons-Hainaut",
+    "country": "Belgium",
     "aggregatedScore": 354.375,
     "originalRankings": {
       "qs": {
@@ -13245,6 +13987,7 @@
   },
   {
     "name": "Alfaisal University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 352.5,
     "originalRankings": {
       "qs": {
@@ -13259,6 +14002,7 @@
   },
   {
     "name": "ITMO University",
+    "country": "Russia",
     "aggregatedScore": 351.75,
     "originalRankings": {
       "qs": {
@@ -13273,6 +14017,7 @@
   },
   {
     "name": "Northern Arizona University",
+    "country": "United States",
     "aggregatedScore": 351.09375,
     "originalRankings": {
       "arwu": {
@@ -13287,6 +14032,7 @@
   },
   {
     "name": "Kingston University",
+    "country": "United Kingdom",
     "aggregatedScore": 350.625,
     "originalRankings": {
       "qs": {
@@ -13301,6 +14047,7 @@
   },
   {
     "name": "Toronto Metropolitan University",
+    "country": "Canada",
     "aggregatedScore": 350.625,
     "originalRankings": {
       "qs": {
@@ -13315,6 +14062,7 @@
   },
   {
     "name": "Birla Institute of Technology and Science",
+    "country": "India",
     "aggregatedScore": 350.625,
     "originalRankings": {
       "qs": {
@@ -13329,6 +14077,7 @@
   },
   {
     "name": "University of Stavanger",
+    "country": "Norway",
     "aggregatedScore": 350.625,
     "originalRankings": {
       "qs": {
@@ -13343,6 +14092,7 @@
   },
   {
     "name": "University of Brighton",
+    "country": "United Kingdom",
     "aggregatedScore": 350.625,
     "originalRankings": {
       "qs": {
@@ -13357,6 +14107,7 @@
   },
   {
     "name": "London South Bank University",
+    "country": "United Kingdom",
     "aggregatedScore": 350.625,
     "originalRankings": {
       "qs": {
@@ -13371,6 +14122,7 @@
   },
   {
     "name": "Al-Ahliyya Amman University",
+    "country": "Jordan",
     "aggregatedScore": 350.625,
     "originalRankings": {
       "qs": {
@@ -13385,6 +14137,7 @@
   },
   {
     "name": "Semmelweis University",
+    "country": "Hungary",
     "aggregatedScore": 350.00624999999997,
     "originalRankings": {
       "the": {
@@ -13399,6 +14152,7 @@
   },
   {
     "name": "Savitribai Phule Pune University",
+    "country": "India",
     "aggregatedScore": 345,
     "originalRankings": {
       "qs": {
@@ -13413,6 +14167,7 @@
   },
   {
     "name": "Zagazig University",
+    "country": "Egypt",
     "aggregatedScore": 343.03125,
     "originalRankings": {
       "arwu": {
@@ -13427,6 +14182,7 @@
   },
   {
     "name": "Thapar University",
+    "country": "India",
     "aggregatedScore": 341.25,
     "originalRankings": {
       "qs": {
@@ -13441,6 +14197,7 @@
   },
   {
     "name": "University of Lincoln (England)",
+    "country": "United Kingdom",
     "aggregatedScore": 341.25,
     "originalRankings": {
       "qs": {
@@ -13455,6 +14212,7 @@
   },
   {
     "name": "Thomas Jefferson University",
+    "country": "United States",
     "aggregatedScore": 340.78125,
     "originalRankings": {
       "arwu": {
@@ -13469,6 +14227,7 @@
   },
   {
     "name": "University of California - Merced",
+    "country": "United States",
     "aggregatedScore": 340.63125,
     "originalRankings": {
       "the": {
@@ -13483,6 +14242,7 @@
   },
   {
     "name": "Guangdong University of Technology",
+    "country": "China",
     "aggregatedScore": 340.63125,
     "originalRankings": {
       "the": {
@@ -13497,6 +14257,7 @@
   },
   {
     "name": "Shiraz University of Technology",
+    "country": "Iran",
     "aggregatedScore": 333.75,
     "originalRankings": {
       "qs": {
@@ -13511,6 +14272,7 @@
   },
   {
     "name": "National Institute of Technology Tiruchirappalli",
+    "country": "India",
     "aggregatedScore": 331.875,
     "originalRankings": {
       "qs": {
@@ -13525,6 +14287,7 @@
   },
   {
     "name": "Future University in Egypt",
+    "country": "Egypt",
     "aggregatedScore": 331.875,
     "originalRankings": {
       "qs": {
@@ -13539,6 +14302,7 @@
   },
   {
     "name": "Imam Muhammad Ibn Saud Islamic University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 331.875,
     "originalRankings": {
       "qs": {
@@ -13553,6 +14317,7 @@
   },
   {
     "name": "Worcester Polytechnic Institute",
+    "country": "United States",
     "aggregatedScore": 331.875,
     "originalRankings": {
       "qs": {
@@ -13567,6 +14332,7 @@
   },
   {
     "name": "Tuscia University",
+    "country": "Italy",
     "aggregatedScore": 331.875,
     "originalRankings": {
       "qs": {
@@ -13581,6 +14347,7 @@
   },
   {
     "name": "University of Westminster",
+    "country": "United Kingdom",
     "aggregatedScore": 324.375,
     "originalRankings": {
       "qs": {
@@ -13595,6 +14362,7 @@
   },
   {
     "name": "University of Malta",
+    "country": "Malta",
     "aggregatedScore": 322.5,
     "originalRankings": {
       "qs": {
@@ -13609,6 +14377,7 @@
   },
   {
     "name": "University of the Western Cape",
+    "country": "South Africa",
     "aggregatedScore": 322.5,
     "originalRankings": {
       "qs": {
@@ -13623,6 +14392,7 @@
   },
   {
     "name": "University of Denver",
+    "country": "United States",
     "aggregatedScore": 322.5,
     "originalRankings": {
       "qs": {
@@ -13637,6 +14407,7 @@
   },
   {
     "name": "Clark University",
+    "country": "United States",
     "aggregatedScore": 322.5,
     "originalRankings": {
       "qs": {
@@ -13651,6 +14422,7 @@
   },
   {
     "name": "St George's - University of London",
+    "country": "United Kingdom",
     "aggregatedScore": 321.88125,
     "originalRankings": {
       "the": {
@@ -13665,6 +14437,7 @@
   },
   {
     "name": "University of Arkansas at Fayetteville",
+    "country": "United States",
     "aggregatedScore": 321.88125,
     "originalRankings": {
       "the": {
@@ -13679,6 +14452,7 @@
   },
   {
     "name": "Nanjing Medical University",
+    "country": "China",
     "aggregatedScore": 321.88125,
     "originalRankings": {
       "the": {
@@ -13693,6 +14467,7 @@
   },
   {
     "name": "Jouf University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 313.125,
     "originalRankings": {
       "qs": {
@@ -13707,6 +14482,7 @@
   },
   {
     "name": "Shahid Beheshti University",
+    "country": "Iran",
     "aggregatedScore": 303.75,
     "originalRankings": {
       "qs": {
@@ -13721,6 +14497,7 @@
   },
   {
     "name": "Yildiz Technical University",
+    "country": "Turkey",
     "aggregatedScore": 303.75,
     "originalRankings": {
       "qs": {
@@ -13735,6 +14512,7 @@
   },
   {
     "name": "CY Cergy Paris University",
+    "country": "France",
     "aggregatedScore": 303.75,
     "originalRankings": {
       "qs": {
@@ -13749,6 +14527,7 @@
   },
   {
     "name": "University of Greifswald",
+    "country": "Germany",
     "aggregatedScore": 303.13125,
     "originalRankings": {
       "the": {
@@ -13763,6 +14542,7 @@
   },
   {
     "name": "Mississippi State University",
+    "country": "United States",
     "aggregatedScore": 303.13125,
     "originalRankings": {
       "the": {
@@ -13777,6 +14557,7 @@
   },
   {
     "name": "Binghamton University",
+    "country": "United States",
     "aggregatedScore": 303.13125,
     "originalRankings": {
       "the": {
@@ -13791,6 +14572,7 @@
   },
   {
     "name": "University of Petroleum (East China)",
+    "country": "China",
     "aggregatedScore": 303.13125,
     "originalRankings": {
       "the": {
@@ -13805,6 +14587,7 @@
   },
   {
     "name": "Nanjing University of Information Science and Technology",
+    "country": "China",
     "aggregatedScore": 303.13125,
     "originalRankings": {
       "the": {
@@ -13819,6 +14602,7 @@
   },
   {
     "name": "North South University",
+    "country": "Bangladesh",
     "aggregatedScore": 294.375,
     "originalRankings": {
       "qs": {
@@ -13833,6 +14617,7 @@
   },
   {
     "name": "Catholic University of Portugal",
+    "country": "Portugal",
     "aggregatedScore": 294.375,
     "originalRankings": {
       "qs": {
@@ -13847,6 +14632,7 @@
   },
   {
     "name": "The Robert Gordon University",
+    "country": "United Kingdom",
     "aggregatedScore": 294.375,
     "originalRankings": {
       "qs": {
@@ -13861,6 +14647,7 @@
   },
   {
     "name": "University of Salford",
+    "country": "United Kingdom",
     "aggregatedScore": 294.375,
     "originalRankings": {
       "qs": {
@@ -13875,6 +14662,7 @@
   },
   {
     "name": "University of Chile",
+    "country": "Chile",
     "aggregatedScore": 287.025,
     "originalRankings": {
       "qs": {
@@ -13889,6 +14677,7 @@
   },
   {
     "name": "Ferdowsi University of Mashhad",
+    "country": "Iran",
     "aggregatedScore": 285,
     "originalRankings": {
       "qs": {
@@ -13903,6 +14692,7 @@
   },
   {
     "name": "King Mongkut's University of Technology Thonburi",
+    "country": "Thailand",
     "aggregatedScore": 285,
     "originalRankings": {
       "qs": {
@@ -13917,6 +14707,7 @@
   },
   {
     "name": "Saveetha Institute of Medical and Technical Sciences",
+    "country": "India",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -13931,6 +14722,7 @@
   },
   {
     "name": "�rebro University",
+    "country": "Sweden",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -13945,6 +14737,7 @@
   },
   {
     "name": "University of Nevada - Las Vegas",
+    "country": "United States",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -13959,6 +14752,7 @@
   },
   {
     "name": "University of Toledo",
+    "country": "United States",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -13973,6 +14767,7 @@
   },
   {
     "name": "University of Texas at San Antonio",
+    "country": "United States",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -13987,6 +14782,7 @@
   },
   {
     "name": "Wenzhou University",
+    "country": "China",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -14001,6 +14797,7 @@
   },
   {
     "name": "Prince Sattam Bin Abdulaziz University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -14015,6 +14812,7 @@
   },
   {
     "name": "Nanjing Normal University",
+    "country": "China",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -14029,6 +14827,7 @@
   },
   {
     "name": "Southwest Jiaotong University",
+    "country": "China",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -14043,6 +14842,7 @@
   },
   {
     "name": "Guangzhou Medical University",
+    "country": "China",
     "aggregatedScore": 284.38125,
     "originalRankings": {
       "the": {
@@ -14057,6 +14857,7 @@
   },
   {
     "name": "University of Strasbourg",
+    "country": "France",
     "aggregatedScore": 283.8375,
     "originalRankings": {
       "qs": {
@@ -14071,6 +14872,7 @@
   },
   {
     "name": "Universite Paris Cite",
+    "country": "France",
     "aggregatedScore": 273.203125,
     "originalRankings": {
       "usnews": {
@@ -14082,6 +14884,7 @@
   },
   {
     "name": "KU Leuven",
+    "country": "Belgium",
     "aggregatedScore": 272.421875,
     "originalRankings": {
       "usnews": {
@@ -14093,6 +14896,7 @@
   },
   {
     "name": "University of Munich",
+    "country": "Germany",
     "aggregatedScore": 271.640625,
     "originalRankings": {
       "usnews": {
@@ -14104,6 +14908,7 @@
   },
   {
     "name": "Leiden University",
+    "country": "Netherlands",
     "aggregatedScore": 271.171875,
     "originalRankings": {
       "usnews": {
@@ -14115,6 +14920,7 @@
   },
   {
     "name": "Sorbonne Universite",
+    "country": "France",
     "aggregatedScore": 271.171875,
     "originalRankings": {
       "usnews": {
@@ -14126,6 +14932,7 @@
   },
   {
     "name": "University of Chinese Academy of Sciences",
+    "country": "China",
     "aggregatedScore": 269.140625,
     "originalRankings": {
       "usnews": {
@@ -14137,6 +14944,7 @@
   },
   {
     "name": "Vrije Universiteit Amsterdam",
+    "country": "Netherlands",
     "aggregatedScore": 267.734375,
     "originalRankings": {
       "usnews": {
@@ -14148,6 +14956,7 @@
   },
   {
     "name": "Technical University of Munich",
+    "country": "Germany",
     "aggregatedScore": 267.109375,
     "originalRankings": {
       "usnews": {
@@ -14159,6 +14968,7 @@
   },
   {
     "name": "Tehran University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14173,6 +14983,7 @@
   },
   {
     "name": "Campus Bio-Medico University of Rome",
+    "country": "Italy",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14187,6 +14998,7 @@
   },
   {
     "name": "Royal Veterinary College",
+    "country": "United Kingdom",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14201,6 +15013,7 @@
   },
   {
     "name": "University of the Sunshine Coast",
+    "country": "Australia",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14215,6 +15028,7 @@
   },
   {
     "name": "Ohio University",
+    "country": "United States",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14229,6 +15043,7 @@
   },
   {
     "name": "University of Texas at Arlington",
+    "country": "United States",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14243,6 +15058,7 @@
   },
   {
     "name": "University of Wyoming",
+    "country": "United States",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14257,6 +15073,7 @@
   },
   {
     "name": "Shahid Beheshti University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14271,6 +15088,7 @@
   },
   {
     "name": "Harbin Engineering University",
+    "country": "China",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14285,6 +15103,7 @@
   },
   {
     "name": "Wenzhou Medical University",
+    "country": "China",
     "aggregatedScore": 265.63125,
     "originalRankings": {
       "the": {
@@ -14299,6 +15118,7 @@
   },
   {
     "name": "Ghent University",
+    "country": "Belgium",
     "aggregatedScore": 262.890625,
     "originalRankings": {
       "usnews": {
@@ -14310,6 +15130,7 @@
   },
   {
     "name": "UT Southwestern Medical Center",
+    "country": "United States",
     "aggregatedScore": 262.890625,
     "originalRankings": {
       "usnews": {
@@ -14321,6 +15142,7 @@
   },
   {
     "name": "Universite PSL",
+    "country": "France",
     "aggregatedScore": 262.421875,
     "originalRankings": {
       "usnews": {
@@ -14332,6 +15154,7 @@
   },
   {
     "name": "Universidade de Sao Paulo",
+    "country": "Brazil",
     "aggregatedScore": 260.078125,
     "originalRankings": {
       "usnews": {
@@ -14343,6 +15166,7 @@
   },
   {
     "name": "Sapienza University of Rome",
+    "country": "Italy",
     "aggregatedScore": 258.046875,
     "originalRankings": {
       "usnews": {
@@ -14354,6 +15178,7 @@
   },
   {
     "name": "Medical Campus",
+    "country": "United States",
     "aggregatedScore": 257.734375,
     "originalRankings": {
       "usnews": {
@@ -14365,6 +15190,7 @@
   },
   {
     "name": "University of Gothenburg",
+    "country": "Sweden",
     "aggregatedScore": 254.921875,
     "originalRankings": {
       "usnews": {
@@ -14376,6 +15202,7 @@
   },
   {
     "name": "Université de Montréal",
+    "country": "Canada",
     "aggregatedScore": 252.734375,
     "originalRankings": {
       "usnews": {
@@ -14387,6 +15214,7 @@
   },
   {
     "name": "Maastricht University",
+    "country": "Netherlands",
     "aggregatedScore": 251.953125,
     "originalRankings": {
       "usnews": {
@@ -14398,6 +15226,7 @@
   },
   {
     "name": "University of Leipzig",
+    "country": "Germany",
     "aggregatedScore": 251.77499999999998,
     "originalRankings": {
       "qs": {
@@ -14412,6 +15241,7 @@
   },
   {
     "name": "Technische Universitat Dresden",
+    "country": "Germany",
     "aggregatedScore": 248.515625,
     "originalRankings": {
       "usnews": {
@@ -14423,6 +15253,7 @@
   },
   {
     "name": "Universite Catholique Louvain",
+    "country": "Belgium",
     "aggregatedScore": 248.515625,
     "originalRankings": {
       "usnews": {
@@ -14434,6 +15265,7 @@
   },
   {
     "name": "Indian Institute of Technology - Delhi",
+    "country": "India",
     "aggregatedScore": 247.46249999999998,
     "originalRankings": {
       "qs": {
@@ -14448,6 +15280,7 @@
   },
   {
     "name": "University of Wuppertal",
+    "country": "Germany",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14462,6 +15295,7 @@
   },
   {
     "name": "University of Nebraska Medical Center",
+    "country": "United States",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14476,6 +15310,7 @@
   },
   {
     "name": "Wroclaw Medical University",
+    "country": "Poland",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14490,6 +15325,7 @@
   },
   {
     "name": "South China Normal University",
+    "country": "China",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14504,6 +15340,7 @@
   },
   {
     "name": "Aligarh Muslim University",
+    "country": "India",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14518,6 +15355,7 @@
   },
   {
     "name": "University of Cagliari",
+    "country": "Italy",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14532,6 +15370,7 @@
   },
   {
     "name": "Florida Atlantic University",
+    "country": "United States",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14546,6 +15385,7 @@
   },
   {
     "name": "Gachon University",
+    "country": "South Korea",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14560,6 +15400,7 @@
   },
   {
     "name": "North China Electric Power University",
+    "country": "China",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14574,6 +15415,7 @@
   },
   {
     "name": "Northeast Agricultural University",
+    "country": "China",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14588,6 +15430,7 @@
   },
   {
     "name": "Northeast Normal University",
+    "country": "China",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14602,6 +15445,7 @@
   },
   {
     "name": "Jaume I University",
+    "country": "Spain",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14616,6 +15460,7 @@
   },
   {
     "name": "University of the Balearic Islands",
+    "country": "Spain",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14630,6 +15475,7 @@
   },
   {
     "name": "University Clermont Auvergne",
+    "country": "France",
     "aggregatedScore": 246.88125000000002,
     "originalRankings": {
       "the": {
@@ -14644,6 +15490,7 @@
   },
   {
     "name": "National and Kapodistrian University of Athens",
+    "country": "Greece",
     "aggregatedScore": 246.328125,
     "originalRankings": {
       "usnews": {
@@ -14655,6 +15502,7 @@
   },
   {
     "name": "Universite de Montpellier",
+    "country": "France",
     "aggregatedScore": 245.859375,
     "originalRankings": {
       "usnews": {
@@ -14666,6 +15514,7 @@
   },
   {
     "name": "Universidade de Lisboa",
+    "country": "Portugal",
     "aggregatedScore": 244.765625,
     "originalRankings": {
       "usnews": {
@@ -14677,6 +15526,7 @@
   },
   {
     "name": "St. Petersburg State University",
+    "country": "Russia",
     "aggregatedScore": 244.64999999999998,
     "originalRankings": {
       "qs": {
@@ -14691,6 +15541,7 @@
   },
   {
     "name": "Goethe University Frankfurt",
+    "country": "Germany",
     "aggregatedScore": 244.453125,
     "originalRankings": {
       "usnews": {
@@ -14702,6 +15553,7 @@
   },
   {
     "name": "Universite Grenoble Alpes (UGA)",
+    "country": "France",
     "aggregatedScore": 242.890625,
     "originalRankings": {
       "usnews": {
@@ -14713,6 +15565,7 @@
   },
   {
     "name": "The London School of Economics and Political Science (LSE)",
+    "country": "United Kingdom",
     "aggregatedScore": 242.578125,
     "originalRankings": {
       "usnews": {
@@ -14724,6 +15577,7 @@
   },
   {
     "name": "Royal Institute of Technology",
+    "country": "Sweden",
     "aggregatedScore": 240.703125,
     "originalRankings": {
       "usnews": {
@@ -14735,6 +15589,7 @@
   },
   {
     "name": "Charit� - University Medicine Berlin",
+    "country": "Germany",
     "aggregatedScore": 238.234375,
     "originalRankings": {
       "the": {
@@ -14746,6 +15601,7 @@
   },
   {
     "name": "Pompeu Fabra University",
+    "country": "Spain",
     "aggregatedScore": 237.890625,
     "originalRankings": {
       "usnews": {
@@ -14757,6 +15613,7 @@
   },
   {
     "name": "Universidade do Porto",
+    "country": "Portugal",
     "aggregatedScore": 237.578125,
     "originalRankings": {
       "usnews": {
@@ -14768,6 +15625,7 @@
   },
   {
     "name": "State University",
+    "country": "United States",
     "aggregatedScore": 236.484375,
     "originalRankings": {
       "usnews": {
@@ -14779,6 +15637,7 @@
   },
   {
     "name": "Western Sydney University",
+    "country": "Australia",
     "aggregatedScore": 236.484375,
     "originalRankings": {
       "usnews": {
@@ -14790,6 +15649,7 @@
   },
   {
     "name": "Universite de Bordeaux",
+    "country": "France",
     "aggregatedScore": 236.015625,
     "originalRankings": {
       "usnews": {
@@ -14801,6 +15661,7 @@
   },
   {
     "name": "Universiti Malaya",
+    "country": "Malaysia",
     "aggregatedScore": 236.015625,
     "originalRankings": {
       "usnews": {
@@ -14812,6 +15673,7 @@
   },
   {
     "name": "University of Erlangen Nuremberg",
+    "country": "Germany",
     "aggregatedScore": 236.015625,
     "originalRankings": {
       "usnews": {
@@ -14823,6 +15685,7 @@
   },
   {
     "name": "Durham University",
+    "country": "United Kingdom",
     "aggregatedScore": 231.640625,
     "originalRankings": {
       "usnews": {
@@ -14834,6 +15697,7 @@
   },
   {
     "name": "Stellenbosch University",
+    "country": "South Africa",
     "aggregatedScore": 231.328125,
     "originalRankings": {
       "usnews": {
@@ -14845,6 +15709,7 @@
   },
   {
     "name": "Soochow University - China",
+    "country": "China",
     "aggregatedScore": 230.390625,
     "originalRankings": {
       "usnews": {
@@ -14856,6 +15721,7 @@
   },
   {
     "name": "Universite de Strasbourg",
+    "country": "France",
     "aggregatedScore": 229.609375,
     "originalRankings": {
       "usnews": {
@@ -14867,6 +15733,7 @@
   },
   {
     "name": "University of Lagos",
+    "country": "Nigeria",
     "aggregatedScore": 229.453125,
     "originalRankings": {
       "usnews": {
@@ -14878,6 +15745,7 @@
   },
   {
     "name": "Leipzig University",
+    "country": "Germany",
     "aggregatedScore": 228.828125,
     "originalRankings": {
       "usnews": {
@@ -14889,6 +15757,7 @@
   },
   {
     "name": "Ege University",
+    "country": "Pakistan",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -14903,6 +15772,7 @@
   },
   {
     "name": "Kaiserslautern University of Technology",
+    "country": "Germany",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -14917,6 +15787,7 @@
   },
   {
     "name": "Banaras Hindu University",
+    "country": "India",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -14931,6 +15802,7 @@
   },
   {
     "name": "University of Udine",
+    "country": "Italy",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -14945,6 +15817,7 @@
   },
   {
     "name": "Juntendo University",
+    "country": "Japan",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -14959,6 +15832,7 @@
   },
   {
     "name": "Xi'an Jiaotong Liverpool University",
+    "country": "China",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -14973,6 +15847,7 @@
   },
   {
     "name": "University of Castilla-La Mancha",
+    "country": "Spain",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -14987,6 +15862,7 @@
   },
   {
     "name": "Open University",
+    "country": "United Kingdom",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -15001,6 +15877,7 @@
   },
   {
     "name": "University of Eastern Piedmont",
+    "country": "Italy",
     "aggregatedScore": 228.13125000000002,
     "originalRankings": {
       "the": {
@@ -15015,6 +15892,7 @@
   },
   {
     "name": "Qatar University",
+    "country": "Qatar",
     "aggregatedScore": 227.265625,
     "originalRankings": {
       "usnews": {
@@ -15026,6 +15904,7 @@
   },
   {
     "name": "Universiti Teknologi Malaysia",
+    "country": "Malaysia",
     "aggregatedScore": 226.171875,
     "originalRankings": {
       "usnews": {
@@ -15037,6 +15916,7 @@
   },
   {
     "name": "St Georges University London",
+    "country": "United Kingdom",
     "aggregatedScore": 225.234375,
     "originalRankings": {
       "usnews": {
@@ -15048,6 +15928,7 @@
   },
   {
     "name": "University of Ibadan",
+    "country": "Nigeria",
     "aggregatedScore": 225.234375,
     "originalRankings": {
       "usnews": {
@@ -15059,6 +15940,7 @@
   },
   {
     "name": "Ulm University",
+    "country": "Germany",
     "aggregatedScore": 224.609375,
     "originalRankings": {
       "usnews": {
@@ -15070,6 +15952,7 @@
   },
   {
     "name": "Technology & Design",
+    "country": "Singapore",
     "aggregatedScore": 224.453125,
     "originalRankings": {
       "usnews": {
@@ -15081,6 +15964,7 @@
   },
   {
     "name": "University Paul Sabatier - Toulouse III",
+    "country": "France",
     "aggregatedScore": 223.08749999999998,
     "originalRankings": {
       "qs": {
@@ -15095,6 +15979,7 @@
   },
   {
     "name": "Islamic Azad University",
+    "country": "Iran",
     "aggregatedScore": 221.484375,
     "originalRankings": {
       "usnews": {
@@ -15106,6 +15991,7 @@
   },
   {
     "name": "Sant'Anna School of Advanced Studies",
+    "country": "Italy",
     "aggregatedScore": 221.359375,
     "originalRankings": {
       "the": {
@@ -15117,6 +16003,7 @@
   },
   {
     "name": "Technology Beijing",
+    "country": "China",
     "aggregatedScore": 220.390625,
     "originalRankings": {
       "usnews": {
@@ -15128,6 +16015,7 @@
   },
   {
     "name": "Ruhr University Bochum",
+    "country": "Germany",
     "aggregatedScore": 219.140625,
     "originalRankings": {
       "usnews": {
@@ -15139,6 +16027,7 @@
   },
   {
     "name": "Universite de Lille",
+    "country": "France",
     "aggregatedScore": 217.265625,
     "originalRankings": {
       "usnews": {
@@ -15150,6 +16039,7 @@
   },
   {
     "name": "Universiti Sains Malaysia",
+    "country": "Malaysia",
     "aggregatedScore": 217.265625,
     "originalRankings": {
       "usnews": {
@@ -15161,6 +16051,7 @@
   },
   {
     "name": "Jinan University",
+    "country": "China",
     "aggregatedScore": 216.171875,
     "originalRankings": {
       "usnews": {
@@ -15172,6 +16063,7 @@
   },
   {
     "name": "Medical University",
+    "country": "Russia",
     "aggregatedScore": 215.546875,
     "originalRankings": {
       "usnews": {
@@ -15183,6 +16075,7 @@
   },
   {
     "name": "Technical University of Madrid",
+    "country": "Spain",
     "aggregatedScore": 215.39999999999998,
     "originalRankings": {
       "qs": {
@@ -15197,6 +16090,7 @@
   },
   {
     "name": "Flinders University South Australia",
+    "country": "Australia",
     "aggregatedScore": 214.140625,
     "originalRankings": {
       "usnews": {
@@ -15208,6 +16102,7 @@
   },
   {
     "name": "Royal College of Surgeons",
+    "country": "Ireland",
     "aggregatedScore": 213.546875,
     "originalRankings": {
       "the": {
@@ -15219,6 +16114,7 @@
   },
   {
     "name": "Universidad Nacional Autónoma de México (UNAM)",
+    "country": "Mexico",
     "aggregatedScore": 212.421875,
     "originalRankings": {
       "usnews": {
@@ -15230,6 +16126,7 @@
   },
   {
     "name": "Vilnius University",
+    "country": "Lithuania",
     "aggregatedScore": 212.02499999999998,
     "originalRankings": {
       "qs": {
@@ -15244,6 +16141,7 @@
   },
   {
     "name": "Nantes Universite",
+    "country": "France",
     "aggregatedScore": 211.484375,
     "originalRankings": {
       "usnews": {
@@ -15255,6 +16153,7 @@
   },
   {
     "name": "Universidad de Chile",
+    "country": "Chile",
     "aggregatedScore": 210.390625,
     "originalRankings": {
       "usnews": {
@@ -15266,6 +16165,7 @@
   },
   {
     "name": "Universite de Lorraine",
+    "country": "France",
     "aggregatedScore": 209.453125,
     "originalRankings": {
       "usnews": {
@@ -15277,6 +16177,7 @@
   },
   {
     "name": "Chengdu University of Technology",
+    "country": "China",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15291,6 +16192,7 @@
   },
   {
     "name": "China Pharmaceutical University",
+    "country": "China",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15305,6 +16207,7 @@
   },
   {
     "name": "University Savoie Mont Blanc",
+    "country": "France",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15319,6 +16222,7 @@
   },
   {
     "name": "University of Campania Luigi Vanvitelli",
+    "country": "Italy",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15333,6 +16237,7 @@
   },
   {
     "name": "University of Rhode Island",
+    "country": "United States",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15347,6 +16252,7 @@
   },
   {
     "name": "University of Texas at El Paso",
+    "country": "United States",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15361,6 +16267,7 @@
   },
   {
     "name": "Old Dominion University",
+    "country": "United States",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15375,6 +16282,7 @@
   },
   {
     "name": "University of Girona",
+    "country": "Spain",
     "aggregatedScore": 209.38125000000002,
     "originalRankings": {
       "the": {
@@ -15389,6 +16297,7 @@
   },
   {
     "name": "York University - Canada",
+    "country": "Canada",
     "aggregatedScore": 207.109375,
     "originalRankings": {
       "usnews": {
@@ -15400,6 +16309,7 @@
   },
   {
     "name": "Tampere University",
+    "country": "Finland",
     "aggregatedScore": 206.328125,
     "originalRankings": {
       "usnews": {
@@ -15411,6 +16321,7 @@
   },
   {
     "name": "University of Szeged",
+    "country": "Hungary",
     "aggregatedScore": 206.21249999999998,
     "originalRankings": {
       "qs": {
@@ -15425,6 +16336,7 @@
   },
   {
     "name": "Universidade de Coimbra",
+    "country": "Portugal",
     "aggregatedScore": 205.859375,
     "originalRankings": {
       "usnews": {
@@ -15436,6 +16348,7 @@
   },
   {
     "name": "Universite de Rennes",
+    "country": "France",
     "aggregatedScore": 205.078125,
     "originalRankings": {
       "usnews": {
@@ -15447,6 +16360,7 @@
   },
   {
     "name": "Eotvos Lorand University",
+    "country": "Hungary",
     "aggregatedScore": 204.140625,
     "originalRankings": {
       "usnews": {
@@ -15458,6 +16372,7 @@
   },
   {
     "name": "University of Tsukuba",
+    "country": "Japan",
     "aggregatedScore": 203.671875,
     "originalRankings": {
       "usnews": {
@@ -15469,6 +16384,7 @@
   },
   {
     "name": "Assiut University",
+    "country": "Egypt",
     "aggregatedScore": 203.515625,
     "originalRankings": {
       "usnews": {
@@ -15480,6 +16396,7 @@
   },
   {
     "name": "University of Indianapolis",
+    "country": "United States",
     "aggregatedScore": 201.640625,
     "originalRankings": {
       "usnews": {
@@ -15491,6 +16408,7 @@
   },
   {
     "name": "Hohai University",
+    "country": "China",
     "aggregatedScore": 201.328125,
     "originalRankings": {
       "usnews": {
@@ -15502,6 +16420,7 @@
   },
   {
     "name": "Saarland University",
+    "country": "Germany",
     "aggregatedScore": 200.39999999999998,
     "originalRankings": {
       "qs": {
@@ -15516,6 +16435,7 @@
   },
   {
     "name": "Donghua University",
+    "country": "China",
     "aggregatedScore": 200.390625,
     "originalRankings": {
       "usnews": {
@@ -15527,6 +16447,7 @@
   },
   {
     "name": "Justus Liebig University Giessen",
+    "country": "Germany",
     "aggregatedScore": 200.390625,
     "originalRankings": {
       "usnews": {
@@ -15538,6 +16459,7 @@
   },
   {
     "name": "University of St.Gallen",
+    "country": "Switzerland",
     "aggregatedScore": 197.921875,
     "originalRankings": {
       "the": {
@@ -15549,6 +16471,7 @@
   },
   {
     "name": "IMT Atlantique",
+    "country": "France",
     "aggregatedScore": 197.921875,
     "originalRankings": {
       "the": {
@@ -15560,6 +16483,7 @@
   },
   {
     "name": "L'institut Agro",
+    "country": "France",
     "aggregatedScore": 197.921875,
     "originalRankings": {
       "the": {
@@ -15571,6 +16495,7 @@
   },
   {
     "name": "National University of Colombia",
+    "country": "Colombia",
     "aggregatedScore": 197.02499999999998,
     "originalRankings": {
       "qs": {
@@ -15585,6 +16510,7 @@
   },
   {
     "name": "Istanbul University",
+    "country": "Turkey",
     "aggregatedScore": 196.64999999999998,
     "originalRankings": {
       "qs": {
@@ -15599,6 +16525,7 @@
   },
   {
     "name": "Indian Institute of Technology - Kharagpur",
+    "country": "India",
     "aggregatedScore": 196.46249999999998,
     "originalRankings": {
       "qs": {
@@ -15613,6 +16540,7 @@
   },
   {
     "name": "Indian Institute of Technology - Madras",
+    "country": "India",
     "aggregatedScore": 195.52499999999998,
     "originalRankings": {
       "qs": {
@@ -15627,6 +16555,7 @@
   },
   {
     "name": "Indian Institute of Technology - Roorkee",
+    "country": "India",
     "aggregatedScore": 194.02499999999998,
     "originalRankings": {
       "qs": {
@@ -15641,6 +16570,7 @@
   },
   {
     "name": "University of Regensburg",
+    "country": "Germany",
     "aggregatedScore": 192.89999999999998,
     "originalRankings": {
       "qs": {
@@ -15655,6 +16585,7 @@
   },
   {
     "name": "University of Zaragoza",
+    "country": "Spain",
     "aggregatedScore": 192.33749999999998,
     "originalRankings": {
       "qs": {
@@ -15669,6 +16600,7 @@
   },
   {
     "name": "University of Ja�n",
+    "country": "Spain",
     "aggregatedScore": 190.63125000000002,
     "originalRankings": {
       "the": {
@@ -15683,6 +16615,7 @@
   },
   {
     "name": "Kaohsiung Medical University",
+    "country": "Taiwan",
     "aggregatedScore": 190.63125000000002,
     "originalRankings": {
       "the": {
@@ -15697,6 +16630,7 @@
   },
   {
     "name": "Abdul Wali Khan University Mardan",
+    "country": "Pakistan",
     "aggregatedScore": 190.63125000000002,
     "originalRankings": {
       "the": {
@@ -15711,6 +16645,7 @@
   },
   {
     "name": "Changsha University of Science and Technology",
+    "country": "China",
     "aggregatedScore": 190.63125000000002,
     "originalRankings": {
       "the": {
@@ -15725,6 +16660,7 @@
   },
   {
     "name": "Jazan University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 190.63125000000002,
     "originalRankings": {
       "the": {
@@ -15739,6 +16675,7 @@
   },
   {
     "name": "University of Vaasa",
+    "country": "Finland",
     "aggregatedScore": 190.109375,
     "originalRankings": {
       "the": {
@@ -15750,6 +16687,7 @@
   },
   {
     "name": "Mahatma Gandhi University",
+    "country": "India",
     "aggregatedScore": 190.109375,
     "originalRankings": {
       "the": {
@@ -15761,6 +16699,7 @@
   },
   {
     "name": "Federal University of Toulouse Midi-Pyr�n�es",
+    "country": "France",
     "aggregatedScore": 190.109375,
     "originalRankings": {
       "the": {
@@ -15772,6 +16711,7 @@
   },
   {
     "name": "Federation University Australia",
+    "country": "Australia",
     "aggregatedScore": 190.109375,
     "originalRankings": {
       "the": {
@@ -15783,6 +16723,7 @@
   },
   {
     "name": "Leuphana University Luneburg",
+    "country": "Germany",
     "aggregatedScore": 190.109375,
     "originalRankings": {
       "the": {
@@ -15794,6 +16735,7 @@
   },
   {
     "name": "Mohammed VI Polytechnic University",
+    "country": "Morocco",
     "aggregatedScore": 190.109375,
     "originalRankings": {
       "the": {
@@ -15805,6 +16747,7 @@
   },
   {
     "name": "University of Halle-Wittenberg",
+    "country": "Germany",
     "aggregatedScore": 187.27499999999998,
     "originalRankings": {
       "qs": {
@@ -15819,6 +16762,7 @@
   },
   {
     "name": "Ural Federal University",
+    "country": "Russia",
     "aggregatedScore": 178.83749999999998,
     "originalRankings": {
       "qs": {
@@ -15833,6 +16777,7 @@
   },
   {
     "name": "Arabian Gulf University",
+    "country": "Bahrain",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15844,6 +16789,7 @@
   },
   {
     "name": "University of Neuchatel",
+    "country": "Switzerland",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15855,6 +16801,7 @@
   },
   {
     "name": "University of Paderborn",
+    "country": "Germany",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15866,6 +16813,7 @@
   },
   {
     "name": "University of Passau",
+    "country": "Germany",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15877,6 +16825,7 @@
   },
   {
     "name": "Roskilde University",
+    "country": "Denmark",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15888,6 +16837,7 @@
   },
   {
     "name": "Ecole Centrale de Nantes",
+    "country": "France",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15899,6 +16849,7 @@
   },
   {
     "name": "National Yunlin University of Science and Technology",
+    "country": "Taiwan",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15910,6 +16861,7 @@
   },
   {
     "name": "University of Tulsa",
+    "country": "United States",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15921,6 +16873,7 @@
   },
   {
     "name": "Anglia Ruskin University",
+    "country": "United Kingdom",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15932,6 +16885,7 @@
   },
   {
     "name": "Hamburg University of Technology",
+    "country": "Germany",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15943,6 +16897,7 @@
   },
   {
     "name": "Babol Noshirvani University of Technology",
+    "country": "Iran",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15954,6 +16909,7 @@
   },
   {
     "name": "University of Nicosia",
+    "country": "Cyprus",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15965,6 +16921,7 @@
   },
   {
     "name": "UEH University",
+    "country": "Viet Nam",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15976,6 +16933,7 @@
   },
   {
     "name": "Constructor University Bremen",
+    "country": "Germany",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15987,6 +16945,7 @@
   },
   {
     "name": "Egypt-Japan University of Science and Technology",
+    "country": "Egypt",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -15998,6 +16957,7 @@
   },
   {
     "name": "ENSTA Bretagne",
+    "country": "France",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -16009,6 +16969,7 @@
   },
   {
     "name": "Nazarbayev University",
+    "country": "Kazakhstan",
     "aggregatedScore": 174.484375,
     "originalRankings": {
       "the": {
@@ -16020,6 +16981,7 @@
   },
   {
     "name": "Northwest Agriculture and Forestry University",
+    "country": "China",
     "aggregatedScore": 172.27499999999998,
     "originalRankings": {
       "qs": {
@@ -16034,6 +16996,7 @@
   },
   {
     "name": "City University of New York - City College",
+    "country": "United States",
     "aggregatedScore": 170.39999999999998,
     "originalRankings": {
       "qs": {
@@ -16048,6 +17011,7 @@
   },
   {
     "name": "Indian Institute of Technology - Kanpur",
+    "country": "India",
     "aggregatedScore": 170.02499999999998,
     "originalRankings": {
       "qs": {
@@ -16062,6 +17026,7 @@
   },
   {
     "name": "Chiang Mai University",
+    "country": "Thailand",
     "aggregatedScore": 169.27499999999998,
     "originalRankings": {
       "qs": {
@@ -16076,6 +17041,7 @@
   },
   {
     "name": "Czech Technical University of Prague",
+    "country": "Czech Republic",
     "aggregatedScore": 159.33749999999998,
     "originalRankings": {
       "qs": {
@@ -16090,6 +17056,7 @@
   },
   {
     "name": "Cyprus International University",
+    "country": "Northern Cyprus",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16101,6 +17068,7 @@
   },
   {
     "name": "Near East University",
+    "country": "Northern Cyprus",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16112,6 +17080,7 @@
   },
   {
     "name": "Espiritu Santo University",
+    "country": "Ecuador",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16123,6 +17092,7 @@
   },
   {
     "name": "Ecole Centrale de Lyon",
+    "country": "France",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16134,6 +17104,7 @@
   },
   {
     "name": "Ecole Nationale des Travaux Publics de l'Etat",
+    "country": "France",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16145,6 +17116,7 @@
   },
   {
     "name": "Harokopio University",
+    "country": "Greece",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16156,6 +17128,7 @@
   },
   {
     "name": "Panjab University",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16167,6 +17140,7 @@
   },
   {
     "name": "Babol University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16178,6 +17152,7 @@
   },
   {
     "name": "Gorgan University Of Agricultural Sciences And Natural Resources",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16189,6 +17164,7 @@
   },
   {
     "name": "Kurdistan University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16200,6 +17176,7 @@
   },
   {
     "name": "Mazandaran University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16211,6 +17188,7 @@
   },
   {
     "name": "Qazvin University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16222,6 +17200,7 @@
   },
   {
     "name": "Tabriz University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16233,6 +17212,7 @@
   },
   {
     "name": "Urmia University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16244,6 +17224,7 @@
   },
   {
     "name": "University of Aquila",
+    "country": "Italy",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16255,6 +17236,7 @@
   },
   {
     "name": "University of Sassari",
+    "country": "Italy",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16266,6 +17248,7 @@
   },
   {
     "name": "University of Aizu",
+    "country": "Japan",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16277,6 +17260,7 @@
   },
   {
     "name": "Air University",
+    "country": "Pakistan",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16288,6 +17272,7 @@
   },
   {
     "name": "University of Beira Interior",
+    "country": "Portugal",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16299,6 +17284,7 @@
   },
   {
     "name": "St. Petersburg State Mining Institute (Technical University)",
+    "country": "Russia",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16310,6 +17296,7 @@
   },
   {
     "name": "J�nk�ping University College",
+    "country": "Sweden",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16321,6 +17308,7 @@
   },
   {
     "name": "London Metropolitan University",
+    "country": "United Kingdom",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16332,6 +17320,7 @@
   },
   {
     "name": "University of Derby",
+    "country": "United Kingdom",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16343,6 +17332,7 @@
   },
   {
     "name": "Catholic University of America",
+    "country": "United States",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16354,6 +17344,7 @@
   },
   {
     "name": "Rochester Institute of Technology",
+    "country": "United States",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16365,6 +17356,7 @@
   },
   {
     "name": "University of North Carolina at Charlotte",
+    "country": "United States",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16376,6 +17368,7 @@
   },
   {
     "name": "College of William and Mary",
+    "country": "United States",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16387,6 +17380,7 @@
   },
   {
     "name": "Cyprus University of Technology",
+    "country": "Cyprus",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16398,6 +17392,7 @@
   },
   {
     "name": "Amity University",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16409,6 +17404,7 @@
   },
   {
     "name": "University of the West Scotland",
+    "country": "United Kingdom",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16420,6 +17416,7 @@
   },
   {
     "name": "�cole des Mines de Saint-�tienne",
+    "country": "France",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16431,6 +17428,7 @@
   },
   {
     "name": "University of Insubria",
+    "country": "Italy",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16442,6 +17440,7 @@
   },
   {
     "name": "Open University of Catalonia",
+    "country": "Spain",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16453,6 +17452,7 @@
   },
   {
     "name": "Indian Institute of Technology - Patna",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16464,6 +17464,7 @@
   },
   {
     "name": "Parthenope University of Naples",
+    "country": "Italy",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16475,6 +17476,7 @@
   },
   {
     "name": "Scotland's Rural College",
+    "country": "United Kingdom",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16486,6 +17488,7 @@
   },
   {
     "name": "Sultan Idris Education University",
+    "country": "Malaysia",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16497,6 +17500,7 @@
   },
   {
     "name": "�buda University",
+    "country": "Hungary",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16508,6 +17512,7 @@
   },
   {
     "name": "Alborz University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16519,6 +17524,7 @@
   },
   {
     "name": "Baqiyatallah University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16530,6 +17536,7 @@
   },
   {
     "name": "Golestan University",
+    "country": "Iran",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16541,6 +17548,7 @@
   },
   {
     "name": "Innopolis University",
+    "country": "Russia",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16552,6 +17560,7 @@
   },
   {
     "name": "Sukkur IBA University",
+    "country": "Pakistan",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16563,6 +17572,7 @@
   },
   {
     "name": "Capital University of Science and Technology",
+    "country": "Pakistan",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16574,6 +17584,7 @@
   },
   {
     "name": "Chitkara University",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16585,6 +17596,7 @@
   },
   {
     "name": "KIIT University",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16596,6 +17608,7 @@
   },
   {
     "name": "Lovely Professional University",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16607,6 +17620,7 @@
   },
   {
     "name": "Majmaah University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16618,6 +17632,7 @@
   },
   {
     "name": "University of Malakand",
+    "country": "Pakistan",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16629,6 +17644,7 @@
   },
   {
     "name": "Malaviya National Institute of Technology",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16640,6 +17656,7 @@
   },
   {
     "name": "International Institute of Information Technology Hyderabad",
+    "country": "India",
     "aggregatedScore": 158.859375,
     "originalRankings": {
       "the": {
@@ -16651,6 +17668,7 @@
   },
   {
     "name": "Palacky University",
+    "country": "Czech Republic",
     "aggregatedScore": 153.52499999999998,
     "originalRankings": {
       "qs": {
@@ -16665,6 +17683,7 @@
   },
   {
     "name": "Toulouse 1 University Capitole",
+    "country": "France",
     "aggregatedScore": 153.52499999999998,
     "originalRankings": {
       "qs": {
@@ -16679,6 +17698,7 @@
   },
   {
     "name": "China University of Mining Technology - Beijing",
+    "country": "China",
     "aggregatedScore": 147.89999999999998,
     "originalRankings": {
       "qs": {
@@ -16693,6 +17713,7 @@
   },
   {
     "name": "University of Rostock",
+    "country": "Germany",
     "aggregatedScore": 144.14999999999998,
     "originalRankings": {
       "qs": {
@@ -16707,6 +17728,7 @@
   },
   {
     "name": "University of Perugia",
+    "country": "Italy",
     "aggregatedScore": 144.14999999999998,
     "originalRankings": {
       "qs": {
@@ -16721,6 +17743,7 @@
   },
   {
     "name": "University of Alabama at Birmingham",
+    "country": "United States",
     "aggregatedScore": 144.14999999999998,
     "originalRankings": {
       "qs": {
@@ -16735,6 +17758,7 @@
   },
   {
     "name": "Brno University of Technology",
+    "country": "Czech Republic",
     "aggregatedScore": 142.27499999999998,
     "originalRankings": {
       "qs": {
@@ -16749,6 +17773,7 @@
   },
   {
     "name": "University of Concepci�n",
+    "country": "Chile",
     "aggregatedScore": 138.52499999999998,
     "originalRankings": {
       "qs": {
@@ -16763,6 +17788,7 @@
   },
   {
     "name": "Singapore University of Technology & Design",
+    "country": "Singapore",
     "aggregatedScore": 136.83749999999998,
     "originalRankings": {
       "qs": {
@@ -16777,6 +17803,7 @@
   },
   {
     "name": "Tokyo University of Science",
+    "country": "Japan",
     "aggregatedScore": 134.77499999999998,
     "originalRankings": {
       "qs": {
@@ -16791,6 +17818,7 @@
   },
   {
     "name": "Indian Institute of Technology - Bombay",
+    "country": "India",
     "aggregatedScore": 133.09375,
     "originalRankings": {
       "qs": {
@@ -16802,6 +17830,7 @@
   },
   {
     "name": "Addis Ababa University",
+    "country": "Ethiopia",
     "aggregatedScore": 131.02499999999998,
     "originalRankings": {
       "qs": {
@@ -16816,6 +17845,7 @@
   },
   {
     "name": "Chiba University",
+    "country": "Japan",
     "aggregatedScore": 131.02499999999998,
     "originalRankings": {
       "qs": {
@@ -16830,6 +17860,7 @@
   },
   {
     "name": "Kermanshah University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16841,6 +17872,7 @@
   },
   {
     "name": "Lorestan University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16852,6 +17884,7 @@
   },
   {
     "name": "Pmas Arid Agricultural University of Rawalpindi",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16863,6 +17896,7 @@
   },
   {
     "name": "University of Leoben",
+    "country": "Austria",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16874,6 +17908,7 @@
   },
   {
     "name": "Daffodil International University",
+    "country": "Bangladesh",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16885,6 +17920,7 @@
   },
   {
     "name": "Jahangirnagar University",
+    "country": "Bangladesh",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16896,6 +17932,7 @@
   },
   {
     "name": "University of Ontario Institute of Technology",
+    "country": "Canada",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16907,6 +17944,7 @@
   },
   {
     "name": "Wilfrid Laurier University",
+    "country": "Canada",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16918,6 +17956,7 @@
   },
   {
     "name": "Zhejiang Gongshang University",
+    "country": "China",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16929,6 +17968,7 @@
   },
   {
     "name": "University Pablo de Olavide",
+    "country": "Spain",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16940,6 +17980,7 @@
   },
   {
     "name": "University of the South Pacific",
+    "country": "Fiji",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16951,6 +17992,7 @@
   },
   {
     "name": "Arts et M�tiers",
+    "country": "France",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16962,6 +18004,7 @@
   },
   {
     "name": "National Veterinary School of Alfort",
+    "country": "France",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16973,6 +18016,7 @@
   },
   {
     "name": "University of Western Brittany",
+    "country": "France",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16984,6 +18028,7 @@
   },
   {
     "name": "University of Cape Coast",
+    "country": "Ghana",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -16995,6 +18040,7 @@
   },
   {
     "name": "Alagappa University",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17006,6 +18052,7 @@
   },
   {
     "name": "Bharathiar University",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17017,6 +18064,7 @@
   },
   {
     "name": "Jamia Hamdard University",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17028,6 +18076,7 @@
   },
   {
     "name": "Jawaharlal Nehru Technological University Anantapur",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17039,6 +18088,7 @@
   },
   {
     "name": "Arak University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17050,6 +18100,7 @@
   },
   {
     "name": "Birjand University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17061,6 +18112,7 @@
   },
   {
     "name": "Guilan University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17072,6 +18124,7 @@
   },
   {
     "name": "Isfahan University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17083,6 +18136,7 @@
   },
   {
     "name": "K.N.Toosi University of Technology",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17094,6 +18148,7 @@
   },
   {
     "name": "Kashan University",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17105,6 +18160,7 @@
   },
   {
     "name": "Mashhad University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17116,6 +18172,7 @@
   },
   {
     "name": "Shiraz University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17127,6 +18184,7 @@
   },
   {
     "name": "Urmia University",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17138,6 +18196,7 @@
   },
   {
     "name": "Zahedan University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17149,6 +18208,7 @@
   },
   {
     "name": "Reykjav�k University",
+    "country": "Iceland",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17160,6 +18220,7 @@
   },
   {
     "name": "University of Camerino",
+    "country": "Italy",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17171,6 +18232,7 @@
   },
   {
     "name": "University of Foggia",
+    "country": "Italy",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17182,6 +18244,7 @@
   },
   {
     "name": "University of Salento",
+    "country": "Italy",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17193,6 +18256,7 @@
   },
   {
     "name": "University of Sannio",
+    "country": "Italy",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17204,6 +18268,7 @@
   },
   {
     "name": "Al al-Bayt University",
+    "country": "Jordan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17215,6 +18280,7 @@
   },
   {
     "name": "Tokyo Medical University",
+    "country": "Japan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17226,6 +18292,7 @@
   },
   {
     "name": "Wakayama Medical University",
+    "country": "Japan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17237,6 +18304,7 @@
   },
   {
     "name": "Seoul University",
+    "country": "South Korea",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17248,6 +18316,7 @@
   },
   {
     "name": "Covenant University",
+    "country": "Nigeria",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17259,6 +18328,7 @@
   },
   {
     "name": "Islamia University Bahawalpur",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17270,6 +18340,7 @@
   },
   {
     "name": "University of Central Punjab",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17281,6 +18352,7 @@
   },
   {
     "name": "University of Engineering and Technology Peshawar",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17292,6 +18364,7 @@
   },
   {
     "name": "University of Gujrat",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17303,6 +18376,7 @@
   },
   {
     "name": "University of Management and Technology",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17314,6 +18388,7 @@
   },
   {
     "name": "University of Veterinary and Animal Sciences",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17325,6 +18400,7 @@
   },
   {
     "name": "Medical University of Lodz",
+    "country": "Poland",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17336,6 +18412,7 @@
   },
   {
     "name": "King Saud bin Abdulaziz University for Health Sciences",
+    "country": "Saudi Arabia",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17347,6 +18424,7 @@
   },
   {
     "name": "Bahcesehir University",
+    "country": "Turkey",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17358,6 +18436,7 @@
   },
   {
     "name": "Kadir Has University",
+    "country": "Turkey",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17369,6 +18448,7 @@
   },
   {
     "name": "Yuan Ze University",
+    "country": "Taiwan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17380,6 +18460,7 @@
   },
   {
     "name": "Sumy State University",
+    "country": "Ukraine",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17391,6 +18472,7 @@
   },
   {
     "name": "Glasgow Caledonian University",
+    "country": "United Kingdom",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17402,6 +18484,7 @@
   },
   {
     "name": "Roehampton University of Surrey",
+    "country": "United Kingdom",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17413,6 +18496,7 @@
   },
   {
     "name": "Sheffield Hallam University",
+    "country": "United Kingdom",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17424,6 +18508,7 @@
   },
   {
     "name": "University of Teesside",
+    "country": "United Kingdom",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17435,6 +18520,7 @@
   },
   {
     "name": "University of Wolverhampton",
+    "country": "United Kingdom",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17446,6 +18532,7 @@
   },
   {
     "name": "Hanoi Medical University",
+    "country": "Viet Nam",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17457,6 +18544,7 @@
   },
   {
     "name": "Florida Institute of Technology",
+    "country": "United States",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17468,6 +18556,7 @@
   },
   {
     "name": "Northern Illinois University",
+    "country": "United States",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17479,6 +18568,7 @@
   },
   {
     "name": "Southern Illinois University at Carbondale",
+    "country": "United States",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17490,6 +18580,7 @@
   },
   {
     "name": "New Mexico State University",
+    "country": "United States",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17501,6 +18592,7 @@
   },
   {
     "name": "Portland State University",
+    "country": "United States",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17512,6 +18604,7 @@
   },
   {
     "name": "University of Memphis",
+    "country": "United States",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17523,6 +18616,7 @@
   },
   {
     "name": "Gabriele D'Annunzio University",
+    "country": "Italy",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17534,6 +18628,7 @@
   },
   {
     "name": "Leeds Beckett University",
+    "country": "United Kingdom",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17545,6 +18640,7 @@
   },
   {
     "name": "National Institute of Technology Rourkela",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17556,6 +18652,7 @@
   },
   {
     "name": "Institute of Chemical Technology",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17567,6 +18664,7 @@
   },
   {
     "name": "Indian Institute of Technology - Ropar",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17578,6 +18676,7 @@
   },
   {
     "name": "Indian Institute of Technology Gandhinagar",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17589,6 +18688,7 @@
   },
   {
     "name": "Imam Khomeini International University",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17600,6 +18700,7 @@
   },
   {
     "name": "Birmingham City University",
+    "country": "United Kingdom",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17611,6 +18712,7 @@
   },
   {
     "name": "Bucharest University of Economic Studies",
+    "country": "Romania",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17622,6 +18724,7 @@
   },
   {
     "name": "International Islamic University Islamabad",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17633,6 +18736,7 @@
   },
   {
     "name": "JSS Academy of Higher Education and Research",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17644,6 +18748,7 @@
   },
   {
     "name": "Delhi Technological University",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17655,6 +18760,7 @@
   },
   {
     "name": "National Institute of Technology Silchar",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17666,6 +18772,7 @@
   },
   {
     "name": "Ozyegin University",
+    "country": "Turkey",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17677,6 +18784,7 @@
   },
   {
     "name": "Universitat Internacional de Catalunya",
+    "country": "Spain",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17688,6 +18796,7 @@
   },
   {
     "name": "University of Tabuk",
+    "country": "Saudi Arabia",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17699,6 +18808,7 @@
   },
   {
     "name": "Bangabandhu Sheikh Mujibur Rahman Agricultural University",
+    "country": "Bangladesh",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17710,6 +18820,7 @@
   },
   {
     "name": "European University Cyprus",
+    "country": "Cyprus",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17721,6 +18832,7 @@
   },
   {
     "name": "Jashore University of Science and Technology",
+    "country": "Bangladesh",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17732,6 +18844,7 @@
   },
   {
     "name": "Khwaja Fareed University of Engineering and Information Technology",
+    "country": "Pakistan",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17743,6 +18856,7 @@
   },
   {
     "name": "University of Nova Gorica",
+    "country": "Slovenia",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17754,6 +18868,7 @@
   },
   {
     "name": "Carol Davila University of Medicine and Pharmacy",
+    "country": "Romania",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17765,6 +18880,7 @@
   },
   {
     "name": "Jaypee University of Information Technology",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17776,6 +18892,7 @@
   },
   {
     "name": "Kalasalingam Academy of Research and Education",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17787,6 +18904,7 @@
   },
   {
     "name": "KL University",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17798,6 +18916,7 @@
   },
   {
     "name": "Lithuanian University of Health Sciences",
+    "country": "Lithuania",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17809,6 +18928,7 @@
   },
   {
     "name": "Najran University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17820,6 +18940,7 @@
   },
   {
     "name": "University of Namur",
+    "country": "Belgium",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17831,6 +18952,7 @@
   },
   {
     "name": "Reichman University",
+    "country": "Israel",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17842,6 +18964,7 @@
   },
   {
     "name": "Shahrekord University of Medical Sciences",
+    "country": "Iran",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17853,6 +18976,7 @@
   },
   {
     "name": "Shri Mata Vaishno Devi University",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17864,6 +18988,7 @@
   },
   {
     "name": "Siksha O Anusandhan",
+    "country": "India",
     "aggregatedScore": 127.609375,
     "originalRankings": {
       "the": {
@@ -17875,6 +19000,7 @@
   },
   {
     "name": "Al-Farabi Kazakh National University",
+    "country": "Kazakhstan",
     "aggregatedScore": 126.0625,
     "originalRankings": {
       "qs": {
@@ -17886,6 +19012,7 @@
   },
   {
     "name": "University of Alicante",
+    "country": "Spain",
     "aggregatedScore": 125.39999999999999,
     "originalRankings": {
       "qs": {
@@ -17900,6 +19027,7 @@
   },
   {
     "name": "National Polytechnic Institute",
+    "country": "Mexico",
     "aggregatedScore": 125.39999999999999,
     "originalRankings": {
       "qs": {
@@ -17914,6 +19042,7 @@
   },
   {
     "name": "Nanjing University of Posts and Telecommunications",
+    "country": "China",
     "aggregatedScore": 125.39999999999999,
     "originalRankings": {
       "qs": {
@@ -17928,6 +19057,7 @@
   },
   {
     "name": "University of Murcia",
+    "country": "Spain",
     "aggregatedScore": 125.39999999999999,
     "originalRankings": {
       "qs": {
@@ -17942,6 +19072,7 @@
   },
   {
     "name": "Beijing Jiaotong University",
+    "country": "China",
     "aggregatedScore": 125.39999999999999,
     "originalRankings": {
       "qs": {
@@ -17956,6 +19087,7 @@
   },
   {
     "name": "Osaka Metropolitan University",
+    "country": "Japan",
     "aggregatedScore": 125.39999999999999,
     "originalRankings": {
       "qs": {
@@ -17970,6 +19102,7 @@
   },
   {
     "name": "University of Los Andes",
+    "country": "Colombia",
     "aggregatedScore": 123.5625,
     "originalRankings": {
       "qs": {
@@ -17981,6 +19114,7 @@
   },
   {
     "name": "Hamad Bin Khalifa University",
+    "country": "Qatar",
     "aggregatedScore": 122.9375,
     "originalRankings": {
       "qs": {
@@ -17992,6 +19126,7 @@
   },
   {
     "name": "Warsaw University of Technology",
+    "country": "Poland",
     "aggregatedScore": 120.52499999999999,
     "originalRankings": {
       "qs": {
@@ -18006,6 +19141,7 @@
   },
   {
     "name": "University of Bras�lia",
+    "country": "Brazil",
     "aggregatedScore": 116.02499999999999,
     "originalRankings": {
       "qs": {
@@ -18020,6 +19156,7 @@
   },
   {
     "name": "University of Sherbrooke",
+    "country": "Canada",
     "aggregatedScore": 116.02499999999999,
     "originalRankings": {
       "qs": {
@@ -18034,6 +19171,7 @@
   },
   {
     "name": "Gadjah Mada University",
+    "country": "Indonesia",
     "aggregatedScore": 114.1875,
     "originalRankings": {
       "qs": {
@@ -18045,6 +19183,7 @@
   },
   {
     "name": "National Chung Hsing University - Taipei",
+    "country": "Taiwan",
     "aggregatedScore": 114.14999999999999,
     "originalRankings": {
       "qs": {
@@ -18059,6 +19198,7 @@
   },
   {
     "name": "Taylor's University",
+    "country": "Malaysia",
     "aggregatedScore": 112.3125,
     "originalRankings": {
       "qs": {
@@ -18070,6 +19210,7 @@
   },
   {
     "name": "Institute of Technology Bandung",
+    "country": "Indonesia",
     "aggregatedScore": 111.53125,
     "originalRankings": {
       "qs": {
@@ -18081,6 +19222,7 @@
   },
   {
     "name": "Federal University of Santa Catarina",
+    "country": "Brazil",
     "aggregatedScore": 110.39999999999999,
     "originalRankings": {
       "qs": {
@@ -18095,6 +19237,7 @@
   },
   {
     "name": "UCSI University",
+    "country": "Malaysia",
     "aggregatedScore": 110.125,
     "originalRankings": {
       "qs": {
@@ -18106,6 +19249,7 @@
   },
   {
     "name": "Dongguk University",
+    "country": "South Korea",
     "aggregatedScore": 106.64999999999999,
     "originalRankings": {
       "qs": {
@@ -18120,6 +19264,7 @@
   },
   {
     "name": "Airlangga University",
+    "country": "Indonesia",
     "aggregatedScore": 103.40625,
     "originalRankings": {
       "qs": {
@@ -18131,6 +19276,7 @@
   },
   {
     "name": "Budapest University of Technology and Economics",
+    "country": "Hungary",
     "aggregatedScore": 102.89999999999999,
     "originalRankings": {
       "qs": {
@@ -18145,6 +19291,7 @@
   },
   {
     "name": "L.N. Gumilyov Eurasian National University",
+    "country": "Kazakhstan",
     "aggregatedScore": 101.375,
     "originalRankings": {
       "qs": {
@@ -18156,6 +19303,7 @@
   },
   {
     "name": "National Central University",
+    "country": "Taiwan",
     "aggregatedScore": 99.14999999999999,
     "originalRankings": {
       "qs": {
@@ -18170,6 +19318,7 @@
   },
   {
     "name": "University of the Philippines Manila",
+    "country": "Philippines",
     "aggregatedScore": 99.03125,
     "originalRankings": {
       "qs": {
@@ -18181,6 +19330,7 @@
   },
   {
     "name": "Chungnam National University",
+    "country": "South Korea",
     "aggregatedScore": 97.27499999999999,
     "originalRankings": {
       "qs": {
@@ -18195,6 +19345,7 @@
   },
   {
     "name": "Pontifical Catholic University of Per�",
+    "country": "Peru",
     "aggregatedScore": 95.4375,
     "originalRankings": {
       "qs": {
@@ -18206,6 +19357,7 @@
   },
   {
     "name": "Comenius University in Bratislava",
+    "country": "Slovakia",
     "aggregatedScore": 95.39999999999999,
     "originalRankings": {
       "qs": {
@@ -18220,6 +19372,7 @@
   },
   {
     "name": "Pontificia Universidad Javeriana",
+    "country": "Colombia",
     "aggregatedScore": 92.625,
     "originalRankings": {
       "qs": {
@@ -18231,6 +19384,7 @@
   },
   {
     "name": "Technical University of Bergakademie Freiberg",
+    "country": "Germany",
     "aggregatedScore": 92.15625,
     "originalRankings": {
       "qs": {
@@ -18242,6 +19396,7 @@
   },
   {
     "name": "Belarusian State University",
+    "country": "Belarus",
     "aggregatedScore": 91.0625,
     "originalRankings": {
       "qs": {
@@ -18253,6 +19408,7 @@
   },
   {
     "name": "Satbayev Kazakh National Technical University",
+    "country": "Kazakhstan",
     "aggregatedScore": 88.25,
     "originalRankings": {
       "qs": {
@@ -18264,6 +19420,7 @@
   },
   {
     "name": "Taras Shevchenko National University of Kyiv",
+    "country": "Ukraine",
     "aggregatedScore": 87.89999999999999,
     "originalRankings": {
       "qs": {
@@ -18278,6 +19435,7 @@
   },
   {
     "name": "Ankara University",
+    "country": "Turkey",
     "aggregatedScore": 87.89999999999999,
     "originalRankings": {
       "qs": {
@@ -18292,6 +19450,7 @@
   },
   {
     "name": "Gda�sk University of Technology",
+    "country": "Poland",
     "aggregatedScore": 87.89999999999999,
     "originalRankings": {
       "qs": {
@@ -18306,6 +19465,7 @@
   },
   {
     "name": "National Taipei University of Technology",
+    "country": "Taiwan",
     "aggregatedScore": 85.125,
     "originalRankings": {
       "qs": {
@@ -18317,6 +19477,7 @@
   },
   {
     "name": "Bogor Agricultural University (IPB University)",
+    "country": "Indonesia",
     "aggregatedScore": 84.96875,
     "originalRankings": {
       "qs": {
@@ -18328,6 +19489,7 @@
   },
   {
     "name": "IE University",
+    "country": "Spain",
     "aggregatedScore": 83.5625,
     "originalRankings": {
       "qs": {
@@ -18339,6 +19501,7 @@
   },
   {
     "name": "University of Santiago de Chile",
+    "country": "Chile",
     "aggregatedScore": 79.5,
     "originalRankings": {
       "qs": {
@@ -18350,6 +19513,7 @@
   },
   {
     "name": "University of Calcutta",
+    "country": "India",
     "aggregatedScore": 78.52499999999999,
     "originalRankings": {
       "qs": {
@@ -18364,6 +19528,7 @@
   },
   {
     "name": "Nagasaki University",
+    "country": "Japan",
     "aggregatedScore": 78.52499999999999,
     "originalRankings": {
       "qs": {
@@ -18378,6 +19543,7 @@
   },
   {
     "name": "Clemson University",
+    "country": "United States",
     "aggregatedScore": 78.52499999999999,
     "originalRankings": {
       "qs": {
@@ -18392,6 +19558,7 @@
   },
   {
     "name": "University of Patras",
+    "country": "Greece",
     "aggregatedScore": 76.64999999999999,
     "originalRankings": {
       "qs": {
@@ -18406,6 +19573,7 @@
   },
   {
     "name": "Adam Mickiewicz University in Poznan",
+    "country": "Poland",
     "aggregatedScore": 76.64999999999999,
     "originalRankings": {
       "qs": {
@@ -18420,6 +19588,7 @@
   },
   {
     "name": "Pontifical Catholic University Argentina",
+    "country": "Argentina",
     "aggregatedScore": 76.375,
     "originalRankings": {
       "qs": {
@@ -18431,6 +19600,7 @@
   },
   {
     "name": "American University of Ras al Khaimah",
+    "country": "United Arab Emirates",
     "aggregatedScore": 75.75,
     "originalRankings": {
       "qs": {
@@ -18442,6 +19612,7 @@
   },
   {
     "name": "University of Costa Rica",
+    "country": "Costa Rica",
     "aggregatedScore": 73.875,
     "originalRankings": {
       "qs": {
@@ -18453,6 +19624,7 @@
   },
   {
     "name": "Ateneo de Manila University",
+    "country": "Philippines",
     "aggregatedScore": 70.90625,
     "originalRankings": {
       "qs": {
@@ -18464,6 +19636,7 @@
   },
   {
     "name": "INTI International University",
+    "country": "Malaysia",
     "aggregatedScore": 70.90625,
     "originalRankings": {
       "qs": {
@@ -18475,6 +19648,7 @@
   },
   {
     "name": "Canadian University Dubai",
+    "country": "United Arab Emirates",
     "aggregatedScore": 69.8125,
     "originalRankings": {
       "qs": {
@@ -18486,6 +19660,7 @@
   },
   {
     "name": "Austral University",
+    "country": "Argentina",
     "aggregatedScore": 69.65625,
     "originalRankings": {
       "qs": {
@@ -18497,6 +19672,7 @@
   },
   {
     "name": "National University de C�rdoba",
+    "country": "Argentina",
     "aggregatedScore": 69.14999999999999,
     "originalRankings": {
       "qs": {
@@ -18511,6 +19687,7 @@
   },
   {
     "name": "Kanazawa University",
+    "country": "Japan",
     "aggregatedScore": 69.14999999999999,
     "originalRankings": {
       "qs": {
@@ -18525,6 +19702,7 @@
   },
   {
     "name": "Indian Institute of Technology (BHU) Varanasi",
+    "country": "India",
     "aggregatedScore": 68.5625,
     "originalRankings": {
       "qs": {
@@ -18536,6 +19714,7 @@
   },
   {
     "name": "National University de La Plata",
+    "country": "Argentina",
     "aggregatedScore": 68.09375,
     "originalRankings": {
       "qs": {
@@ -18547,6 +19726,7 @@
   },
   {
     "name": "Hitotsubashi University",
+    "country": "Japan",
     "aggregatedScore": 67.3125,
     "originalRankings": {
       "qs": {
@@ -18558,6 +19738,7 @@
   },
   {
     "name": "Applied Science University Bahrain",
+    "country": "Bahrain",
     "aggregatedScore": 67.3125,
     "originalRankings": {
       "qs": {
@@ -18569,6 +19750,7 @@
   },
   {
     "name": "University Pontificia Comillas",
+    "country": "Spain",
     "aggregatedScore": 66.53125,
     "originalRankings": {
       "qs": {
@@ -18580,6 +19762,7 @@
   },
   {
     "name": "University of Dhaka",
+    "country": "Bangladesh",
     "aggregatedScore": 64.96875,
     "originalRankings": {
       "qs": {
@@ -18591,6 +19774,7 @@
   },
   {
     "name": "Lebanese University Beirut",
+    "country": "Lebanon",
     "aggregatedScore": 62.93749999999999,
     "originalRankings": {
       "qs": {
@@ -18602,6 +19786,7 @@
   },
   {
     "name": "Moscow State Institute of International Relations",
+    "country": "Russia",
     "aggregatedScore": 62.93749999999999,
     "originalRankings": {
       "qs": {
@@ -18613,6 +19798,7 @@
   },
   {
     "name": "University of Chemistry and Technology - Prague",
+    "country": "Czech Republic",
     "aggregatedScore": 62.46874999999999,
     "originalRankings": {
       "qs": {
@@ -18624,6 +19810,7 @@
   },
   {
     "name": "University of California - San Francisco",
+    "country": "United States",
     "aggregatedScore": 61.953125,
     "originalRankings": {
       "arwu": {
@@ -18635,6 +19822,7 @@
   },
   {
     "name": "University Adolfo Ib��ez",
+    "country": "Chile",
     "aggregatedScore": 61.53124999999999,
     "originalRankings": {
       "qs": {
@@ -18646,6 +19834,7 @@
   },
   {
     "name": "Singapore Management University",
+    "country": "Singapore",
     "aggregatedScore": 60.12499999999999,
     "originalRankings": {
       "qs": {
@@ -18657,6 +19846,7 @@
   },
   {
     "name": "Sepuluh Nopember Institute of Technology",
+    "country": "Indonesia",
     "aggregatedScore": 60.12499999999999,
     "originalRankings": {
       "qs": {
@@ -18668,6 +19858,7 @@
   },
   {
     "name": "University of Technology - Mara",
+    "country": "Malaysia",
     "aggregatedScore": 59.81249999999999,
     "originalRankings": {
       "qs": {
@@ -18679,6 +19870,7 @@
   },
   {
     "name": "University of Valladolid",
+    "country": "Spain",
     "aggregatedScore": 59.77499999999999,
     "originalRankings": {
       "qs": {
@@ -18693,6 +19885,7 @@
   },
   {
     "name": "University of Ghana",
+    "country": "Ghana",
     "aggregatedScore": 59.77499999999999,
     "originalRankings": {
       "qs": {
@@ -18707,6 +19900,7 @@
   },
   {
     "name": "Tokyo University of Agriculture and Technology",
+    "country": "Japan",
     "aggregatedScore": 59.77499999999999,
     "originalRankings": {
       "qs": {
@@ -18721,6 +19915,7 @@
   },
   {
     "name": "SRM Institute Of Science and Technology ( Deemed University)",
+    "country": "Poland",
     "aggregatedScore": 59.77499999999999,
     "originalRankings": {
       "qs": {
@@ -18735,6 +19930,7 @@
   },
   {
     "name": "University of South Africa",
+    "country": "South Africa",
     "aggregatedScore": 59.77499999999999,
     "originalRankings": {
       "qs": {
@@ -18749,6 +19945,7 @@
   },
   {
     "name": "Padjadjaran University",
+    "country": "Indonesia",
     "aggregatedScore": 58.40624999999999,
     "originalRankings": {
       "qs": {
@@ -18760,6 +19957,7 @@
   },
   {
     "name": "Thammasat University",
+    "country": "Thailand",
     "aggregatedScore": 58.40624999999999,
     "originalRankings": {
       "qs": {
@@ -18771,6 +19969,7 @@
   },
   {
     "name": "National Chengchi University",
+    "country": "Taiwan",
     "aggregatedScore": 57.62499999999999,
     "originalRankings": {
       "qs": {
@@ -18782,6 +19981,7 @@
   },
   {
     "name": "University of Texas Southwestern Medical Center at Dallas",
+    "country": "United States",
     "aggregatedScore": 56.640625,
     "originalRankings": {
       "arwu": {
@@ -18793,6 +19993,7 @@
   },
   {
     "name": "Asia Pacific University of Technology and Innovation",
+    "country": "Malaysia",
     "aggregatedScore": 56.06249999999999,
     "originalRankings": {
       "qs": {
@@ -18804,6 +20005,7 @@
   },
   {
     "name": "Universidad de Palermo",
+    "country": "Argentina",
     "aggregatedScore": 54.49999999999999,
     "originalRankings": {
       "qs": {
@@ -18815,6 +20017,7 @@
   },
   {
     "name": "American University in Dubai",
+    "country": "United Arab Emirates",
     "aggregatedScore": 54.49999999999999,
     "originalRankings": {
       "qs": {
@@ -18826,6 +20029,7 @@
   },
   {
     "name": "Auezov South Kazakhstan State University",
+    "country": "Kazakhstan",
     "aggregatedScore": 54.49999999999999,
     "originalRankings": {
       "qs": {
@@ -18837,6 +20041,7 @@
   },
   {
     "name": "Far Eastern Federal University",
+    "country": "Russia",
     "aggregatedScore": 52.93749999999999,
     "originalRankings": {
       "qs": {
@@ -18848,6 +20053,7 @@
   },
   {
     "name": "University of Texas MD Anderson Cancer Center",
+    "country": "United States",
     "aggregatedScore": 51.640625,
     "originalRankings": {
       "arwu": {
@@ -18859,6 +20065,7 @@
   },
   {
     "name": "Ritsumeikan University",
+    "country": "Japan",
     "aggregatedScore": 51.37499999999999,
     "originalRankings": {
       "qs": {
@@ -18870,6 +20077,7 @@
   },
   {
     "name": "De La Salle University",
+    "country": "Philippines",
     "aggregatedScore": 51.37499999999999,
     "originalRankings": {
       "qs": {
@@ -18881,6 +20089,7 @@
   },
   {
     "name": "Yokohama City University",
+    "country": "Japan",
     "aggregatedScore": 50.39999999999999,
     "originalRankings": {
       "qs": {
@@ -18895,6 +20104,7 @@
   },
   {
     "name": "Nicolaus Copernicus University",
+    "country": "Poland",
     "aggregatedScore": 50.39999999999999,
     "originalRankings": {
       "qs": {
@@ -18909,6 +20119,7 @@
   },
   {
     "name": "Hankuk University of Foreign Studies",
+    "country": "South Korea",
     "aggregatedScore": 49.81249999999999,
     "originalRankings": {
       "qs": {
@@ -18920,6 +20131,7 @@
   },
   {
     "name": "Mayo Medical School",
+    "country": "United States",
     "aggregatedScore": 49.296875,
     "originalRankings": {
       "arwu": {
@@ -18931,6 +20143,7 @@
   },
   {
     "name": "Sofia University",
+    "country": "Bulgaria",
     "aggregatedScore": 48.24999999999999,
     "originalRankings": {
       "qs": {
@@ -18942,6 +20155,7 @@
   },
   {
     "name": "International Islamic University Malaysia",
+    "country": "Malaysia",
     "aggregatedScore": 48.24999999999999,
     "originalRankings": {
       "qs": {
@@ -18953,6 +20167,7 @@
   },
   {
     "name": "University of the Republic",
+    "country": "Uruguay",
     "aggregatedScore": 48.24999999999999,
     "originalRankings": {
       "qs": {
@@ -18964,6 +20179,7 @@
   },
   {
     "name": "Kazakh National Pedagogical University",
+    "country": "Kazakhstan",
     "aggregatedScore": 46.68749999999999,
     "originalRankings": {
       "qs": {
@@ -18975,6 +20191,7 @@
   },
   {
     "name": "Kazakh National Agrarian University",
+    "country": "Kazakhstan",
     "aggregatedScore": 46.68749999999999,
     "originalRankings": {
       "qs": {
@@ -18986,6 +20203,7 @@
   },
   {
     "name": "University of Agriculture Faisalabad",
+    "country": "Pakistan",
     "aggregatedScore": 45.12499999999999,
     "originalRankings": {
       "qs": {
@@ -18997,6 +20215,7 @@
   },
   {
     "name": "Indian Institute of Technology - Hyderabad",
+    "country": "India",
     "aggregatedScore": 45.12499999999999,
     "originalRankings": {
       "qs": {
@@ -19008,6 +20227,7 @@
   },
   {
     "name": "University of Havana",
+    "country": "Cuba",
     "aggregatedScore": 43.56249999999999,
     "originalRankings": {
       "qs": {
@@ -19019,6 +20239,7 @@
   },
   {
     "name": "Panamerican University",
+    "country": "Mexico",
     "aggregatedScore": 43.56249999999999,
     "originalRankings": {
       "qs": {
@@ -19030,6 +20251,7 @@
   },
   {
     "name": "University Central de Venezuela",
+    "country": "Venezuela",
     "aggregatedScore": 43.56249999999999,
     "originalRankings": {
       "qs": {
@@ -19041,6 +20263,7 @@
   },
   {
     "name": "Pakistan Institute of Engineering and Applied Sciences",
+    "country": "Pakistan",
     "aggregatedScore": 43.56249999999999,
     "originalRankings": {
       "qs": {
@@ -19052,6 +20275,7 @@
   },
   {
     "name": "Chandigarh University",
+    "country": "India",
     "aggregatedScore": 43.56249999999999,
     "originalRankings": {
       "qs": {
@@ -19063,6 +20287,7 @@
   },
   {
     "name": "Kumamoto University",
+    "country": "Japan",
     "aggregatedScore": 41.02499999999999,
     "originalRankings": {
       "qs": {
@@ -19077,6 +20302,7 @@
   },
   {
     "name": "Hallym University",
+    "country": "South Korea",
     "aggregatedScore": 41.02499999999999,
     "originalRankings": {
       "qs": {
@@ -19091,6 +20317,7 @@
   },
   {
     "name": "Al Ahlia University",
+    "country": "Bahrain",
     "aggregatedScore": 40.43749999999999,
     "originalRankings": {
       "qs": {
@@ -19102,6 +20329,7 @@
   },
   {
     "name": "University of Franche-Comt�",
+    "country": "France",
     "aggregatedScore": 40.43749999999999,
     "originalRankings": {
       "qs": {
@@ -19113,6 +20341,7 @@
   },
   {
     "name": "Lingnan University",
+    "country": "Hong Kong",
     "aggregatedScore": 40.43749999999999,
     "originalRankings": {
       "qs": {
@@ -19124,6 +20353,7 @@
   },
   {
     "name": "University of Mumbai",
+    "country": "India",
     "aggregatedScore": 40.43749999999999,
     "originalRankings": {
       "qs": {
@@ -19135,6 +20365,7 @@
   },
   {
     "name": "Plekhanov Russian University of Economics",
+    "country": "Russia",
     "aggregatedScore": 40.43749999999999,
     "originalRankings": {
       "qs": {
@@ -19146,6 +20377,7 @@
   },
   {
     "name": "Saint Joseph University of Beirut",
+    "country": "Lebanon",
     "aggregatedScore": 40.43749999999999,
     "originalRankings": {
       "qs": {
@@ -19157,6 +20389,7 @@
   },
   {
     "name": "Diponegoro University",
+    "country": "Indonesia",
     "aggregatedScore": 38.87499999999999,
     "originalRankings": {
       "qs": {
@@ -19168,6 +20401,7 @@
   },
   {
     "name": "Jadavpur University",
+    "country": "India",
     "aggregatedScore": 38.87499999999999,
     "originalRankings": {
       "qs": {
@@ -19179,6 +20413,7 @@
   },
   {
     "name": "Riga Technical University",
+    "country": "Latvia",
     "aggregatedScore": 38.87499999999999,
     "originalRankings": {
       "qs": {
@@ -19190,6 +20425,7 @@
   },
   {
     "name": "Effat University",
+    "country": "Saudi Arabia",
     "aggregatedScore": 38.87499999999999,
     "originalRankings": {
       "qs": {
@@ -19201,6 +20437,7 @@
   },
   {
     "name": "Vytautas Magnus University",
+    "country": "Lithuania",
     "aggregatedScore": 35.74999999999999,
     "originalRankings": {
       "qs": {
@@ -19212,6 +20449,7 @@
   },
   {
     "name": "Altai State University",
+    "country": "Russia",
     "aggregatedScore": 35.74999999999999,
     "originalRankings": {
       "qs": {
@@ -19223,6 +20461,7 @@
   },
   {
     "name": "University of Montevideo",
+    "country": "Uruguay",
     "aggregatedScore": 35.74999999999999,
     "originalRankings": {
       "qs": {
@@ -19234,6 +20473,7 @@
   },
   {
     "name": "Catholic University Andres Bello",
+    "country": "Venezuela",
     "aggregatedScore": 35.74999999999999,
     "originalRankings": {
       "qs": {
@@ -19245,6 +20485,7 @@
   },
   {
     "name": "V.N. Karazin Kharkiv National University",
+    "country": "Ukraine",
     "aggregatedScore": 35.74999999999999,
     "originalRankings": {
       "qs": {
@@ -19256,6 +20497,7 @@
   },
   {
     "name": "Kaunas University of Technology",
+    "country": "Lithuania",
     "aggregatedScore": 34.18749999999999,
     "originalRankings": {
       "qs": {
@@ -19267,6 +20509,7 @@
   },
   {
     "name": "M�xico Autonomous Institute of Technology",
+    "country": "Mexico",
     "aggregatedScore": 34.18749999999999,
     "originalRankings": {
       "qs": {
@@ -19278,6 +20521,7 @@
   },
   {
     "name": "Nanchang University",
+    "country": "China",
     "aggregatedScore": 33.671875,
     "originalRankings": {
       "arwu": {
@@ -19289,6 +20533,7 @@
   },
   {
     "name": "University of Massachusetts Medical School",
+    "country": "United States",
     "aggregatedScore": 33.671875,
     "originalRankings": {
       "arwu": {
@@ -19300,6 +20545,7 @@
   },
   {
     "name": "Peking Union Medical College",
+    "country": "China",
     "aggregatedScore": 33.671875,
     "originalRankings": {
       "arwu": {
@@ -19311,6 +20557,7 @@
   },
   {
     "name": "Bangladesh University of Engineering and Technology (BUET)",
+    "country": "Bangladesh",
     "aggregatedScore": 32.62499999999999,
     "originalRankings": {
       "qs": {
@@ -19322,6 +20569,7 @@
   },
   {
     "name": "University of Rosario",
+    "country": "Colombia",
     "aggregatedScore": 31.062499999999993,
     "originalRankings": {
       "qs": {
@@ -19333,6 +20581,7 @@
   },
   {
     "name": "University of Pecs",
+    "country": "Hungary",
     "aggregatedScore": 31.062499999999993,
     "originalRankings": {
       "qs": {
@@ -19344,6 +20593,7 @@
   },
   {
     "name": "Holy Spirit University of Kaslik",
+    "country": "Lebanon",
     "aggregatedScore": 31.062499999999993,
     "originalRankings": {
       "qs": {
@@ -19355,6 +20605,7 @@
   },
   {
     "name": "The College of Mexico",
+    "country": "Mexico",
     "aggregatedScore": 31.062499999999993,
     "originalRankings": {
       "qs": {
@@ -19366,6 +20617,7 @@
   },
   {
     "name": "University of Latvia",
+    "country": "Latvia",
     "aggregatedScore": 29.499999999999993,
     "originalRankings": {
       "qs": {
@@ -19377,6 +20629,7 @@
   },
   {
     "name": "Babes-Bolyai University",
+    "country": "Romania",
     "aggregatedScore": 29.499999999999993,
     "originalRankings": {
       "qs": {
@@ -19388,6 +20641,7 @@
   },
   {
     "name": "Kasetsart University",
+    "country": "Thailand",
     "aggregatedScore": 29.499999999999993,
     "originalRankings": {
       "qs": {
@@ -19399,6 +20653,7 @@
   },
   {
     "name": "National University of Uzbekistan",
+    "country": "Uzbekistan",
     "aggregatedScore": 29.499999999999993,
     "originalRankings": {
       "qs": {
@@ -19410,6 +20665,7 @@
   },
   {
     "name": "The New School",
+    "country": "United States",
     "aggregatedScore": 29.499999999999993,
     "originalRankings": {
       "qs": {
@@ -19421,6 +20677,7 @@
   },
   {
     "name": "Zurich University of Applied Sciences",
+    "country": "Switzerland",
     "aggregatedScore": 29.499999999999993,
     "originalRankings": {
       "qs": {
@@ -19432,6 +20689,7 @@
   },
   {
     "name": "University of Antioqu�a",
+    "country": "Colombia",
     "aggregatedScore": 27.937499999999993,
     "originalRankings": {
       "qs": {
@@ -19443,6 +20701,7 @@
   },
   {
     "name": "Tbilisi State University",
+    "country": "Georgia",
     "aggregatedScore": 27.937499999999993,
     "originalRankings": {
       "qs": {
@@ -19454,6 +20713,7 @@
   },
   {
     "name": "I.M. Sechenov First Moscow State Medical University",
+    "country": "Russia",
     "aggregatedScore": 27.937499999999993,
     "originalRankings": {
       "qs": {
@@ -19465,6 +20725,7 @@
   },
   {
     "name": "Pontifical Catholic University of Valparaiso",
+    "country": "Chile",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19476,6 +20737,7 @@
   },
   {
     "name": "University San Francisco de Quito",
+    "country": "Ecuador",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19487,6 +20749,7 @@
   },
   {
     "name": "University of Hyderabad",
+    "country": "India",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19498,6 +20761,7 @@
   },
   {
     "name": "Kuwait University",
+    "country": "Kuwait",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19509,6 +20773,7 @@
   },
   {
     "name": "An�huac University",
+    "country": "Mexico",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19520,6 +20785,7 @@
   },
   {
     "name": "University of Tunku Abdul Rahman",
+    "country": "Malaysia",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19531,6 +20797,7 @@
   },
   {
     "name": "University of Bucharest",
+    "country": "Romania",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19542,6 +20809,7 @@
   },
   {
     "name": "National Technical University of Ukraine",
+    "country": "Ukraine",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19553,6 +20821,7 @@
   },
   {
     "name": "Ibero-American University",
+    "country": "Mexico",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19564,6 +20833,7 @@
   },
   {
     "name": "University of Brawijaya",
+    "country": "Indonesia",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19575,6 +20845,7 @@
   },
   {
     "name": "University of Baghdad",
+    "country": "Iraq",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19586,6 +20857,7 @@
   },
   {
     "name": "Belarusian National Technical University",
+    "country": "Belarus",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19597,6 +20869,7 @@
   },
   {
     "name": "Immanuel Kant Baltic Federal University",
+    "country": "Russia",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19608,6 +20881,7 @@
   },
   {
     "name": "Khoja Akhmet Yassawi International Kazakh-Turkish University",
+    "country": "Kazakhstan",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
       "qs": {
@@ -19619,6 +20893,7 @@
   },
   {
     "name": "Al-Quds University",
+    "country": "Palestine",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19630,6 +20905,7 @@
   },
   {
     "name": "Dubai University College",
+    "country": "United Arab Emirates",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19641,6 +20917,7 @@
   },
   {
     "name": "Mendel University of Agriculture and Forestry",
+    "country": "Czech Republic",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19652,6 +20929,7 @@
   },
   {
     "name": "Kyrgyz Russian Slavic University",
+    "country": "Kyrgyzstan",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19663,6 +20941,7 @@
   },
   {
     "name": "Gulf University for Science and Technology",
+    "country": "Kuwait",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19674,6 +20953,7 @@
   },
   {
     "name": "Karaganda State Technical University",
+    "country": "Kazakhstan",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19685,6 +20965,7 @@
   },
   {
     "name": "Vilnius Gediminas Technical University",
+    "country": "Lithuania",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19696,6 +20977,7 @@
   },
   {
     "name": "University of Santo Tomas",
+    "country": "Philippines",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19707,6 +20989,7 @@
   },
   {
     "name": "University of Gdansk",
+    "country": "Poland",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19718,6 +21001,7 @@
   },
   {
     "name": "University of Wroclaw",
+    "country": "Poland",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19729,6 +21013,7 @@
   },
   {
     "name": "Pavol Jozef Safarik University in Kosice",
+    "country": "Slovakia",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19740,6 +21025,7 @@
   },
   {
     "name": "University ORT Uruguay",
+    "country": "Uruguay",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19751,6 +21037,7 @@
   },
   {
     "name": "Clarkson University",
+    "country": "United States",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19762,6 +21049,7 @@
   },
   {
     "name": "Swarthmore College",
+    "country": "United States",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19773,6 +21061,7 @@
   },
   {
     "name": "Viet Nam National University - Hanoi",
+    "country": "Viet Nam",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19784,6 +21073,7 @@
   },
   {
     "name": "Technological University Dublin",
+    "country": "Ireland",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19795,6 +21085,7 @@
   },
   {
     "name": "Poznan University of Life Sciences",
+    "country": "Poland",
     "aggregatedScore": 18.562499999999993,
     "originalRankings": {
       "qs": {
@@ -19806,6 +21097,7 @@
   },
   {
     "name": "Anhui University",
+    "country": "China",
     "aggregatedScore": 18.046875,
     "originalRankings": {
       "arwu": {
@@ -19817,6 +21109,7 @@
   },
   {
     "name": "Guangxi University",
+    "country": "China",
     "aggregatedScore": 18.046875,
     "originalRankings": {
       "arwu": {
@@ -19828,6 +21121,7 @@
   },
   {
     "name": "University of Shanghai for Science and Technology",
+    "country": "China",
     "aggregatedScore": 18.046875,
     "originalRankings": {
       "arwu": {
@@ -19839,6 +21133,7 @@
   },
   {
     "name": "Indiana University-Purdue University of Indianapolis",
+    "country": "United States",
     "aggregatedScore": 18.046875,
     "originalRankings": {
       "arwu": {
@@ -19850,6 +21145,7 @@
   },
   {
     "name": "Albert Einstein College of Medicine - Yeshiva University",
+    "country": "United States",
     "aggregatedScore": 18.046875,
     "originalRankings": {
       "arwu": {
@@ -19861,6 +21157,7 @@
   },
   {
     "name": "China University of Geosciences - Beijing",
+    "country": "China",
     "aggregatedScore": 18.046875,
     "originalRankings": {
       "arwu": {
@@ -19872,6 +21169,7 @@
   },
   {
     "name": "Yerevan State University",
+    "country": "Armenia",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19883,6 +21181,7 @@
   },
   {
     "name": "EAFIT University",
+    "country": "Colombia",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19894,6 +21193,7 @@
   },
   {
     "name": "University Externado de Colombia",
+    "country": "Colombia",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19905,6 +21205,7 @@
   },
   {
     "name": "University Marta Abreu of Las Villas",
+    "country": "Cuba",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19916,6 +21217,7 @@
   },
   {
     "name": "University Panth�on-Assas (Paris II)",
+    "country": "France",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19927,6 +21229,7 @@
   },
   {
     "name": "Georgian Technical University",
+    "country": "Georgia",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19938,6 +21241,7 @@
   },
   {
     "name": "German Jordanian University",
+    "country": "Jordan",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19949,6 +21253,7 @@
   },
   {
     "name": "Princess Sumaya University for Technology",
+    "country": "Jordan",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19960,6 +21265,7 @@
   },
   {
     "name": "Ritsumeikan Asia Pacific University",
+    "country": "Japan",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19971,6 +21277,7 @@
   },
   {
     "name": "University of Nairobi",
+    "country": "Kenya",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19982,6 +21289,7 @@
   },
   {
     "name": "Kyrgyz Turkish Manas University",
+    "country": "Kyrgyzstan",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -19993,6 +21301,7 @@
   },
   {
     "name": "Karaganda State Buketov University",
+    "country": "Kazakhstan",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20004,6 +21313,7 @@
   },
   {
     "name": "National University of San Marcos",
+    "country": "Peru",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20015,6 +21325,7 @@
   },
   {
     "name": "University of Peshawar",
+    "country": "Pakistan",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20026,6 +21337,7 @@
   },
   {
     "name": "University of Lodz",
+    "country": "Poland",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20037,6 +21349,7 @@
   },
   {
     "name": "Saratov State University",
+    "country": "Russia",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20048,6 +21361,7 @@
   },
   {
     "name": "University of Maribor",
+    "country": "Slovenia",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20059,6 +21373,7 @@
   },
   {
     "name": "Gazi University Ankara",
+    "country": "Turkey",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20070,6 +21385,7 @@
   },
   {
     "name": "Makerere University",
+    "country": "Uganda",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20081,6 +21397,7 @@
   },
   {
     "name": "University of East London",
+    "country": "United Kingdom",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20092,6 +21409,7 @@
   },
   {
     "name": "Catholic University of Uruguay",
+    "country": "Uruguay",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20103,6 +21421,7 @@
   },
   {
     "name": "Michigan Technological University",
+    "country": "United States",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20114,6 +21433,7 @@
   },
   {
     "name": "Wroclaw University of Science and Technology",
+    "country": "Poland",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20125,6 +21445,7 @@
   },
   {
     "name": "Viet Nam National University - Ho Chi Minh City",
+    "country": "Viet Nam",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20136,6 +21457,7 @@
   },
   {
     "name": "Pontifical Bolivarian University",
+    "country": "Colombia",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
       "qs": {
@@ -20147,6 +21469,7 @@
   },
   {
     "name": "D. Serikbayev East Kazakhstan State Technical University",
+    "country": "Kazakhstan",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20158,6 +21481,7 @@
   },
   {
     "name": "Financial University of Under the Government the Russian Federation",
+    "country": "Russia",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20169,6 +21493,7 @@
   },
   {
     "name": "Buenos Aires Institute of Technology",
+    "country": "Argentina",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20180,6 +21505,7 @@
   },
   {
     "name": "National University de Rosario",
+    "country": "Argentina",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20191,6 +21517,7 @@
   },
   {
     "name": "University Torcuato di Tella",
+    "country": "Argentina",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20202,6 +21529,7 @@
   },
   {
     "name": "University of San Andres",
+    "country": "Argentina",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20213,6 +21541,7 @@
   },
   {
     "name": "Baku State University",
+    "country": "Azerbaijan",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20224,6 +21553,7 @@
   },
   {
     "name": "University of Bahrain",
+    "country": "Bahrain",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20235,6 +21565,7 @@
   },
   {
     "name": "Federico Santa Mar�a Technical University",
+    "country": "Chile",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20246,6 +21577,7 @@
   },
   {
     "name": "University of the Andes - Chile",
+    "country": "Chile",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20257,6 +21589,7 @@
   },
   {
     "name": "University of La Sabana",
+    "country": "Colombia",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20268,6 +21601,7 @@
   },
   {
     "name": "University of South Bohemia",
+    "country": "Czech Republic",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20279,6 +21613,7 @@
   },
   {
     "name": "Pontifical Catholic University of Ecuador",
+    "country": "Ecuador",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20290,6 +21625,7 @@
   },
   {
     "name": "University of Le�n",
+    "country": "Spain",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20301,6 +21637,7 @@
   },
   {
     "name": "University Paris Nord (Paris XIII)",
+    "country": "France",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20312,6 +21649,7 @@
   },
   {
     "name": "Athens University of Economics and Business",
+    "country": "Greece",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20323,6 +21661,7 @@
   },
   {
     "name": "Bina Nusantara University",
+    "country": "Indonesia",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20334,6 +21673,7 @@
   },
   {
     "name": "Yarmouk University",
+    "country": "Jordan",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20345,6 +21685,7 @@
   },
   {
     "name": "Niigata University",
+    "country": "Japan",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20356,6 +21697,7 @@
   },
   {
     "name": "Sophia University",
+    "country": "Japan",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20367,6 +21709,7 @@
   },
   {
     "name": "University of Colombo",
+    "country": "Sri Lanka",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20378,6 +21721,7 @@
   },
   {
     "name": "Metropolitan Autonomous University",
+    "country": "Mexico",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20389,6 +21733,7 @@
   },
   {
     "name": "Khon Kaen University",
+    "country": "Thailand",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20400,6 +21745,7 @@
   },
   {
     "name": "Prince of Songkla University",
+    "country": "Thailand",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20411,6 +21757,7 @@
   },
   {
     "name": "Rhodes University",
+    "country": "South Africa",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20422,6 +21769,7 @@
   },
   {
     "name": "Southern Federal University",
+    "country": "Russia",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20433,6 +21781,7 @@
   },
   {
     "name": "Riga Stradins University",
+    "country": "Latvia",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20444,6 +21793,7 @@
   },
   {
     "name": "Indian Institute of Technology - Bhubaneswar",
+    "country": "India",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20455,6 +21805,7 @@
   },
   {
     "name": "Almaty Technological University",
+    "country": "Kazakhstan",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
       "qs": {
@@ -20466,6 +21817,7 @@
   },
   {
     "name": "Hainan University",
+    "country": "China",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20477,6 +21829,7 @@
   },
   {
     "name": "Hefei University of Technology",
+    "country": "China",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20488,6 +21841,7 @@
   },
   {
     "name": "Henan University",
+    "country": "China",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20499,6 +21853,7 @@
   },
   {
     "name": "National University of Defense Technology",
+    "country": "China",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20510,6 +21865,7 @@
   },
   {
     "name": "Ningbo University",
+    "country": "China",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20521,6 +21877,7 @@
   },
   {
     "name": "Yunnan University",
+    "country": "China",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20532,6 +21889,7 @@
   },
   {
     "name": "The Graduate Center - CUNY",
+    "country": "United States",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20543,6 +21901,7 @@
   },
   {
     "name": "University of Texas Medical Branch Galveston",
+    "country": "United States",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20554,6 +21913,7 @@
   },
   {
     "name": "Utah State University",
+    "country": "United States",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20565,6 +21925,7 @@
   },
   {
     "name": "Kunming University of Science and Technology",
+    "country": "China",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20576,6 +21937,7 @@
   },
   {
     "name": "Okinawa Institute of Science and Technology Graduate University",
+    "country": "Japan",
     "aggregatedScore": 2.421875,
     "originalRankings": {
       "arwu": {
@@ -20587,6 +21949,7 @@
   },
   {
     "name": "Hohai University Changzhou",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20598,6 +21961,7 @@
   },
   {
     "name": "Anhui Medical University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20609,6 +21973,7 @@
   },
   {
     "name": "Chongqing Medical University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20620,6 +21985,7 @@
   },
   {
     "name": "Fujian Medical University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20631,6 +21997,7 @@
   },
   {
     "name": "Guizhou University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20642,6 +22009,7 @@
   },
   {
     "name": "Nanjing University of Traditional Chinese Medicine",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20653,6 +22021,7 @@
   },
   {
     "name": "Shaanxi Normal University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20664,6 +22033,7 @@
   },
   {
     "name": "Shandong University of Science Technology",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20675,6 +22045,7 @@
   },
   {
     "name": "Tianjin Medical University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20686,6 +22057,7 @@
   },
   {
     "name": "Xi'an University of Technology",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20697,6 +22069,7 @@
   },
   {
     "name": "University of La Laguna",
+    "country": "Spain",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20708,6 +22081,7 @@
   },
   {
     "name": "University of Tromso",
+    "country": "Norway",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20719,6 +22093,7 @@
   },
   {
     "name": "San Diego State University",
+    "country": "United States",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20730,6 +22105,7 @@
   },
   {
     "name": "University of Maine - Orono",
+    "country": "United States",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20741,6 +22117,7 @@
   },
   {
     "name": "Medical University of South Carolina",
+    "country": "United States",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20752,6 +22129,7 @@
   },
   {
     "name": "University of North Texas",
+    "country": "United States",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20763,6 +22141,7 @@
   },
   {
     "name": "West Virginia University",
+    "country": "United States",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20774,6 +22153,7 @@
   },
   {
     "name": "Southwest University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20785,6 +22165,7 @@
   },
   {
     "name": "Zhejiang Science-Technology University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20796,6 +22177,7 @@
   },
   {
     "name": "Hangzhou Dianzi University",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20807,6 +22189,7 @@
   },
   {
     "name": "The Chinese University of Hong Kong - Shenzhen",
+    "country": "China",
     "aggregatedScore": -13.203125,
     "originalRankings": {
       "arwu": {
@@ -20818,6 +22201,7 @@
   },
   {
     "name": "Hebei University of Technology",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20829,6 +22213,7 @@
   },
   {
     "name": "Second Military Medical University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20840,6 +22225,7 @@
   },
   {
     "name": "Air Force Medical University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20851,6 +22237,7 @@
   },
   {
     "name": "Dalian Maritime University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20862,6 +22249,7 @@
   },
   {
     "name": "Fujian Normal University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20873,6 +22261,7 @@
   },
   {
     "name": "Henan Normal University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20884,6 +22273,7 @@
   },
   {
     "name": "Hunan Normal University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20895,6 +22285,7 @@
   },
   {
     "name": "Qingdao University of Science and Technology",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20906,6 +22297,7 @@
   },
   {
     "name": "Shandong Agricultural University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20917,6 +22309,7 @@
   },
   {
     "name": "Shanxi University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20928,6 +22321,7 @@
   },
   {
     "name": "Taiyuan University of Technology",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20939,6 +22333,7 @@
   },
   {
     "name": "University of Lubeck",
+    "country": "Germany",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20950,6 +22345,7 @@
   },
   {
     "name": "University of Bielefeld",
+    "country": "Germany",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20961,6 +22357,7 @@
   },
   {
     "name": "Tarbiat Modares University",
+    "country": "Iran",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20972,6 +22369,7 @@
   },
   {
     "name": "Shinshu University",
+    "country": "Japan",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20983,6 +22381,7 @@
   },
   {
     "name": "University of Louisville",
+    "country": "United States",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -20994,6 +22393,7 @@
   },
   {
     "name": "University of Nevada - Reno",
+    "country": "United States",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21005,6 +22405,7 @@
   },
   {
     "name": "University of New Hampshire",
+    "country": "United States",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21016,6 +22417,7 @@
   },
   {
     "name": "Brigham Young University",
+    "country": "United States",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21027,6 +22429,7 @@
   },
   {
     "name": "Medical College of Wisconsin",
+    "country": "United States",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21038,6 +22441,7 @@
   },
   {
     "name": "University of Natural Resources and Life Sciences",
+    "country": "Austria",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21049,6 +22453,7 @@
   },
   {
     "name": "Nantong University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21060,6 +22465,7 @@
   },
   {
     "name": "Yanshan University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21071,6 +22477,7 @@
   },
   {
     "name": "Fujian Agriculture and Forestry University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21082,6 +22489,7 @@
   },
   {
     "name": "Duke-NUS Medical School",
+    "country": "Singapore",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21093,6 +22501,7 @@
   },
   {
     "name": "Zhejiang Chinese Medical University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21104,6 +22513,7 @@
   },
   {
     "name": "Qilu University of Technology",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21115,6 +22525,7 @@
   },
   {
     "name": "Shandong First Medical University",
+    "country": "China",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21126,6 +22537,7 @@
   },
   {
     "name": "University of Health Sciences Turkey",
+    "country": "Turkey",
     "aggregatedScore": -28.828125,
     "originalRankings": {
       "arwu": {
@@ -21137,6 +22549,7 @@
   },
   {
     "name": "Federal University of Santa Maria",
+    "country": "Brazil",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21148,6 +22561,7 @@
   },
   {
     "name": "Federal University of Paran�",
+    "country": "Brazil",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21159,6 +22573,7 @@
   },
   {
     "name": "Beijing Forestry University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21170,6 +22585,7 @@
   },
   {
     "name": "China Medical University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21181,6 +22597,7 @@
   },
   {
     "name": "Chongqing University of Posts and Telecommunications",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21192,6 +22609,7 @@
   },
   {
     "name": "Harbin Medical University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21203,6 +22621,7 @@
   },
   {
     "name": "Hubei University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21214,6 +22633,7 @@
   },
   {
     "name": "Shantou University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21225,6 +22645,7 @@
   },
   {
     "name": "Xinjiang University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21236,6 +22657,7 @@
   },
   {
     "name": "University of Oldenburg",
+    "country": "Germany",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21247,6 +22669,7 @@
   },
   {
     "name": "University of Magdeburg",
+    "country": "Germany",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21258,6 +22681,7 @@
   },
   {
     "name": "University of Augsburg",
+    "country": "Germany",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21269,6 +22693,7 @@
   },
   {
     "name": "Copenhagen Business School",
+    "country": "Denmark",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21280,6 +22705,7 @@
   },
   {
     "name": "University of Extremadura",
+    "country": "Spain",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21291,6 +22717,7 @@
   },
   {
     "name": "University of M�laga",
+    "country": "Spain",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21302,6 +22729,7 @@
   },
   {
     "name": "Kindai University",
+    "country": "Japan",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21313,6 +22741,7 @@
   },
   {
     "name": "Kitasato University",
+    "country": "Japan",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21324,6 +22753,7 @@
   },
   {
     "name": "Chungbuk National University",
+    "country": "South Korea",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21335,6 +22765,7 @@
   },
   {
     "name": "Stockholm School of Economics",
+    "country": "Sweden",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21346,6 +22777,7 @@
   },
   {
     "name": "University of Idaho",
+    "country": "United States",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21357,6 +22789,7 @@
   },
   {
     "name": "Kent State University",
+    "country": "United States",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21368,6 +22801,7 @@
   },
   {
     "name": "Southern Methodist University",
+    "country": "United States",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21379,6 +22813,7 @@
   },
   {
     "name": "University of Tennessee Health Science Center",
+    "country": "United States",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21390,6 +22825,7 @@
   },
   {
     "name": "University Paris-Est Cr�teil Val de Marne",
+    "country": "France",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21401,6 +22837,7 @@
   },
   {
     "name": "Army Medical University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21412,6 +22849,7 @@
   },
   {
     "name": "Southwestern University of Finance and Economics",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21423,6 +22861,7 @@
   },
   {
     "name": "Chang'an University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21434,6 +22873,7 @@
   },
   {
     "name": "Beijing Technology and Business University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21445,6 +22885,7 @@
   },
   {
     "name": "Shanghai Ocean University",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21456,6 +22897,7 @@
   },
   {
     "name": "Homi Bhabha National Institute",
+    "country": "India",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21467,6 +22909,7 @@
   },
   {
     "name": "Suzhou University of Science and Technology",
+    "country": "China",
     "aggregatedScore": -44.453125,
     "originalRankings": {
       "arwu": {
@@ -21478,6 +22921,7 @@
   },
   {
     "name": "Federal University of S�o Carlos",
+    "country": "Brazil",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21489,6 +22933,7 @@
   },
   {
     "name": "Federal University of Vi�osa",
+    "country": "Brazil",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21500,6 +22945,7 @@
   },
   {
     "name": "University of Qu�bec at Montreal",
+    "country": "Canada",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21511,6 +22957,7 @@
   },
   {
     "name": "Capital Normal University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21522,6 +22969,7 @@
   },
   {
     "name": "Hebei Medical University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21533,6 +22981,7 @@
   },
   {
     "name": "Heilongjiang University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21544,6 +22993,7 @@
   },
   {
     "name": "Jiangxi Normal University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21555,6 +23005,7 @@
   },
   {
     "name": "Jimei University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21566,6 +23017,7 @@
   },
   {
     "name": "Liaocheng Teachers University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21577,6 +23029,7 @@
   },
   {
     "name": "Shandong Normal University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21588,6 +23041,7 @@
   },
   {
     "name": "Shanghai Normal University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21599,6 +23053,7 @@
   },
   {
     "name": "Sichuan Agricultural University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21610,6 +23065,7 @@
   },
   {
     "name": "Xi'an University of Architecture and Technology",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21621,6 +23077,7 @@
   },
   {
     "name": "Xiangtan University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21632,6 +23089,7 @@
   },
   {
     "name": "Zhongnan University of Economics and Law",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21643,6 +23101,7 @@
   },
   {
     "name": "University of Kassel",
+    "country": "Germany",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21654,6 +23113,7 @@
   },
   {
     "name": "University of Oviedo",
+    "country": "Spain",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21665,6 +23125,7 @@
   },
   {
     "name": "University of Burgundy",
+    "country": "France",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21676,6 +23137,7 @@
   },
   {
     "name": "University of Thessaly",
+    "country": "Greece",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21687,6 +23149,7 @@
   },
   {
     "name": "Education University of Hong Kong",
+    "country": "Hong Kong",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21698,6 +23161,7 @@
   },
   {
     "name": "Graduate University for Advanced Studies",
+    "country": "Japan",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21709,6 +23173,7 @@
   },
   {
     "name": "Kangwon National University",
+    "country": "South Korea",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21720,6 +23185,7 @@
   },
   {
     "name": "Cranfield University",
+    "country": "United Kingdom",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21731,6 +23197,7 @@
   },
   {
     "name": "University of Missouri - Kansas City",
+    "country": "United States",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21742,6 +23209,7 @@
   },
   {
     "name": "University of Wisconsin-Milwaukee",
+    "country": "United States",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21753,6 +23221,7 @@
   },
   {
     "name": "Northeast Forestry University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21764,6 +23233,7 @@
   },
   {
     "name": "Hangzhou Normal University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21775,6 +23245,7 @@
   },
   {
     "name": "Southwest Petroleum University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21786,6 +23257,7 @@
   },
   {
     "name": "Anhui Agricultural University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21797,6 +23269,7 @@
   },
   {
     "name": "Xuzhou Medical College",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21808,6 +23281,7 @@
   },
   {
     "name": "Shaanxi University of Science and Technology",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21819,6 +23293,7 @@
   },
   {
     "name": "Qingdao Agricultural University",
+    "country": "China",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21830,6 +23305,7 @@
   },
   {
     "name": "Skolkovo Institute of Science and Technology",
+    "country": "Russia",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21841,6 +23317,7 @@
   },
   {
     "name": "Istanbul University Cerrahpasa",
+    "country": "Turkey",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21852,6 +23329,7 @@
   },
   {
     "name": "SUNY Downstate Health Sciences University",
+    "country": "United States",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21863,6 +23341,7 @@
   },
   {
     "name": "University of Texas Rio Grande Valley",
+    "country": "United States",
     "aggregatedScore": -60.078125,
     "originalRankings": {
       "arwu": {
@@ -21874,6 +23353,7 @@
   },
   {
     "name": "Federal University of Bahia",
+    "country": "Brazil",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21885,6 +23365,7 @@
   },
   {
     "name": "Federal University of Goi�s",
+    "country": "Brazil",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21896,6 +23377,7 @@
   },
   {
     "name": "Federal University of Pelotas",
+    "country": "Brazil",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21907,6 +23389,7 @@
   },
   {
     "name": "Federal University of Pernambuco",
+    "country": "Brazil",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21918,6 +23401,7 @@
   },
   {
     "name": "Federal University of Cear�",
+    "country": "Brazil",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21929,6 +23413,7 @@
   },
   {
     "name": "Lakehead University",
+    "country": "Canada",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21940,6 +23425,7 @@
   },
   {
     "name": "National University Andr�s Bello",
+    "country": "Chile",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21951,6 +23437,7 @@
   },
   {
     "name": "Dalian Medical University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21962,6 +23449,7 @@
   },
   {
     "name": "Guangzhou University of Traditional Chinese Medicine",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21973,6 +23461,7 @@
   },
   {
     "name": "Harbin University of Science and Technology",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21984,6 +23473,7 @@
   },
   {
     "name": "Henan Agricultural University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -21995,6 +23485,7 @@
   },
   {
     "name": "Inner Mongolia University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22006,6 +23497,7 @@
   },
   {
     "name": "Huaqiao University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22017,6 +23509,7 @@
   },
   {
     "name": "North China University of Technology",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22028,6 +23521,7 @@
   },
   {
     "name": "Shanghai University of Finance and Economics",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22039,6 +23533,7 @@
   },
   {
     "name": "Shanghai University of Traditional Chinese Medicine and Pharmacology",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22050,6 +23545,7 @@
   },
   {
     "name": "Yantai University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22061,6 +23557,7 @@
   },
   {
     "name": "Suez Canal University",
+    "country": "Egypt",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22072,6 +23569,7 @@
   },
   {
     "name": "Tanta University",
+    "country": "Egypt",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22083,6 +23581,7 @@
   },
   {
     "name": "University of C�diz",
+    "country": "Spain",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22094,6 +23593,7 @@
   },
   {
     "name": "University of Poitiers",
+    "country": "France",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22105,6 +23605,7 @@
   },
   {
     "name": "Tokushima University",
+    "country": "Japan",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22116,6 +23617,7 @@
   },
   {
     "name": "Gyeongsang National University",
+    "country": "South Korea",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22127,6 +23629,7 @@
   },
   {
     "name": "Ataturk University",
+    "country": "Turkey",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22138,6 +23641,7 @@
   },
   {
     "name": "Cukurova University",
+    "country": "Turkey",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22149,6 +23653,7 @@
   },
   {
     "name": "Augusta State University",
+    "country": "United States",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22160,6 +23665,7 @@
   },
   {
     "name": "Loyola University of Chicago",
+    "country": "United States",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22171,6 +23677,7 @@
   },
   {
     "name": "Amherst College",
+    "country": "United States",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22182,6 +23689,7 @@
   },
   {
     "name": "North Dakota State University",
+    "country": "United States",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22193,6 +23701,7 @@
   },
   {
     "name": "Guangxi Medical University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22204,6 +23713,7 @@
   },
   {
     "name": "University of Novi Sad",
+    "country": "Serbia",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22215,6 +23725,7 @@
   },
   {
     "name": "University of Alabama in Huntsville",
+    "country": "United States",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22226,6 +23737,7 @@
   },
   {
     "name": "Liaoning University of Technology",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22237,6 +23749,7 @@
   },
   {
     "name": "Linnaeus University",
+    "country": "Sweden",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22248,6 +23761,7 @@
   },
   {
     "name": "Shanxi Medical University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22259,6 +23773,7 @@
   },
   {
     "name": "Henan Polytechnic University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22270,6 +23785,7 @@
   },
   {
     "name": "Yangtze University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22281,6 +23797,7 @@
   },
   {
     "name": "Western Norway University of Applied Sciences",
+    "country": "Norway",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22292,6 +23809,7 @@
   },
   {
     "name": "Zhejiang A & F University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22303,6 +23821,7 @@
   },
   {
     "name": "Dalian Polytechnic University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22314,6 +23833,7 @@
   },
   {
     "name": "Guangdong Ocean University",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22325,6 +23845,7 @@
   },
   {
     "name": "Guilin University of Electronic Technology",
+    "country": "China",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {
@@ -22336,6 +23857,7 @@
   },
   {
     "name": "Hassan II University of Casablanca",
+    "country": "Morocco",
     "aggregatedScore": -75.703125,
     "originalRankings": {
       "arwu": {

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders loading state', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const loading = screen.getByText(/Loading Universities/i);
+  expect(loading).toBeInTheDocument();
 });

--- a/scripts/aggregation.js
+++ b/scripts/aggregation.js
@@ -99,6 +99,7 @@ function aggregateRankings(universitiesData, sourceWeights, sourceMaxRanks, tota
         const finalScore = calculateAggregatedScore(university, sourceWeights, finalSourceMaxRanks, totalSources);
         return {
             name: university.name,
+            country: university.country,
             aggregatedScore: finalScore,
             // Potentially add other relevant info like original ranks, appearances, etc.
             originalRankings: university.rankings, // Keeping original ranks for context

--- a/scripts/arwu-scraper.js
+++ b/scripts/arwu-scraper.js
@@ -72,9 +72,10 @@ async function scrapeARWURankings(limit) {
                     // Use the exact header names to access data
                     const rank = parseInt(row['# World Rank'], 10);
                     const name = row[' Institution'] ? row[' Institution'].trim() : '';
+                    const country = row[' Country'] ? row[' Country'].trim() : '';
 
                     if (name && !isNaN(rank)) {
-                        rankings.push({ name, rank });
+                        rankings.push({ name, rank, country });
                     }
                 })
                 .on('end', () => {

--- a/scripts/qs-scraper.js
+++ b/scripts/qs-scraper.js
@@ -44,8 +44,9 @@ function parseQSCSV(filePath) {
       .on('data', (row) => {
         const rank = parseInt(row['# World Rank'], 10);
         const name = row[' Institution'];
+        const country = row[' Country'];
         if (name && !isNaN(rank)) {
-          results.push({ name: name.trim(), rank });
+          results.push({ name: name.trim(), rank, country: country.trim() });
         }
       })
       .on('end', () => resolve(results))

--- a/scripts/the-scraper.js
+++ b/scripts/the-scraper.js
@@ -76,11 +76,13 @@ async function scrapeTHERankings() {
                     }
 
                     const name = row['Institution'] ? row['Institution'].trim() : '';
+                    const country = row['Country'] ? row['Country'].trim() : '';
 
                     if (name && !isNaN(rank)) {
                         results.push({
                             name: name,        // Use 'name' property as expected by scrape-rankings.js
                             rank: rank,        // Include the parsed rank
+                            country: country,
                             source: 'the'
                         });
                     }


### PR DESCRIPTION
## Summary
- record country for each university when scraping
- standardize country names and include them in aggregated results
- expose country info in the React UI and add a filter dropdown
- update tests for new loading text

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684285f0e954832082530efc843f3fed