### PR TITLE
Add national ranking information

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project aggregates university rankings from multiple sources (QS, THE, ARWU, US News) using a Borda Count with Penalized Absence method.
 
+Each university entry in the aggregated data also includes a simple country specific rank. This `countryRank` is determined by counting how many universities from the same country appear above it in the aggregated results. It is meant only as a quick reference and is not an authoritative national ranking.
+
 [![Deploy to GitHub Pages](https://github.com/mmostagirbhuiyan/university-ranking-aggregator/actions/workflows/deploy.yml/badge.svg)](https://github.com/mmostagirbhuiyan/university-ranking-aggregator/actions/workflows/deploy.yml)
 
 ## Setup

--- a/frontend/public/data/aggregated-rankings.json
+++ b/frontend/public/data/aggregated-rankings.json
@@ -18,7 +18,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 1
+    "aggregatedRank": 1,
+    "countryRank": 1
   },
   {
     "name": "Harvard University",
@@ -39,7 +40,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 2
+    "aggregatedRank": 2,
+    "countryRank": 2
   },
   {
     "name": "University of Oxford",
@@ -60,7 +62,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 3
+    "aggregatedRank": 3,
+    "countryRank": 1
   },
   {
     "name": "Stanford University",
@@ -81,7 +84,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 4
+    "aggregatedRank": 4,
+    "countryRank": 3
   },
   {
     "name": "University of Cambridge",
@@ -102,7 +106,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 5
+    "aggregatedRank": 5,
+    "countryRank": 2
   },
   {
     "name": "University of California - Berkeley",
@@ -123,7 +128,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 6
+    "aggregatedRank": 6,
+    "countryRank": 4
   },
   {
     "name": "Imperial College London",
@@ -144,7 +150,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 7
+    "aggregatedRank": 7,
+    "countryRank": 3
   },
   {
     "name": "California Institute of Technology - Caltech",
@@ -165,7 +172,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 8
+    "aggregatedRank": 8,
+    "countryRank": 5
   },
   {
     "name": "Princeton University",
@@ -186,7 +194,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 9
+    "aggregatedRank": 9,
+    "countryRank": 6
   },
   {
     "name": "University of Pennsylvania",
@@ -207,7 +216,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 10
+    "aggregatedRank": 10,
+    "countryRank": 7
   },
   {
     "name": "University College London",
@@ -228,7 +238,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 11
+    "aggregatedRank": 11,
+    "countryRank": 4
   },
   {
     "name": "Yale University",
@@ -249,7 +260,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 12
+    "aggregatedRank": 12,
+    "countryRank": 8
   },
   {
     "name": "Cornell University",
@@ -270,7 +282,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 13
+    "aggregatedRank": 13,
+    "countryRank": 9
   },
   {
     "name": "Columbia University",
@@ -291,7 +304,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 14
+    "aggregatedRank": 14,
+    "countryRank": 10
   },
   {
     "name": "Tsinghua University",
@@ -312,7 +326,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 15
+    "aggregatedRank": 15,
+    "countryRank": 1
   },
   {
     "name": "University of Chicago",
@@ -333,7 +348,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 16
+    "aggregatedRank": 16,
+    "countryRank": 11
   },
   {
     "name": "Swiss Federal Institute of Technology Zurich - ETHZ",
@@ -354,7 +370,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 17
+    "aggregatedRank": 17,
+    "countryRank": 1
   },
   {
     "name": "Johns Hopkins University",
@@ -375,7 +392,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 18
+    "aggregatedRank": 18,
+    "countryRank": 12
   },
   {
     "name": "Peking University",
@@ -396,7 +414,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 19
+    "aggregatedRank": 19,
+    "countryRank": 2
   },
   {
     "name": "University of Toronto",
@@ -417,7 +436,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 20
+    "aggregatedRank": 20,
+    "countryRank": 1
   },
   {
     "name": "National University of Singapore",
@@ -438,7 +458,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 21
+    "aggregatedRank": 21,
+    "countryRank": 1
   },
   {
     "name": "University of Michigan - Ann Arbor",
@@ -459,7 +480,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 22
+    "aggregatedRank": 22,
+    "countryRank": 13
   },
   {
     "name": "University of Melbourne",
@@ -480,7 +502,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 23
+    "aggregatedRank": 23,
+    "countryRank": 1
   },
   {
     "name": "University of Washington Seattle",
@@ -501,7 +524,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 24
+    "aggregatedRank": 24,
+    "countryRank": 14
   },
   {
     "name": "University of Edinburgh",
@@ -522,7 +546,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 25
+    "aggregatedRank": 25,
+    "countryRank": 5
   },
   {
     "name": "Northwestern University",
@@ -543,7 +568,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 26
+    "aggregatedRank": 26,
+    "countryRank": 15
   },
   {
     "name": "New York University",
@@ -564,7 +590,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 27
+    "aggregatedRank": 27,
+    "countryRank": 16
   },
   {
     "name": "University of California - San Diego",
@@ -585,7 +612,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 28
+    "aggregatedRank": 28,
+    "countryRank": 17
   },
   {
     "name": "Duke University",
@@ -606,7 +634,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 29
+    "aggregatedRank": 29,
+    "countryRank": 18
   },
   {
     "name": "Nanyang Technological University",
@@ -627,7 +656,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 30
+    "aggregatedRank": 30,
+    "countryRank": 2
   },
   {
     "name": "University of Hong Kong",
@@ -648,7 +678,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 31
+    "aggregatedRank": 31,
+    "countryRank": 1
   },
   {
     "name": "University of British Columbia",
@@ -669,7 +700,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 32
+    "aggregatedRank": 32,
+    "countryRank": 2
   },
   {
     "name": "King's College London",
@@ -690,7 +722,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 33
+    "aggregatedRank": 33,
+    "countryRank": 6
   },
   {
     "name": "The University of Tokyo",
@@ -711,7 +744,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 34
+    "aggregatedRank": 34,
+    "countryRank": 1
   },
   {
     "name": "Shanghai Jiao Tong University",
@@ -732,7 +766,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 35
+    "aggregatedRank": 35,
+    "countryRank": 3
   },
   {
     "name": "McGill University",
@@ -753,7 +788,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 36
+    "aggregatedRank": 36,
+    "countryRank": 3
   },
   {
     "name": "University of Manchester",
@@ -774,7 +810,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 37
+    "aggregatedRank": 37,
+    "countryRank": 7
   },
   {
     "name": "Fudan University",
@@ -795,7 +832,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 38
+    "aggregatedRank": 38,
+    "countryRank": 4
   },
   {
     "name": "Monash University",
@@ -816,7 +854,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 39
+    "aggregatedRank": 39,
+    "countryRank": 2
   },
   {
     "name": "University of Texas at Austin",
@@ -837,7 +876,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 40
+    "aggregatedRank": 40,
+    "countryRank": 19
   },
   {
     "name": "University of Queensland",
@@ -858,7 +898,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 41
+    "aggregatedRank": 41,
+    "countryRank": 3
   },
   {
     "name": "Chinese University of Hong Kong",
@@ -879,7 +920,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 42
+    "aggregatedRank": 42,
+    "countryRank": 2
   },
   {
     "name": "Universit� Paris-Saclay",
@@ -900,7 +942,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 43
+    "aggregatedRank": 43,
+    "countryRank": 1
   },
   {
     "name": "University of Amsterdam",
@@ -921,7 +964,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 44
+    "aggregatedRank": 44,
+    "countryRank": 1
   },
   {
     "name": "University of Copenhagen",
@@ -942,7 +986,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 45
+    "aggregatedRank": 45,
+    "countryRank": 1
   },
   {
     "name": "University of Wisconsin-Madison",
@@ -963,7 +1008,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 46
+    "aggregatedRank": 46,
+    "countryRank": 20
   },
   {
     "name": "Australian National University",
@@ -984,7 +1030,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 47
+    "aggregatedRank": 47,
+    "countryRank": 4
   },
   {
     "name": "Washington University in St. Louis",
@@ -1005,7 +1052,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 48
+    "aggregatedRank": 48,
+    "countryRank": 21
   },
   {
     "name": "University of North Carolina at Chapel Hill",
@@ -1026,7 +1074,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 49
+    "aggregatedRank": 49,
+    "countryRank": 22
   },
   {
     "name": "Seoul National University",
@@ -1047,7 +1096,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 50
+    "aggregatedRank": 50,
+    "countryRank": 1
   },
   {
     "name": "Carnegie Mellon University",
@@ -1068,7 +1118,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 51
+    "aggregatedRank": 51,
+    "countryRank": 23
   },
   {
     "name": "Kyoto University",
@@ -1089,7 +1140,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 52
+    "aggregatedRank": 52,
+    "countryRank": 2
   },
   {
     "name": "City University of Hong Kong",
@@ -1110,7 +1162,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 53
+    "aggregatedRank": 53,
+    "countryRank": 3
   },
   {
     "name": "University of Bristol",
@@ -1131,7 +1184,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 54
+    "aggregatedRank": 54,
+    "countryRank": 8
   },
   {
     "name": "University of Glasgow",
@@ -1152,7 +1206,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 55
+    "aggregatedRank": 55,
+    "countryRank": 9
   },
   {
     "name": "University of Southern California",
@@ -1173,7 +1228,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 56
+    "aggregatedRank": 56,
+    "countryRank": 24
   },
   {
     "name": "Hong Kong Polytechnic University",
@@ -1194,7 +1250,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 57
+    "aggregatedRank": 57,
+    "countryRank": 4
   },
   {
     "name": "Georgia Institute of Technology",
@@ -1215,7 +1272,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 58
+    "aggregatedRank": 58,
+    "countryRank": 25
   },
   {
     "name": "University of California - Davis",
@@ -1236,7 +1294,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 59
+    "aggregatedRank": 59,
+    "countryRank": 26
   },
   {
     "name": "University of Groningen",
@@ -1257,7 +1316,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 60
+    "aggregatedRank": 60,
+    "countryRank": 2
   },
   {
     "name": "Pennsylvania State University",
@@ -1278,7 +1338,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 61
+    "aggregatedRank": 61,
+    "countryRank": 27
   },
   {
     "name": "Brown University",
@@ -1299,7 +1360,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 62
+    "aggregatedRank": 62,
+    "countryRank": 28
   },
   {
     "name": "Lund University",
@@ -1320,7 +1382,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 63
+    "aggregatedRank": 63,
+    "countryRank": 1
   },
   {
     "name": "University of Oslo",
@@ -1341,7 +1404,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 64
+    "aggregatedRank": 64,
+    "countryRank": 1
   },
   {
     "name": "University of Western Australia",
@@ -1362,7 +1426,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 65
+    "aggregatedRank": 65,
+    "countryRank": 5
   },
   {
     "name": "University of Birmingham",
@@ -1383,7 +1448,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 66
+    "aggregatedRank": 66,
+    "countryRank": 10
   },
   {
     "name": "Hong Kong University of Science and Technology",
@@ -1404,7 +1470,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 67
+    "aggregatedRank": 67,
+    "countryRank": 5
   },
   {
     "name": "Purdue University",
@@ -1425,7 +1492,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 68
+    "aggregatedRank": 68,
+    "countryRank": 29
   },
   {
     "name": "University of Helsinki",
@@ -1446,7 +1514,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 69
+    "aggregatedRank": 69,
+    "countryRank": 1
   },
   {
     "name": "Erasmus University Rotterdam",
@@ -1467,7 +1536,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 70
+    "aggregatedRank": 70,
+    "countryRank": 3
   },
   {
     "name": "Delft University of Technology",
@@ -1488,7 +1558,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 71
+    "aggregatedRank": 71,
+    "countryRank": 4
   },
   {
     "name": "University of Warwick",
@@ -1509,7 +1580,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 72
+    "aggregatedRank": 72,
+    "countryRank": 11
   },
   {
     "name": "Aarhus University",
@@ -1530,7 +1602,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 73
+    "aggregatedRank": 73,
+    "countryRank": 2
   },
   {
     "name": "University of Adelaide",
@@ -1551,7 +1624,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 74
+    "aggregatedRank": 74,
+    "countryRank": 6
   },
   {
     "name": "Emory University",
@@ -1572,7 +1646,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 75
+    "aggregatedRank": 75,
+    "countryRank": 30
   },
   {
     "name": "University of Alberta",
@@ -1593,7 +1668,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 76
+    "aggregatedRank": 76,
+    "countryRank": 4
   },
   {
     "name": "Ohio State University",
@@ -1614,7 +1690,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 77
+    "aggregatedRank": 77,
+    "countryRank": 31
   },
   {
     "name": "Vanderbilt University",
@@ -1635,7 +1712,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 78
+    "aggregatedRank": 78,
+    "countryRank": 32
   },
   {
     "name": "University of Southampton",
@@ -1656,7 +1734,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 79
+    "aggregatedRank": 79,
+    "countryRank": 12
   },
   {
     "name": "Uppsala University",
@@ -1677,7 +1756,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 80
+    "aggregatedRank": 80,
+    "countryRank": 2
   },
   {
     "name": "University of Nottingham",
@@ -1698,7 +1778,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 81
+    "aggregatedRank": 81,
+    "countryRank": 13
   },
   {
     "name": "University of Leeds",
@@ -1719,7 +1800,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 82
+    "aggregatedRank": 82,
+    "countryRank": 14
   },
   {
     "name": "University of Sheffield",
@@ -1740,7 +1822,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 83
+    "aggregatedRank": 83,
+    "countryRank": 15
   },
   {
     "name": "University of Basel",
@@ -1761,7 +1844,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 84
+    "aggregatedRank": 84,
+    "countryRank": 2
   },
   {
     "name": "McMaster University",
@@ -1782,7 +1866,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 85
+    "aggregatedRank": 85,
+    "countryRank": 5
   },
   {
     "name": "University of Technology Sydney",
@@ -1803,7 +1888,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 86
+    "aggregatedRank": 86,
+    "countryRank": 7
   },
   {
     "name": "University of Bonn",
@@ -1824,7 +1910,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 87
+    "aggregatedRank": 87,
+    "countryRank": 1
   },
   {
     "name": "University of Barcelona",
@@ -1845,7 +1932,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 88
+    "aggregatedRank": 88,
+    "countryRank": 1
   },
   {
     "name": "Michigan State University",
@@ -1866,7 +1954,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 89
+    "aggregatedRank": 89,
+    "countryRank": 33
   },
   {
     "name": "University of Geneva",
@@ -1887,7 +1976,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 90
+    "aggregatedRank": 90,
+    "countryRank": 3
   },
   {
     "name": "University of Auckland",
@@ -1908,7 +1998,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 91
+    "aggregatedRank": 91,
+    "countryRank": 1
   },
   {
     "name": "University of Florida",
@@ -1929,7 +2020,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 92
+    "aggregatedRank": 92,
+    "countryRank": 34
   },
   {
     "name": "Queen Mary - University of London",
@@ -1950,7 +2042,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 93
+    "aggregatedRank": 93,
+    "countryRank": 16
   },
   {
     "name": "University of Pittsburgh",
@@ -1971,7 +2064,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 94
+    "aggregatedRank": 94,
+    "countryRank": 35
   },
   {
     "name": "University of Vienna",
@@ -1992,7 +2086,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 95
+    "aggregatedRank": 95,
+    "countryRank": 1
   },
   {
     "name": "University of Liverpool",
@@ -2013,7 +2108,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 96
+    "aggregatedRank": 96,
+    "countryRank": 17
   },
   {
     "name": "Yonsei University",
@@ -2034,7 +2130,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 97
+    "aggregatedRank": 97,
+    "countryRank": 2
   },
   {
     "name": "Technical University of Denmark",
@@ -2055,7 +2152,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 98
+    "aggregatedRank": 98,
+    "countryRank": 3
   },
   {
     "name": "Stockholm University",
@@ -2076,7 +2174,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 99
+    "aggregatedRank": 99,
+    "countryRank": 3
   },
   {
     "name": "University of California - Irvine",
@@ -2097,7 +2196,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 100
+    "aggregatedRank": 100,
+    "countryRank": 36
   },
   {
     "name": "Rice University",
@@ -2118,7 +2218,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 101
+    "aggregatedRank": 101,
+    "countryRank": 37
   },
   {
     "name": "RWTH Aachen University",
@@ -2139,7 +2240,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 102
+    "aggregatedRank": 102,
+    "countryRank": 2
   },
   {
     "name": "University of Bologna",
@@ -2160,7 +2262,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 103
+    "aggregatedRank": 103,
+    "countryRank": 1
   },
   {
     "name": "University of Exeter",
@@ -2181,7 +2284,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 104
+    "aggregatedRank": 104,
+    "countryRank": 18
   },
   {
     "name": "University of Waterloo",
@@ -2202,7 +2306,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 105
+    "aggregatedRank": 105,
+    "countryRank": 6
   },
   {
     "name": "University of Colorado at Boulder",
@@ -2223,7 +2328,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 106
+    "aggregatedRank": 106,
+    "countryRank": 38
   },
   {
     "name": "Korea Advanced Institute of Science and Technology - KAIST",
@@ -2244,7 +2350,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 107
+    "aggregatedRank": 107,
+    "countryRank": 3
   },
   {
     "name": "Trinity College Dublin",
@@ -2265,7 +2372,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 108
+    "aggregatedRank": 108,
+    "countryRank": 1
   },
   {
     "name": "Radboud University of Nijmegen",
@@ -2286,7 +2394,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 109
+    "aggregatedRank": 109,
+    "countryRank": 5
   },
   {
     "name": "University of Lausanne",
@@ -2307,7 +2416,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 110
+    "aggregatedRank": 110,
+    "countryRank": 4
   },
   {
     "name": "Newcastle University - Newcastle-upon-Tyne",
@@ -2328,7 +2438,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 111
+    "aggregatedRank": 111,
+    "countryRank": 19
   },
   {
     "name": "Tongji University",
@@ -2349,7 +2460,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 112
+    "aggregatedRank": 112,
+    "countryRank": 5
   },
   {
     "name": "Sungkyunkwan University",
@@ -2370,7 +2482,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 113
+    "aggregatedRank": 113,
+    "countryRank": 4
   },
   {
     "name": "University of Freiburg",
@@ -2391,7 +2504,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 114
+    "aggregatedRank": 114,
+    "countryRank": 3
   },
   {
     "name": "Harbin Institute of Technology",
@@ -2412,7 +2526,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 115
+    "aggregatedRank": 115,
+    "countryRank": 6
   },
   {
     "name": "University of Cape Town",
@@ -2433,7 +2548,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 116
+    "aggregatedRank": 116,
+    "countryRank": 1
   },
   {
     "name": "Texas A&M University",
@@ -2454,7 +2570,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 117
+    "aggregatedRank": 117,
+    "countryRank": 39
   },
   {
     "name": "University of Hamburg",
@@ -2475,7 +2592,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 118
+    "aggregatedRank": 118,
+    "countryRank": 4
   },
   {
     "name": "National Taiwan University",
@@ -2496,7 +2614,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 119
+    "aggregatedRank": 119,
+    "countryRank": 1
   },
   {
     "name": "King Saud University",
@@ -2517,7 +2636,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 120
+    "aggregatedRank": 120,
+    "countryRank": 1
   },
   {
     "name": "University of Arizona",
@@ -2538,7 +2658,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 121
+    "aggregatedRank": 121,
+    "countryRank": 40
   },
   {
     "name": "University of G�ttingen",
@@ -2559,7 +2680,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 122
+    "aggregatedRank": 122,
+    "countryRank": 5
   },
   {
     "name": "Macquarie University",
@@ -2580,7 +2702,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 123
+    "aggregatedRank": 123,
+    "countryRank": 8
   },
   {
     "name": "Sun Yat-Sen University",
@@ -2601,7 +2724,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 124
+    "aggregatedRank": 124,
+    "countryRank": 7
   },
   {
     "name": "University of Rochester",
@@ -2622,7 +2746,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 125
+    "aggregatedRank": 125,
+    "countryRank": 41
   },
   {
     "name": "Cardiff University",
@@ -2643,7 +2768,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 126
+    "aggregatedRank": 126,
+    "countryRank": 20
   },
   {
     "name": "Case Western Reserve University",
@@ -2664,7 +2790,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 127
+    "aggregatedRank": 127,
+    "countryRank": 42
   },
   {
     "name": "Arizona State University",
@@ -2685,7 +2812,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 128
+    "aggregatedRank": 128,
+    "countryRank": 43
   },
   {
     "name": "Tohoku University",
@@ -2706,7 +2834,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 129
+    "aggregatedRank": 129,
+    "countryRank": 3
   },
   {
     "name": "University of Calgary",
@@ -2727,7 +2856,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 130
+    "aggregatedRank": 130,
+    "countryRank": 7
   },
   {
     "name": "Korea University",
@@ -2748,7 +2878,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 131
+    "aggregatedRank": 131,
+    "countryRank": 5
   },
   {
     "name": "Karlsruhe Institute of Technology",
@@ -2769,7 +2900,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 132
+    "aggregatedRank": 132,
+    "countryRank": 6
   },
   {
     "name": "Osaka University",
@@ -2790,7 +2922,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 133
+    "aggregatedRank": 133,
+    "countryRank": 4
   },
   {
     "name": "Tianjin University",
@@ -2811,7 +2944,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 134
+    "aggregatedRank": 134,
+    "countryRank": 8
   },
   {
     "name": "University of Padua",
@@ -2832,7 +2966,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 135
+    "aggregatedRank": 135,
+    "countryRank": 2
   },
   {
     "name": "Xi'an Jiaotong University",
@@ -2853,7 +2988,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 136
+    "aggregatedRank": 136,
+    "countryRank": 9
   },
   {
     "name": "Beijing Normal University",
@@ -2874,7 +3010,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 137
+    "aggregatedRank": 137,
+    "countryRank": 10
   },
   {
     "name": "King Abdulaziz University",
@@ -2895,7 +3032,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 138
+    "aggregatedRank": 138,
+    "countryRank": 2
   },
   {
     "name": "Deakin University",
@@ -2916,7 +3054,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 139
+    "aggregatedRank": 139,
+    "countryRank": 9
   },
   {
     "name": "Technical University of Berlin",
@@ -2937,7 +3076,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 140
+    "aggregatedRank": 140,
+    "countryRank": 7
   },
   {
     "name": "University of Virginia",
@@ -2958,7 +3098,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 141
+    "aggregatedRank": 141,
+    "countryRank": 44
   },
   {
     "name": "Tel Aviv University",
@@ -2979,7 +3120,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 142
+    "aggregatedRank": 142,
+    "countryRank": 1
   },
   {
     "name": "Curtin University",
@@ -3000,7 +3142,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 143
+    "aggregatedRank": 143,
+    "countryRank": 10
   },
   {
     "name": "Universit� Libre de Bruxelles",
@@ -3021,7 +3164,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 144
+    "aggregatedRank": 144,
+    "countryRank": 1
   },
   {
     "name": "University of Ottawa",
@@ -3042,7 +3186,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 145
+    "aggregatedRank": 145,
+    "countryRank": 8
   },
   {
     "name": "Queensland University of Technology",
@@ -3063,7 +3208,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 146
+    "aggregatedRank": 146,
+    "countryRank": 11
   },
   {
     "name": "Nagoya University",
@@ -3084,7 +3230,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 147
+    "aggregatedRank": 147,
+    "countryRank": 5
   },
   {
     "name": "Polytechnic University of Milan",
@@ -3105,7 +3252,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 148
+    "aggregatedRank": 148,
+    "countryRank": 3
   },
   {
     "name": "Indiana University at Bloomington",
@@ -3126,7 +3274,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 149
+    "aggregatedRank": 149,
+    "countryRank": 45
   },
   {
     "name": "Western University",
@@ -3147,7 +3296,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 150
+    "aggregatedRank": 150,
+    "countryRank": 9
   },
   {
     "name": "University of Cologne",
@@ -3168,7 +3318,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 151
+    "aggregatedRank": 151,
+    "countryRank": 8
   },
   {
     "name": "Lancaster University",
@@ -3189,7 +3340,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 152
+    "aggregatedRank": 152,
+    "countryRank": 21
   },
   {
     "name": "Sichuan University",
@@ -3210,7 +3362,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 153
+    "aggregatedRank": 153,
+    "countryRank": 11
   },
   {
     "name": "University of California - Santa Cruz",
@@ -3231,7 +3384,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 154
+    "aggregatedRank": 154,
+    "countryRank": 46
   },
   {
     "name": "RMIT University",
@@ -3252,7 +3406,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 155
+    "aggregatedRank": 155,
+    "countryRank": 12
   },
   {
     "name": "University of Wollongong",
@@ -3273,7 +3428,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 156
+    "aggregatedRank": 156,
+    "countryRank": 13
   },
   {
     "name": "Tokyo Institute of Technology",
@@ -3294,7 +3450,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 157
+    "aggregatedRank": 157,
+    "countryRank": 6
   },
   {
     "name": "University of York",
@@ -3315,7 +3472,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 158
+    "aggregatedRank": 158,
+    "countryRank": 22
   },
   {
     "name": "University College Dublin",
@@ -3336,7 +3494,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 159
+    "aggregatedRank": 159,
+    "countryRank": 2
   },
   {
     "name": "University of Milan",
@@ -3357,7 +3516,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 160
+    "aggregatedRank": 160,
+    "countryRank": 4
   },
   {
     "name": "University of Sussex",
@@ -3378,7 +3538,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 161
+    "aggregatedRank": 161,
+    "countryRank": 23
   },
   {
     "name": "Nankai University",
@@ -3399,7 +3560,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 162
+    "aggregatedRank": 162,
+    "countryRank": 12
   },
   {
     "name": "Hebrew University of Jerusalem",
@@ -3420,7 +3582,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 163
+    "aggregatedRank": 163,
+    "countryRank": 2
   },
   {
     "name": "University of M�nster",
@@ -3441,7 +3604,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 164
+    "aggregatedRank": 164,
+    "countryRank": 9
   },
   {
     "name": "Tufts University",
@@ -3462,7 +3626,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 165
+    "aggregatedRank": 165,
+    "countryRank": 47
   },
   {
     "name": "University of Antwerp",
@@ -3483,7 +3648,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 166
+    "aggregatedRank": 166,
+    "countryRank": 2
   },
   {
     "name": "University of Leicester",
@@ -3504,7 +3670,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 167
+    "aggregatedRank": 167,
+    "countryRank": 24
   },
   {
     "name": "Queen's University Belfast",
@@ -3525,7 +3692,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 168
+    "aggregatedRank": 168,
+    "countryRank": 25
   },
   {
     "name": "Norwegian University of Science and Technology",
@@ -3546,7 +3714,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 169
+    "aggregatedRank": 169,
+    "countryRank": 2
   },
   {
     "name": "University of Utah",
@@ -3567,7 +3736,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 170
+    "aggregatedRank": 170,
+    "countryRank": 48
   },
   {
     "name": "University of St. Andrews",
@@ -3588,7 +3758,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 171
+    "aggregatedRank": 171,
+    "countryRank": 26
   },
   {
     "name": "University of Macau",
@@ -3609,7 +3780,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 172
+    "aggregatedRank": 172,
+    "countryRank": 1
   },
   {
     "name": "Griffith University",
@@ -3630,7 +3802,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 173
+    "aggregatedRank": 173,
+    "countryRank": 14
   },
   {
     "name": "Zhejiang University of Technology",
@@ -3651,7 +3824,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 174
+    "aggregatedRank": 174,
+    "countryRank": 13
   },
   {
     "name": "University of Bergen",
@@ -3672,7 +3846,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 175
+    "aggregatedRank": 175,
+    "countryRank": 5
   },
   {
     "name": "University of W�rzburg",
@@ -3693,7 +3868,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 176
+    "aggregatedRank": 176,
+    "countryRank": 10
   },
   {
     "name": "University of Aberdeen",
@@ -3714,7 +3890,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 177
+    "aggregatedRank": 177,
+    "countryRank": 27
   },
   {
     "name": "Aalto University",
@@ -3735,7 +3912,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 178
+    "aggregatedRank": 178,
+    "countryRank": 2
   },
   {
     "name": "Xiamen University",
@@ -3756,7 +3934,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 179
+    "aggregatedRank": 179,
+    "countryRank": 14
   },
   {
     "name": "Southeast University",
@@ -3777,7 +3956,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 180
+    "aggregatedRank": 180,
+    "countryRank": 15
   },
   {
     "name": "Hunan University",
@@ -3798,7 +3978,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 181
+    "aggregatedRank": 181,
+    "countryRank": 16
   },
   {
     "name": "North Carolina State University",
@@ -3819,7 +4000,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 182
+    "aggregatedRank": 182,
+    "countryRank": 49
   },
   {
     "name": "Northeastern University",
@@ -3840,7 +4022,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 183
+    "aggregatedRank": 183,
+    "countryRank": 50
   },
   {
     "name": "Kyushu University",
@@ -3861,7 +4044,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 184
+    "aggregatedRank": 184,
+    "countryRank": 7
   },
   {
     "name": "Dartmouth College",
@@ -3882,7 +4066,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 185
+    "aggregatedRank": 185,
+    "countryRank": 51
   },
   {
     "name": "La Trobe University",
@@ -3903,7 +4088,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 186
+    "aggregatedRank": 186,
+    "countryRank": 15
   },
   {
     "name": "Queen's University",
@@ -3924,7 +4110,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 187
+    "aggregatedRank": 187,
+    "countryRank": 10
   },
   {
     "name": "University of Electronic Science and Technology of China",
@@ -3945,7 +4132,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 188
+    "aggregatedRank": 188,
+    "countryRank": 17
   },
   {
     "name": "University of Newcastle - Australia",
@@ -3966,7 +4154,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 189
+    "aggregatedRank": 189,
+    "countryRank": 16
   },
   {
     "name": "University of Miami",
@@ -3987,7 +4176,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 190
+    "aggregatedRank": 190,
+    "countryRank": 52
   },
   {
     "name": "Ulsan National Institute of Science and Technology",
@@ -4008,7 +4198,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 191
+    "aggregatedRank": 191,
+    "countryRank": 6
   },
   {
     "name": "Beihang University",
@@ -4029,7 +4220,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 192
+    "aggregatedRank": 192,
+    "countryRank": 18
   },
   {
     "name": "Vrije Universiteit Brussel",
@@ -4050,7 +4242,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 193
+    "aggregatedRank": 193,
+    "countryRank": 3
   },
   {
     "name": "University of Naples Federico II",
@@ -4071,7 +4264,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 194
+    "aggregatedRank": 194,
+    "countryRank": 5
   },
   {
     "name": "University of Southern Denmark",
@@ -4092,7 +4286,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 195
+    "aggregatedRank": 195,
+    "countryRank": 4
   },
   {
     "name": "Linkoping University",
@@ -4113,7 +4308,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 196
+    "aggregatedRank": 196,
+    "countryRank": 4
   },
   {
     "name": "Autonomous University of Madrid",
@@ -4134,7 +4330,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 197
+    "aggregatedRank": 197,
+    "countryRank": 2
   },
   {
     "name": "University of Pisa",
@@ -4155,7 +4352,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 198
+    "aggregatedRank": 198,
+    "countryRank": 6
   },
   {
     "name": "University of Tasmania",
@@ -4176,7 +4374,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 199
+    "aggregatedRank": 199,
+    "countryRank": 17
   },
   {
     "name": "University of Witwatersrand",
@@ -4197,7 +4396,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 200
+    "aggregatedRank": 200,
+    "countryRank": 2
   },
   {
     "name": "University of Illinois at Chicago",
@@ -4218,7 +4418,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 201
+    "aggregatedRank": 201,
+    "countryRank": 53
   },
   {
     "name": "George Washington University",
@@ -4239,7 +4440,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 202
+    "aggregatedRank": 202,
+    "countryRank": 54
   },
   {
     "name": "Nanjing University of Technology",
@@ -4260,7 +4462,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 203
+    "aggregatedRank": 203,
+    "countryRank": 19
   },
   {
     "name": "University of Reading",
@@ -4281,7 +4484,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 204
+    "aggregatedRank": 204,
+    "countryRank": 28
   },
   {
     "name": "Hanyang University",
@@ -4302,7 +4506,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 205
+    "aggregatedRank": 205,
+    "countryRank": 7
   },
   {
     "name": "Hokkaido University",
@@ -4323,7 +4528,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 206
+    "aggregatedRank": 206,
+    "countryRank": 8
   },
   {
     "name": "University of California - Riverside",
@@ -4344,7 +4550,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 207
+    "aggregatedRank": 207,
+    "countryRank": 55
   },
   {
     "name": "University of East Anglia",
@@ -4365,7 +4572,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 208
+    "aggregatedRank": 208,
+    "countryRank": 29
   },
   {
     "name": "Aix-Marseille University",
@@ -4386,7 +4594,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 209
+    "aggregatedRank": 209,
+    "countryRank": 2
   },
   {
     "name": "University of Notre Dame",
@@ -4407,7 +4616,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 210
+    "aggregatedRank": 210,
+    "countryRank": 56
   },
   {
     "name": "Shenzhen University",
@@ -4428,7 +4638,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 211
+    "aggregatedRank": 211,
+    "countryRank": 20
   },
   {
     "name": "Vita-Salute San Raffaele University",
@@ -4449,7 +4660,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 212
+    "aggregatedRank": 212,
+    "countryRank": 7
   },
   {
     "name": "Charles University Prague",
@@ -4470,7 +4682,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 213
+    "aggregatedRank": 213,
+    "countryRank": 1
   },
   {
     "name": "East China Normal University",
@@ -4491,7 +4704,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 214
+    "aggregatedRank": 214,
+    "countryRank": 21
   },
   {
     "name": "University of Surrey",
@@ -4512,7 +4726,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 215
+    "aggregatedRank": 215,
+    "countryRank": 30
   },
   {
     "name": "University of Twente",
@@ -4533,7 +4748,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 216
+    "aggregatedRank": 216,
+    "countryRank": 6
   },
   {
     "name": "University of Tennessee - Knoxville",
@@ -4554,7 +4770,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 217
+    "aggregatedRank": 217,
+    "countryRank": 57
   },
   {
     "name": "Dalhousie University",
@@ -4575,7 +4792,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 218
+    "aggregatedRank": 218,
+    "countryRank": 11
   },
   {
     "name": "Aalborg University",
@@ -4596,7 +4814,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 219
+    "aggregatedRank": 219,
+    "countryRank": 5
   },
   {
     "name": "State University of New York at Stony Brook",
@@ -4617,7 +4836,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 220
+    "aggregatedRank": 220,
+    "countryRank": 58
   },
   {
     "name": "University of Otago",
@@ -4638,7 +4858,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 221
+    "aggregatedRank": 221,
+    "countryRank": 2
   },
   {
     "name": "University of Florence",
@@ -4659,7 +4880,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 222
+    "aggregatedRank": 222,
+    "countryRank": 8
   },
   {
     "name": "University of Innsbruck",
@@ -4680,7 +4902,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 223
+    "aggregatedRank": 223,
+    "countryRank": 2
   },
   {
     "name": "Chongqing University",
@@ -4701,7 +4924,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 224
+    "aggregatedRank": 224,
+    "countryRank": 22
   },
   {
     "name": "Complutense University of Madrid",
@@ -4722,7 +4946,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 225
+    "aggregatedRank": 225,
+    "countryRank": 3
   },
   {
     "name": "Georgetown University",
@@ -4743,7 +4968,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 226
+    "aggregatedRank": 226,
+    "countryRank": 59
   },
   {
     "name": "Simon Fraser University",
@@ -4764,7 +4990,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 227
+    "aggregatedRank": 227,
+    "countryRank": 12
   },
   {
     "name": "University of Li�ge",
@@ -4785,7 +5012,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 228
+    "aggregatedRank": 228,
+    "countryRank": 4
   },
   {
     "name": "University of Victoria",
@@ -4806,7 +5034,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 229
+    "aggregatedRank": 229,
+    "countryRank": 13
   },
   {
     "name": "University College Cork",
@@ -4827,7 +5056,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 230
+    "aggregatedRank": 230,
+    "countryRank": 3
   },
   {
     "name": "Sejong University",
@@ -4848,7 +5078,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 231
+    "aggregatedRank": 231,
+    "countryRank": 8
   },
   {
     "name": "Dalian University of Technology",
@@ -4869,7 +5100,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 232
+    "aggregatedRank": 232,
+    "countryRank": 23
   },
   {
     "name": "University of Potsdam",
@@ -4890,7 +5122,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 233
+    "aggregatedRank": 233,
+    "countryRank": 11
   },
   {
     "name": "Colorado State University",
@@ -4911,7 +5144,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 234
+    "aggregatedRank": 234,
+    "countryRank": 60
   },
   {
     "name": "University of Iowa",
@@ -4932,7 +5166,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 235
+    "aggregatedRank": 235,
+    "countryRank": 61
   },
   {
     "name": "University of Navarra",
@@ -4953,7 +5188,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 236
+    "aggregatedRank": 236,
+    "countryRank": 4
   },
   {
     "name": "University of Valencia",
@@ -4974,7 +5210,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 237
+    "aggregatedRank": 237,
+    "countryRank": 5
   },
   {
     "name": "Laval University",
@@ -4995,7 +5232,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 238
+    "aggregatedRank": 238,
+    "countryRank": 14
   },
   {
     "name": "University of Oulu",
@@ -5016,7 +5254,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 239
+    "aggregatedRank": 239,
+    "countryRank": 3
   },
   {
     "name": "Shanghai University",
@@ -5037,7 +5276,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 240
+    "aggregatedRank": 240,
+    "countryRank": 24
   },
   {
     "name": "University of Milan - Bicocca",
@@ -5058,7 +5298,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 241
+    "aggregatedRank": 241,
+    "countryRank": 9
   },
   {
     "name": "University of South Australia",
@@ -5079,7 +5320,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 242
+    "aggregatedRank": 242,
+    "countryRank": 18
   },
   {
     "name": "University of Trento",
@@ -5100,7 +5342,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 243
+    "aggregatedRank": 243,
+    "countryRank": 10
   },
   {
     "name": "University of Kansas",
@@ -5121,7 +5364,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 244
+    "aggregatedRank": 244,
+    "countryRank": 62
   },
   {
     "name": "University of Kiel",
@@ -5142,7 +5386,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 245
+    "aggregatedRank": 245,
+    "countryRank": 12
   },
   {
     "name": "University of Tehran",
@@ -5163,7 +5408,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 246
+    "aggregatedRank": 246,
+    "countryRank": 1
   },
   {
     "name": "State University of New York at Buffalo",
@@ -5184,7 +5430,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 247
+    "aggregatedRank": 247,
+    "countryRank": 63
   },
   {
     "name": "University of Pavia",
@@ -5205,7 +5452,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 248
+    "aggregatedRank": 248,
+    "countryRank": 11
   },
   {
     "name": "Boston University",
@@ -5226,7 +5474,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 249
+    "aggregatedRank": 249,
+    "countryRank": 64
   },
   {
     "name": "University of Rome - Tor Vergata",
@@ -5247,7 +5496,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 250
+    "aggregatedRank": 250,
+    "countryRank": 12
   },
   {
     "name": "University of Johannesburg",
@@ -5268,7 +5518,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 251
+    "aggregatedRank": 251,
+    "countryRank": 3
   },
   {
     "name": "Florida State University",
@@ -5289,7 +5540,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 252
+    "aggregatedRank": 252,
+    "countryRank": 65
   },
   {
     "name": "Beijing University of Technology",
@@ -5310,7 +5562,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 253
+    "aggregatedRank": 253,
+    "countryRank": 25
   },
   {
     "name": "University of Dundee",
@@ -5331,7 +5584,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 254
+    "aggregatedRank": 254,
+    "countryRank": 31
   },
   {
     "name": "University of Connecticut",
@@ -5352,7 +5606,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 255
+    "aggregatedRank": 255,
+    "countryRank": 66
   },
   {
     "name": "University of Delaware",
@@ -5373,7 +5628,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 256
+    "aggregatedRank": 256,
+    "countryRank": 67
   },
   {
     "name": "Kyung Hee University",
@@ -5394,7 +5650,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 257
+    "aggregatedRank": 257,
+    "countryRank": 9
   },
   {
     "name": "University of Tartu",
@@ -5415,7 +5672,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 258
+    "aggregatedRank": 258,
+    "countryRank": 1
   },
   {
     "name": "University Claude Bernard - Lyon I",
@@ -5436,7 +5694,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 259
+    "aggregatedRank": 259,
+    "countryRank": 3
   },
   {
     "name": "University of Hawaii at Manoa",
@@ -5457,7 +5716,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 260
+    "aggregatedRank": 260,
+    "countryRank": 68
   },
   {
     "name": "National Tsinghua University",
@@ -5478,7 +5738,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 261
+    "aggregatedRank": 261,
+    "countryRank": 2
   },
   {
     "name": "University of Turin",
@@ -5499,7 +5760,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 262
+    "aggregatedRank": 262,
+    "countryRank": 13
   },
   {
     "name": "Swansea University",
@@ -5520,7 +5782,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 263
+    "aggregatedRank": 263,
+    "countryRank": 32
   },
   {
     "name": "Victoria University of Wellington",
@@ -5541,7 +5804,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 264
+    "aggregatedRank": 264,
+    "countryRank": 3
   },
   {
     "name": "James Cook University",
@@ -5562,7 +5826,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 265
+    "aggregatedRank": 265,
+    "countryRank": 19
   },
   {
     "name": "University of Colorado at Denver",
@@ -5583,7 +5848,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 266
+    "aggregatedRank": 266,
+    "countryRank": 69
   },
   {
     "name": "University of Strathclyde",
@@ -5604,7 +5870,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 267
+    "aggregatedRank": 267,
+    "countryRank": 33
   },
   {
     "name": "Hong Kong Baptist University",
@@ -5625,7 +5892,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 268
+    "aggregatedRank": 268,
+    "countryRank": 6
   },
   {
     "name": "University of Genoa",
@@ -5646,7 +5914,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 269
+    "aggregatedRank": 269,
+    "countryRank": 14
   },
   {
     "name": "University of South Florida",
@@ -5667,7 +5936,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 270
+    "aggregatedRank": 270,
+    "countryRank": 70
   },
   {
     "name": "University of Duisburg-Essen",
@@ -5688,7 +5958,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 271
+    "aggregatedRank": 271,
+    "countryRank": 13
   },
   {
     "name": "Washington State University",
@@ -5709,7 +5980,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 272
+    "aggregatedRank": 272,
+    "countryRank": 71
   },
   {
     "name": "University of Luxembourg",
@@ -5730,7 +6002,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 273
+    "aggregatedRank": 273,
+    "countryRank": 1
   },
   {
     "name": "University of Houston",
@@ -5751,7 +6024,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 274
+    "aggregatedRank": 274,
+    "countryRank": 72
   },
   {
     "name": "University of Manitoba",
@@ -5772,7 +6046,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 275
+    "aggregatedRank": 275,
+    "countryRank": 15
   },
   {
     "name": "University of Granada",
@@ -5793,7 +6068,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 276
+    "aggregatedRank": 276,
+    "countryRank": 6
   },
   {
     "name": "University of Georgia",
@@ -5814,7 +6090,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 277
+    "aggregatedRank": 277,
+    "countryRank": 73
   },
   {
     "name": "University of Sharjah",
@@ -5835,7 +6112,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 278
+    "aggregatedRank": 278,
+    "countryRank": 1
   },
   {
     "name": "Jagiellonian University",
@@ -5856,7 +6134,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 279
+    "aggregatedRank": 279,
+    "countryRank": 1
   },
   {
     "name": "Umea University",
@@ -5877,7 +6156,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 280
+    "aggregatedRank": 280,
+    "countryRank": 5
   },
   {
     "name": "United Arab Emirates University",
@@ -5898,7 +6178,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 281
+    "aggregatedRank": 281,
+    "countryRank": 2
   },
   {
     "name": "Iowa State University",
@@ -5919,7 +6200,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 282
+    "aggregatedRank": 282,
+    "countryRank": 74
   },
   {
     "name": "Cairo University",
@@ -5940,7 +6222,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 283
+    "aggregatedRank": 283,
+    "countryRank": 1
   },
   {
     "name": "University of Warsaw",
@@ -5961,7 +6244,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 284
+    "aggregatedRank": 284,
+    "countryRank": 2
   },
   {
     "name": "Polytechnic University of Turin",
@@ -5982,7 +6266,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 285
+    "aggregatedRank": 285,
+    "countryRank": 15
   },
   {
     "name": "King Khalid University",
@@ -6003,7 +6288,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 286
+    "aggregatedRank": 286,
+    "countryRank": 3
   },
   {
     "name": "Temple University",
@@ -6024,7 +6310,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 287
+    "aggregatedRank": 287,
+    "countryRank": 75
   },
   {
     "name": "University of Missouri - Columbia",
@@ -6045,7 +6332,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 288
+    "aggregatedRank": 288,
+    "countryRank": 76
   },
   {
     "name": "Sharif University of Technology",
@@ -6066,7 +6354,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 289
+    "aggregatedRank": 289,
+    "countryRank": 2
   },
   {
     "name": "University of Kentucky",
@@ -6087,7 +6376,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 290
+    "aggregatedRank": 290,
+    "countryRank": 77
   },
   {
     "name": "Brunel University",
@@ -6108,7 +6398,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 291
+    "aggregatedRank": 291,
+    "countryRank": 34
   },
   {
     "name": "University of Pretoria",
@@ -6129,7 +6420,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 292
+    "aggregatedRank": 292,
+    "countryRank": 4
   },
   {
     "name": "University of Nebraska - Lincoln",
@@ -6150,7 +6442,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 293
+    "aggregatedRank": 293,
+    "countryRank": 78
   },
   {
     "name": "Drexel University",
@@ -6171,7 +6464,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 294
+    "aggregatedRank": 294,
+    "countryRank": 79
   },
   {
     "name": "Edith Cowan University",
@@ -6192,7 +6486,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 295
+    "aggregatedRank": 295,
+    "countryRank": 20
   },
   {
     "name": "American University of Beirut",
@@ -6213,7 +6508,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 296
+    "aggregatedRank": 296,
+    "countryRank": 1
   },
   {
     "name": "Tulane University",
@@ -6234,7 +6530,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 297
+    "aggregatedRank": 297,
+    "countryRank": 80
   },
   {
     "name": "University of Texas at Dallas",
@@ -6255,7 +6552,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 298
+    "aggregatedRank": 298,
+    "countryRank": 81
   },
   {
     "name": "Florida International University",
@@ -6276,7 +6574,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 299
+    "aggregatedRank": 299,
+    "countryRank": 82
   },
   {
     "name": "University of Central Florida",
@@ -6297,7 +6596,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 300
+    "aggregatedRank": 300,
+    "countryRank": 83
   },
   {
     "name": "University of KwaZulu-Natal",
@@ -6318,7 +6618,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 301
+    "aggregatedRank": 301,
+    "countryRank": 5
   },
   {
     "name": "University of Oregon",
@@ -6339,7 +6640,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 302
+    "aggregatedRank": 302,
+    "countryRank": 84
   },
   {
     "name": "Nanjing University of Science and Technology",
@@ -6360,7 +6662,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 303
+    "aggregatedRank": 303,
+    "countryRank": 10
   },
   {
     "name": "University of the Basque Country",
@@ -6381,7 +6684,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 304
+    "aggregatedRank": 304,
+    "countryRank": 7
   },
   {
     "name": "Humboldt University of Berlin",
@@ -6399,7 +6703,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 305
+    "aggregatedRank": 305,
+    "countryRank": 14
   },
   {
     "name": "Free University of Berlin",
@@ -6417,7 +6722,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 306
+    "aggregatedRank": 306,
+    "countryRank": 15
   },
   {
     "name": "University of Brescia",
@@ -6438,7 +6744,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 307
+    "aggregatedRank": 307,
+    "countryRank": 16
   },
   {
     "name": "University of Vermont",
@@ -6459,7 +6766,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 308
+    "aggregatedRank": 308,
+    "countryRank": 17
   },
   {
     "name": "Wake Forest University",
@@ -6480,7 +6788,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 309
+    "aggregatedRank": 309,
+    "countryRank": 85
   },
   {
     "name": "Federal University of Rio Grande do Sul",
@@ -6501,7 +6810,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 310
+    "aggregatedRank": 310,
+    "countryRank": 1
   },
   {
     "name": "Wuhan University of Technology",
@@ -6522,7 +6832,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 311
+    "aggregatedRank": 311,
+    "countryRank": 26
   },
   {
     "name": "COMSATS University Islamabad",
@@ -6543,7 +6854,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 312
+    "aggregatedRank": 312,
+    "countryRank": 1
   },
   {
     "name": "China University of Petroleum (Beijing)",
@@ -6564,7 +6876,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 313
+    "aggregatedRank": 313,
+    "countryRank": 27
   },
   {
     "name": "Australian Catholic University",
@@ -6585,7 +6898,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 314
+    "aggregatedRank": 314,
+    "countryRank": 21
   },
   {
     "name": "University of Trieste",
@@ -6606,7 +6920,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 315
+    "aggregatedRank": 315,
+    "countryRank": 18
   },
   {
     "name": "Louisiana State University",
@@ -6627,7 +6942,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 316
+    "aggregatedRank": 316,
+    "countryRank": 86
   },
   {
     "name": "University of Bari",
@@ -6648,7 +6964,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 317
+    "aggregatedRank": 317,
+    "countryRank": 35
   },
   {
     "name": "Wayne State University",
@@ -6669,7 +6986,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 318
+    "aggregatedRank": 318,
+    "countryRank": 87
   },
   {
     "name": "Syracuse University",
@@ -6690,7 +7008,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 319
+    "aggregatedRank": 319,
+    "countryRank": 88
   },
   {
     "name": "University of Ljubljana",
@@ -6711,7 +7030,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 320
+    "aggregatedRank": 320,
+    "countryRank": 1
   },
   {
     "name": "Karolinska Institute",
@@ -6729,7 +7049,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 321
+    "aggregatedRank": 321,
+    "countryRank": 6
   },
   {
     "name": "Mansoura University",
@@ -6750,7 +7071,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 322
+    "aggregatedRank": 322,
+    "countryRank": 2
   },
   {
     "name": "North-West University",
@@ -6771,7 +7093,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 323
+    "aggregatedRank": 323,
+    "countryRank": 6
   },
   {
     "name": "Quaid-i-Azam University",
@@ -6789,7 +7112,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 324
+    "aggregatedRank": 324,
+    "countryRank": 2
   },
   {
     "name": "Medical University of Vienna",
@@ -6807,7 +7131,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 325
+    "aggregatedRank": 325,
+    "countryRank": 3
   },
   {
     "name": "Duy Tan University",
@@ -6825,7 +7150,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 326
+    "aggregatedRank": 326,
+    "countryRank": 1
   },
   {
     "name": "Utrecht University",
@@ -6843,7 +7169,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 327
+    "aggregatedRank": 327,
+    "countryRank": 7
   },
   {
     "name": "University of Zurich",
@@ -6861,7 +7188,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 328
+    "aggregatedRank": 328,
+    "countryRank": 6
   },
   {
     "name": "University of California - Los Angeles",
@@ -6879,7 +7207,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 329
+    "aggregatedRank": 329,
+    "countryRank": 89
   },
   {
     "name": "PSL Research University Paris",
@@ -6897,7 +7226,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 330
+    "aggregatedRank": 330,
+    "countryRank": 4
   },
   {
     "name": "Technical University of M�nchen",
@@ -6915,7 +7245,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 331
+    "aggregatedRank": 331,
+    "countryRank": 16
   },
   {
     "name": "Swiss Federal Institute of Technology Lausanne - EPFL",
@@ -6933,7 +7264,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 332
+    "aggregatedRank": 332,
+    "countryRank": 7
   },
   {
     "name": "Bogazici University",
@@ -6951,7 +7283,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 333
+    "aggregatedRank": 333,
+    "countryRank": 1
   },
   {
     "name": "University of M�nchen",
@@ -6969,7 +7302,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 334
+    "aggregatedRank": 334,
+    "countryRank": 17
   },
   {
     "name": "Prince Sultan University",
@@ -6987,7 +7321,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 335
+    "aggregatedRank": 335,
+    "countryRank": 4
   },
   {
     "name": "China Medical University - Taiwan",
@@ -7005,7 +7340,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 336
+    "aggregatedRank": 336,
+    "countryRank": 3
   },
   {
     "name": "University of Illinois at Urbana-Champaign",
@@ -7023,7 +7359,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 337
+    "aggregatedRank": 337,
+    "countryRank": 90
   },
   {
     "name": "University of New South Wales",
@@ -7041,7 +7378,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 338
+    "aggregatedRank": 338,
+    "countryRank": 22
   },
   {
     "name": "Sorbonne University",
@@ -7059,7 +7397,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 339
+    "aggregatedRank": 339,
+    "countryRank": 5
   },
   {
     "name": "University of Heidelberg",
@@ -7077,7 +7416,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 340
+    "aggregatedRank": 340,
+    "countryRank": 18
   },
   {
     "name": "Catholic University of Leuven",
@@ -7095,7 +7435,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 341
+    "aggregatedRank": 341,
+    "countryRank": 5
   },
   {
     "name": "Ton Duc Thang University",
@@ -7113,7 +7454,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 342
+    "aggregatedRank": 342,
+    "countryRank": 2
   },
   {
     "name": "London School of Economics",
@@ -7131,7 +7473,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 343
+    "aggregatedRank": 343,
+    "countryRank": 36
   },
   {
     "name": "Medical University of Graz",
@@ -7149,7 +7492,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 344
+    "aggregatedRank": 344,
+    "countryRank": 4
   },
   {
     "name": "George Mason University",
@@ -7167,7 +7511,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 345
+    "aggregatedRank": 345,
+    "countryRank": 91
   },
   {
     "name": "Moscow State University",
@@ -7185,7 +7530,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 346
+    "aggregatedRank": 346,
+    "countryRank": 1
   },
   {
     "name": "University of California - Santa Barbara",
@@ -7203,7 +7549,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 347
+    "aggregatedRank": 347,
+    "countryRank": 92
   },
   {
     "name": "University of Minnesota - Twin Cities",
@@ -7221,7 +7568,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 348
+    "aggregatedRank": 348,
+    "countryRank": 93
   },
   {
     "name": "KTH - Royal Institute of Technology",
@@ -7239,7 +7587,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 349
+    "aggregatedRank": 349,
+    "countryRank": 7
   },
   {
     "name": "Wageningen University & Research Center",
@@ -7257,7 +7606,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 350
+    "aggregatedRank": 350,
+    "countryRank": 8
   },
   {
     "name": "Medical University of Innsbruck",
@@ -7275,7 +7625,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 351
+    "aggregatedRank": 351,
+    "countryRank": 5
   },
   {
     "name": "University of Maryland at College Park",
@@ -7293,7 +7644,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 352
+    "aggregatedRank": 352,
+    "countryRank": 94
   },
   {
     "name": "University of Sao Paulo",
@@ -7311,7 +7663,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 353
+    "aggregatedRank": 353,
+    "countryRank": 2
   },
   {
     "name": "Fuzhou University",
@@ -7329,7 +7682,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 354
+    "aggregatedRank": 354,
+    "countryRank": 28
   },
   {
     "name": "Institut Polytechnique de Paris",
@@ -7347,7 +7701,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 355
+    "aggregatedRank": 355,
+    "countryRank": 6
   },
   {
     "name": "University of Rome - La Sapienza",
@@ -7365,7 +7720,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 356
+    "aggregatedRank": 356,
+    "countryRank": 19
   },
   {
     "name": "University of Montreal",
@@ -7383,7 +7739,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 357
+    "aggregatedRank": 357,
+    "countryRank": 16
   },
   {
     "name": "Humanitas University",
@@ -7401,7 +7758,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 358
+    "aggregatedRank": 358,
+    "countryRank": 20
   },
   {
     "name": "Northeastern University in China",
@@ -7419,7 +7777,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 359
+    "aggregatedRank": 359,
+    "countryRank": 29
   },
   {
     "name": "University of T�bingen",
@@ -7437,7 +7796,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 360
+    "aggregatedRank": 360,
+    "countryRank": 19
   },
   {
     "name": "G�teborg University",
@@ -7455,7 +7815,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 361
+    "aggregatedRank": 361,
+    "countryRank": 8
   },
   {
     "name": "Qingdao University",
@@ -7473,7 +7834,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 362
+    "aggregatedRank": 362,
+    "countryRank": 30
   },
   {
     "name": "VU University Amsterdam",
@@ -7491,7 +7853,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 363
+    "aggregatedRank": 363,
+    "countryRank": 9
   },
   {
     "name": "Central South University",
@@ -7509,7 +7872,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 364
+    "aggregatedRank": 364,
+    "countryRank": 31
   },
   {
     "name": "Shandong University",
@@ -7527,7 +7891,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 365
+    "aggregatedRank": 365,
+    "countryRank": 32
   },
   {
     "name": "Taif University",
@@ -7545,7 +7910,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 366
+    "aggregatedRank": 366,
+    "countryRank": 5
   },
   {
     "name": "Huazhong University of Science and Technology",
@@ -7563,7 +7929,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 367
+    "aggregatedRank": 367,
+    "countryRank": 33
   },
   {
     "name": "Paris Cit� University",
@@ -7581,7 +7948,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 368
+    "aggregatedRank": 368,
+    "countryRank": 7
   },
   {
     "name": "University of Buenos Aires",
@@ -7599,7 +7967,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 369
+    "aggregatedRank": 369,
+    "countryRank": 1
   },
   {
     "name": "University of Massachusetts - Amherst",
@@ -7617,7 +7986,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 370
+    "aggregatedRank": 370,
+    "countryRank": 95
   },
   {
     "name": "University of Durham",
@@ -7635,7 +8005,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 371
+    "aggregatedRank": 371,
+    "countryRank": 37
   },
   {
     "name": "University of Maastricht",
@@ -7653,7 +8024,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 372
+    "aggregatedRank": 372,
+    "countryRank": 10
   },
   {
     "name": "Southern University of Science and Technology",
@@ -7671,7 +8043,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 373
+    "aggregatedRank": 373,
+    "countryRank": 34
   },
   {
     "name": "Jiangnan University",
@@ -7689,7 +8062,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 374
+    "aggregatedRank": 374,
+    "countryRank": 35
   },
   {
     "name": "Catholic University of Louvain",
@@ -7707,7 +8081,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 375
+    "aggregatedRank": 375,
+    "countryRank": 6
   },
   {
     "name": "Scuola Normale Superiore di Pisa",
@@ -7725,7 +8100,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 376
+    "aggregatedRank": 376,
+    "countryRank": 21
   },
   {
     "name": "Technical University of Dresden",
@@ -7743,7 +8119,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 377
+    "aggregatedRank": 377,
+    "countryRank": 20
   },
   {
     "name": "University of Erlangen-N�rnberg",
@@ -7761,7 +8138,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 378
+    "aggregatedRank": 378,
+    "countryRank": 21
   },
   {
     "name": "Guangzhou University",
@@ -7779,7 +8157,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 379
+    "aggregatedRank": 379,
+    "countryRank": 36
   },
   {
     "name": "Nanjing Forestry University",
@@ -7797,7 +8176,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 380
+    "aggregatedRank": 380,
+    "countryRank": 37
   },
   {
     "name": "Rush University",
@@ -7815,7 +8195,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 381
+    "aggregatedRank": 381,
+    "countryRank": 96
   },
   {
     "name": "University of Frankfurt am Main",
@@ -7833,7 +8214,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 382
+    "aggregatedRank": 382,
+    "countryRank": 22
   },
   {
     "name": "Xidian University",
@@ -7851,7 +8233,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 383
+    "aggregatedRank": 383,
+    "countryRank": 38
   },
   {
     "name": "Autonomous University of Barcelona",
@@ -7869,7 +8252,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 384
+    "aggregatedRank": 384,
+    "countryRank": 8
   },
   {
     "name": "Zhengzhou University",
@@ -7887,7 +8271,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 385
+    "aggregatedRank": 385,
+    "countryRank": 39
   },
   {
     "name": "Baylor University",
@@ -7905,7 +8290,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 386
+    "aggregatedRank": 386,
+    "countryRank": 97
   },
   {
     "name": "University of Malaya",
@@ -7923,7 +8309,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 387
+    "aggregatedRank": 387,
+    "countryRank": 1
   },
   {
     "name": "Eindhoven University of Technology",
@@ -7941,7 +8328,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 388
+    "aggregatedRank": 388,
+    "countryRank": 11
   },
   {
     "name": "South China University of Technology",
@@ -7959,7 +8347,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 389
+    "aggregatedRank": 389,
+    "countryRank": 40
   },
   {
     "name": "Ecole Normale Sup�rieure de Lyon",
@@ -7977,7 +8366,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 390
+    "aggregatedRank": 390,
+    "countryRank": 8
   },
   {
     "name": "Chalmers University of Technology",
@@ -7995,7 +8385,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 391
+    "aggregatedRank": 391,
+    "countryRank": 9
   },
   {
     "name": "University Pompeu Fabra",
@@ -8013,7 +8404,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 392
+    "aggregatedRank": 392,
+    "countryRank": 9
   },
   {
     "name": "Swinburne University of Technology",
@@ -8031,7 +8423,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 393
+    "aggregatedRank": 393,
+    "countryRank": 23
   },
   {
     "name": "Jilin University",
@@ -8049,7 +8442,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 394
+    "aggregatedRank": 394,
+    "countryRank": 41
   },
   {
     "name": "Grenoble Alpes University",
@@ -8067,7 +8461,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 395
+    "aggregatedRank": 395,
+    "countryRank": 9
   },
   {
     "name": "Vienna University of Technology",
@@ -8085,7 +8480,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 396
+    "aggregatedRank": 396,
+    "countryRank": 6
   },
   {
     "name": "University of Qatar",
@@ -8103,7 +8499,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 397
+    "aggregatedRank": 397,
+    "countryRank": 1
   },
   {
     "name": "Virginia Polytechnic Institute and State University",
@@ -8121,7 +8518,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 398
+    "aggregatedRank": 398,
+    "countryRank": 98
   },
   {
     "name": "University of Science and Technology Beijing",
@@ -8139,7 +8537,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 399
+    "aggregatedRank": 399,
+    "countryRank": 42
   },
   {
     "name": "University of International Business and Economics",
@@ -8157,7 +8556,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 400
+    "aggregatedRank": 400,
+    "countryRank": 43
   },
   {
     "name": "Indian Institute of Science",
@@ -8175,7 +8575,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 401
+    "aggregatedRank": 401,
+    "countryRank": 1
   },
   {
     "name": "University of Stuttgart",
@@ -8193,7 +8594,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 402
+    "aggregatedRank": 402,
+    "countryRank": 23
   },
   {
     "name": "University of Porto",
@@ -8211,7 +8613,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 403
+    "aggregatedRank": 403,
+    "countryRank": 1
   },
   {
     "name": "Technical University of Darmstadt",
@@ -8229,7 +8632,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 404
+    "aggregatedRank": 404,
+    "countryRank": 24
   },
   {
     "name": "University of Bochum",
@@ -8247,7 +8651,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 405
+    "aggregatedRank": 405,
+    "countryRank": 25
   },
   {
     "name": "Northwestern Polytechnical University",
@@ -8265,7 +8670,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 406
+    "aggregatedRank": 406,
+    "countryRank": 44
   },
   {
     "name": "Technion - Israel Institute of Technology",
@@ -8283,7 +8689,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 407
+    "aggregatedRank": 407,
+    "countryRank": 3
   },
   {
     "name": "University of Mainz",
@@ -8301,7 +8708,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 408
+    "aggregatedRank": 408,
+    "countryRank": 26
   },
   {
     "name": "Jiangsu University",
@@ -8319,7 +8727,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 409
+    "aggregatedRank": 409,
+    "countryRank": 45
   },
   {
     "name": "Tsukuba University",
@@ -8337,7 +8746,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 410
+    "aggregatedRank": 410,
+    "countryRank": 9
   },
   {
     "name": "Zhejiang Normal University",
@@ -8355,7 +8765,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 411
+    "aggregatedRank": 411,
+    "countryRank": 46
   },
   {
     "name": "South China Agricultural University",
@@ -8373,7 +8784,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 412
+    "aggregatedRank": 412,
+    "countryRank": 47
   },
   {
     "name": "University of Montpellier",
@@ -8391,7 +8803,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 413
+    "aggregatedRank": 413,
+    "countryRank": 10
   },
   {
     "name": "King Fahd University of Petroleum & Minerals",
@@ -8409,7 +8822,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 414
+    "aggregatedRank": 414,
+    "countryRank": 6
   },
   {
     "name": "State University of Campinas",
@@ -8427,7 +8841,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 415
+    "aggregatedRank": 415,
+    "countryRank": 3
   },
   {
     "name": "University of Western Sydney",
@@ -8445,7 +8860,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 416
+    "aggregatedRank": 416,
+    "countryRank": 24
   },
   {
     "name": "University of Stellenbosch",
@@ -8463,7 +8879,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 417
+    "aggregatedRank": 417,
+    "countryRank": 7
   },
   {
     "name": "Khalifa University",
@@ -8481,7 +8898,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 418
+    "aggregatedRank": 418,
+    "countryRank": 3
   },
   {
     "name": "Al Azhar University",
@@ -8499,7 +8917,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 419
+    "aggregatedRank": 419,
+    "countryRank": 3
   },
   {
     "name": "China University of Geosciences Wuhan",
@@ -8517,7 +8936,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 420
+    "aggregatedRank": 420,
+    "countryRank": 48
   },
   {
     "name": "National Yang Ming Chiao Tung University",
@@ -8535,7 +8955,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 421
+    "aggregatedRank": 421,
+    "countryRank": 4
   },
   {
     "name": "University of Jena",
@@ -8553,7 +8974,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 422
+    "aggregatedRank": 422,
+    "countryRank": 27
   },
   {
     "name": "Oregon State University",
@@ -8571,7 +8993,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 423
+    "aggregatedRank": 423,
+    "countryRank": 99
   },
   {
     "name": "Flinders University",
@@ -8589,7 +9012,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 424
+    "aggregatedRank": 424,
+    "countryRank": 25
   },
   {
     "name": "University of Ulm",
@@ -8607,7 +9031,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 425
+    "aggregatedRank": 425,
+    "countryRank": 28
   },
   {
     "name": "Keio University",
@@ -8625,7 +9050,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 426
+    "aggregatedRank": 426,
+    "countryRank": 10
   },
   {
     "name": "University of Saskatchewan",
@@ -8643,7 +9069,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 427
+    "aggregatedRank": 427,
+    "countryRank": 17
   },
   {
     "name": "National Autonomous University of Mexico",
@@ -8661,7 +9088,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 428
+    "aggregatedRank": 428,
+    "countryRank": 1
   },
   {
     "name": "University of Cincinnati",
@@ -8679,7 +9107,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 429
+    "aggregatedRank": 429,
+    "countryRank": 100
   },
   {
     "name": "Macau University of Science and Technology",
@@ -8697,7 +9126,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 430
+    "aggregatedRank": 430,
+    "countryRank": 2
   },
   {
     "name": "National Cheng Kung University",
@@ -8715,7 +9145,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 431
+    "aggregatedRank": 431,
+    "countryRank": 5
   },
   {
     "name": "University of Kent at Canterbury",
@@ -8733,7 +9164,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 432
+    "aggregatedRank": 432,
+    "countryRank": 38
   },
   {
     "name": "University of Bordeaux",
@@ -8751,7 +9183,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 433
+    "aggregatedRank": 433,
+    "countryRank": 11
   },
   {
     "name": "National University of Malaysia",
@@ -8769,7 +9202,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 434
+    "aggregatedRank": 434,
+    "countryRank": 2
   },
   {
     "name": "Catholic University of the Sacred Heart",
@@ -8787,7 +9221,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 435
+    "aggregatedRank": 435,
+    "countryRank": 22
   },
   {
     "name": "University of Science - Malaysia",
@@ -8805,7 +9240,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 436
+    "aggregatedRank": 436,
+    "countryRank": 3
   },
   {
     "name": "University of Canterbury",
@@ -8823,7 +9259,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 437
+    "aggregatedRank": 437,
+    "countryRank": 4
   },
   {
     "name": "York University",
@@ -8841,7 +9278,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 438
+    "aggregatedRank": 438,
+    "countryRank": 18
   },
   {
     "name": "Nanjing Agricultural University",
@@ -8859,7 +9297,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 439
+    "aggregatedRank": 439,
+    "countryRank": 49
   },
   {
     "name": "University of Hannover",
@@ -8877,7 +9316,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 440
+    "aggregatedRank": 440,
+    "countryRank": 29
   },
   {
     "name": "Pontifical Catholic University of Chile",
@@ -8895,7 +9335,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 441
+    "aggregatedRank": 441,
+    "countryRank": 1
   },
   {
     "name": "University of Athens",
@@ -8913,7 +9354,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 442
+    "aggregatedRank": 442,
+    "countryRank": 1
   },
   {
     "name": "Renmin University of China",
@@ -8931,7 +9373,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 443
+    "aggregatedRank": 443,
+    "countryRank": 50
   },
   {
     "name": "Moscow Institute of Physics and Technology",
@@ -8949,7 +9392,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 444
+    "aggregatedRank": 444,
+    "countryRank": 2
   },
   {
     "name": "University of Konstanz",
@@ -8967,7 +9411,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 445
+    "aggregatedRank": 445,
+    "countryRank": 30
   },
   {
     "name": "National University of Ireland - Galway",
@@ -8985,7 +9430,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 446
+    "aggregatedRank": 446,
+    "countryRank": 4
   },
   {
     "name": "Loughborough University",
@@ -9003,7 +9449,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 447
+    "aggregatedRank": 447,
+    "countryRank": 39
   },
   {
     "name": "University of Bayreuth",
@@ -9021,7 +9468,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 448
+    "aggregatedRank": 448,
+    "countryRank": 31
   },
   {
     "name": "University of Coimbra",
@@ -9039,7 +9487,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 449
+    "aggregatedRank": 449,
+    "countryRank": 2
   },
   {
     "name": "University of Tampere",
@@ -9057,7 +9506,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 450
+    "aggregatedRank": 450,
+    "countryRank": 4
   },
   {
     "name": "Ben-Gurion University of the Negev",
@@ -9075,7 +9525,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 451
+    "aggregatedRank": 451,
+    "countryRank": 4
   },
   {
     "name": "Jinan University - Guangdong",
@@ -9093,7 +9544,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 452
+    "aggregatedRank": 452,
+    "countryRank": 51
   },
   {
     "name": "Soochow University",
@@ -9111,7 +9563,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 453
+    "aggregatedRank": 453,
+    "countryRank": 52
   },
   {
     "name": "University of Giessen",
@@ -9129,7 +9582,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 454
+    "aggregatedRank": 454,
+    "countryRank": 32
   },
   {
     "name": "Huazhong Agricultural University",
@@ -9147,7 +9601,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 455
+    "aggregatedRank": 455,
+    "countryRank": 53
   },
   {
     "name": "Tilburg University",
@@ -9165,7 +9620,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 456
+    "aggregatedRank": 456,
+    "countryRank": 12
   },
   {
     "name": "Beijing University of Chemical Technology",
@@ -9183,7 +9639,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 457
+    "aggregatedRank": 457,
+    "countryRank": 54
   },
   {
     "name": "University of D�sseldorf",
@@ -9201,7 +9658,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 458
+    "aggregatedRank": 458,
+    "countryRank": 33
   },
   {
     "name": "University of Lugano",
@@ -9219,7 +9677,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 459
+    "aggregatedRank": 459,
+    "countryRank": 8
   },
   {
     "name": "University of Essex",
@@ -9237,7 +9696,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 460
+    "aggregatedRank": 460,
+    "countryRank": 40
   },
   {
     "name": "Murdoch University",
@@ -9255,7 +9715,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 461
+    "aggregatedRank": 461,
+    "countryRank": 26
   },
   {
     "name": "University of Southern Queensland",
@@ -9273,7 +9734,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 462
+    "aggregatedRank": 462,
+    "countryRank": 27
   },
   {
     "name": "University of Guelph",
@@ -9291,7 +9753,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 463
+    "aggregatedRank": 463,
+    "countryRank": 19
   },
   {
     "name": "University of Aveiro",
@@ -9309,7 +9772,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 464
+    "aggregatedRank": 464,
+    "countryRank": 3
   },
   {
     "name": "University of Zagreb",
@@ -9327,7 +9791,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 465
+    "aggregatedRank": 465,
+    "countryRank": 1
   },
   {
     "name": "University of Bremen",
@@ -9345,7 +9810,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 466
+    "aggregatedRank": 466,
+    "countryRank": 34
   },
   {
     "name": "University of South Carolina",
@@ -9363,7 +9829,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 467
+    "aggregatedRank": 467,
+    "countryRank": 101
   },
   {
     "name": "Federal University of Rio de Janeiro",
@@ -9381,7 +9848,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 468
+    "aggregatedRank": 468,
+    "countryRank": 4
   },
   {
     "name": "Masaryk University",
@@ -9399,7 +9867,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 469
+    "aggregatedRank": 469,
+    "countryRank": 2
   },
   {
     "name": "Kyungpook National University",
@@ -9417,7 +9886,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 470
+    "aggregatedRank": 470,
+    "countryRank": 11
   },
   {
     "name": "Ain Shams University",
@@ -9435,7 +9905,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 471
+    "aggregatedRank": 471,
+    "countryRank": 4
   },
   {
     "name": "Brandeis University",
@@ -9453,7 +9924,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 472
+    "aggregatedRank": 472,
+    "countryRank": 102
   },
   {
     "name": "Pusan National University",
@@ -9471,7 +9943,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 473
+    "aggregatedRank": 473,
+    "countryRank": 12
   },
   {
     "name": "Chulalongkorn University",
@@ -9489,7 +9962,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 474
+    "aggregatedRank": 474,
+    "countryRank": 1
   },
   {
     "name": "Ocean University of China",
@@ -9507,7 +9981,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 475
+    "aggregatedRank": 475,
+    "countryRank": 55
   },
   {
     "name": "University of Waikato",
@@ -9525,7 +10000,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 476
+    "aggregatedRank": 476,
+    "countryRank": 5
   },
   {
     "name": "Polytechnic University of Valencia",
@@ -9543,7 +10019,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 477
+    "aggregatedRank": 477,
+    "countryRank": 10
   },
   {
     "name": "University of Fribourg",
@@ -9561,7 +10038,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 478
+    "aggregatedRank": 478,
+    "countryRank": 9
   },
   {
     "name": "University of Belgrade",
@@ -9579,7 +10057,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 479
+    "aggregatedRank": 479,
+    "countryRank": 1
   },
   {
     "name": "Koc University",
@@ -9597,7 +10076,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 480
+    "aggregatedRank": 480,
+    "countryRank": 2
   },
   {
     "name": "Lebanese American University",
@@ -9615,7 +10095,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 481
+    "aggregatedRank": 481,
+    "countryRank": 2
   },
   {
     "name": "Virginia Commonwealth University",
@@ -9633,7 +10114,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 482
+    "aggregatedRank": 482,
+    "countryRank": 103
   },
   {
     "name": "Heriot-Watt University",
@@ -9651,7 +10133,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 483
+    "aggregatedRank": 483,
+    "countryRank": 41
   },
   {
     "name": "ISCTE-University Institute of Lisbon",
@@ -9669,7 +10152,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 484
+    "aggregatedRank": 484,
+    "countryRank": 4
   },
   {
     "name": "Bangor University",
@@ -9687,7 +10171,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 485
+    "aggregatedRank": 485,
+    "countryRank": 42
   },
   {
     "name": "Princess Nourah bint Abdulrahman University",
@@ -9705,7 +10190,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 486
+    "aggregatedRank": 486,
+    "countryRank": 7
   },
   {
     "name": "University of Cyprus",
@@ -9723,7 +10209,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 487
+    "aggregatedRank": 487,
+    "countryRank": 1
   },
   {
     "name": "National Taiwan University of Science and Technology",
@@ -9741,7 +10228,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 488
+    "aggregatedRank": 488,
+    "countryRank": 6
   },
   {
     "name": "Colorado School of Mines",
@@ -9759,7 +10247,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 489
+    "aggregatedRank": 489,
+    "countryRank": 104
   },
   {
     "name": "Rensselaer Polytechnic Institute",
@@ -9777,7 +10266,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 490
+    "aggregatedRank": 490,
+    "countryRank": 105
   },
   {
     "name": "University of Marburg",
@@ -9795,7 +10285,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 491
+    "aggregatedRank": 491,
+    "countryRank": 35
   },
   {
     "name": "University of New Mexico",
@@ -9813,7 +10304,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 492
+    "aggregatedRank": 492,
+    "countryRank": 106
   },
   {
     "name": "Birkbeck - University of London",
@@ -9831,7 +10323,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 493
+    "aggregatedRank": 493,
+    "countryRank": 43
   },
   {
     "name": "Higher School of Economics",
@@ -9849,7 +10342,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 494
+    "aggregatedRank": 494,
+    "countryRank": 3
   },
   {
     "name": "Concordia University",
@@ -9867,7 +10361,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 495
+    "aggregatedRank": 495,
+    "countryRank": 20
   },
   {
     "name": "Istanbul Technical University",
@@ -9885,7 +10380,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 496
+    "aggregatedRank": 496,
+    "countryRank": 3
   },
   {
     "name": "University of Oklahoma - Norman",
@@ -9903,7 +10399,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 497
+    "aggregatedRank": 497,
+    "countryRank": 107
   },
   {
     "name": "Massey University",
@@ -9921,7 +10418,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 498
+    "aggregatedRank": 498,
+    "countryRank": 6
   },
   {
     "name": "East China University of Science and Technology",
@@ -9939,7 +10437,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 499
+    "aggregatedRank": 499,
+    "countryRank": 56
   },
   {
     "name": "Hasselt University",
@@ -9957,7 +10456,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 500
+    "aggregatedRank": 500,
+    "countryRank": 7
   },
   {
     "name": "Tokyo Medical and Dental University",
@@ -9975,7 +10475,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 501
+    "aggregatedRank": 501,
+    "countryRank": 11
   },
   {
     "name": "Nanjing University of Aeronautics and Astronautics",
@@ -9993,7 +10494,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 502
+    "aggregatedRank": 502,
+    "countryRank": 57
   },
   {
     "name": "Kobe University",
@@ -10011,7 +10513,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 503
+    "aggregatedRank": 503,
+    "countryRank": 12
   },
   {
     "name": "Mahidol University",
@@ -10029,7 +10532,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 504
+    "aggregatedRank": 504,
+    "countryRank": 2
   },
   {
     "name": "Hiroshima University",
@@ -10047,7 +10551,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 505
+    "aggregatedRank": 505,
+    "countryRank": 13
   },
   {
     "name": "Waseda University",
@@ -10065,7 +10570,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 506
+    "aggregatedRank": 506,
+    "countryRank": 14
   },
   {
     "name": "University of Catania",
@@ -10083,7 +10589,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 507
+    "aggregatedRank": 507,
+    "countryRank": 23
   },
   {
     "name": "New University of Lisbon",
@@ -10101,7 +10608,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 508
+    "aggregatedRank": 508,
+    "countryRank": 5
   },
   {
     "name": "Chung-Ang University",
@@ -10119,7 +10627,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 509
+    "aggregatedRank": 509,
+    "countryRank": 13
   },
   {
     "name": "University of Jyvaskyla",
@@ -10137,7 +10646,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 510
+    "aggregatedRank": 510,
+    "countryRank": 5
   },
   {
     "name": "University of Lorraine",
@@ -10155,7 +10665,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 511
+    "aggregatedRank": 511,
+    "countryRank": 12
   },
   {
     "name": "University of Canberra",
@@ -10173,7 +10684,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 512
+    "aggregatedRank": 512,
+    "countryRank": 28
   },
   {
     "name": "Auckland University of Technology",
@@ -10191,7 +10703,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 513
+    "aggregatedRank": 513,
+    "countryRank": 7
   },
   {
     "name": "University of Hull",
@@ -10209,7 +10722,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 514
+    "aggregatedRank": 514,
+    "countryRank": 44
   },
   {
     "name": "University of Lille",
@@ -10227,7 +10741,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 515
+    "aggregatedRank": 515,
+    "countryRank": 13
   },
   {
     "name": "Alexandria University",
@@ -10245,7 +10760,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 516
+    "aggregatedRank": 516,
+    "countryRank": 5
   },
   {
     "name": "University of Northumbria at Newcastle",
@@ -10263,7 +10779,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 517
+    "aggregatedRank": 517,
+    "countryRank": 45
   },
   {
     "name": "University of Leiden",
@@ -10281,7 +10798,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 518
+    "aggregatedRank": 518,
+    "countryRank": 13
   },
   {
     "name": "University of Iceland",
@@ -10299,7 +10817,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 519
+    "aggregatedRank": 519,
+    "countryRank": 1
   },
   {
     "name": "University of Stirling",
@@ -10317,7 +10836,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 520
+    "aggregatedRank": 520,
+    "countryRank": 46
   },
   {
     "name": "Amirkabir University of Technology",
@@ -10335,7 +10855,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 521
+    "aggregatedRank": 521,
+    "countryRank": 3
   },
   {
     "name": "Umm Al-Qura University",
@@ -10353,7 +10874,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 522
+    "aggregatedRank": 522,
+    "countryRank": 8
   },
   {
     "name": "University of Seville",
@@ -10371,7 +10893,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 523
+    "aggregatedRank": 523,
+    "countryRank": 11
   },
   {
     "name": "Dublin City University",
@@ -10389,7 +10912,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 524
+    "aggregatedRank": 524,
+    "countryRank": 5
   },
   {
     "name": "Bar-Ilan University",
@@ -10407,7 +10931,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 525
+    "aggregatedRank": 525,
+    "countryRank": 5
   },
   {
     "name": "University of Linz",
@@ -10425,7 +10950,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 526
+    "aggregatedRank": 526,
+    "countryRank": 7
   },
   {
     "name": "Royal Holloway - University of London",
@@ -10443,7 +10969,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 527
+    "aggregatedRank": 527,
+    "countryRank": 47
   },
   {
     "name": "National Sun Yat-Sen University",
@@ -10461,7 +10988,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 528
+    "aggregatedRank": 528,
+    "countryRank": 7
   },
   {
     "name": "Iran University of Science and Technology Tehran",
@@ -10479,7 +11007,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 529
+    "aggregatedRank": 529,
+    "countryRank": 4
   },
   {
     "name": "Sao Paulo State University",
@@ -10497,7 +11026,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 530
+    "aggregatedRank": 530,
+    "countryRank": 5
   },
   {
     "name": "Cankaya University",
@@ -10512,7 +11042,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 531
+    "aggregatedRank": 531,
+    "countryRank": 4
   },
   {
     "name": "Ulsan University",
@@ -10530,7 +11061,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 532
+    "aggregatedRank": 532,
+    "countryRank": 14
   },
   {
     "name": "Ewha Womans University",
@@ -10548,7 +11080,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 533
+    "aggregatedRank": 533,
+    "countryRank": 15
   },
   {
     "name": "University of Minho",
@@ -10566,7 +11099,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 534
+    "aggregatedRank": 534,
+    "countryRank": 6
   },
   {
     "name": "Taipei Medical University",
@@ -10584,7 +11118,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 535
+    "aggregatedRank": 535,
+    "countryRank": 8
   },
   {
     "name": "University of Limerick",
@@ -10602,7 +11137,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 536
+    "aggregatedRank": 536,
+    "countryRank": 6
   },
   {
     "name": "University of Rennes I",
@@ -10620,7 +11156,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 537
+    "aggregatedRank": 537,
+    "countryRank": 14
   },
   {
     "name": "University of Delhi",
@@ -10638,7 +11175,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 538
+    "aggregatedRank": 538,
+    "countryRank": 2
   },
   {
     "name": "University of C�te d'Azur",
@@ -10656,7 +11194,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 539
+    "aggregatedRank": 539,
+    "countryRank": 15
   },
   {
     "name": "Lanzhou University of Technology",
@@ -10674,7 +11213,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 540
+    "aggregatedRank": 540,
+    "countryRank": 58
   },
   {
     "name": "University of Eastern Finland",
@@ -10692,7 +11232,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 541
+    "aggregatedRank": 541,
+    "countryRank": 6
   },
   {
     "name": "Carleton University",
@@ -10710,7 +11251,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 542
+    "aggregatedRank": 542,
+    "countryRank": 21
   },
   {
     "name": "University of Santiago de Compostela",
@@ -10728,7 +11270,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 543
+    "aggregatedRank": 543,
+    "countryRank": 12
   },
   {
     "name": "University of Putra Malaysia",
@@ -10746,7 +11289,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 544
+    "aggregatedRank": 544,
+    "countryRank": 4
   },
   {
     "name": "Jordan University",
@@ -10764,7 +11308,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 545
+    "aggregatedRank": 545,
+    "countryRank": 1
   },
   {
     "name": "Polytechnic University of Catalonia",
@@ -10782,7 +11327,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 546
+    "aggregatedRank": 546,
+    "countryRank": 13
   },
   {
     "name": "University of Graz",
@@ -10800,7 +11346,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 547
+    "aggregatedRank": 547,
+    "countryRank": 8
   },
   {
     "name": "Kafrelsheikh University",
@@ -10815,7 +11362,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 548
+    "aggregatedRank": 548,
+    "countryRank": 6
   },
   {
     "name": "Texas Technical University",
@@ -10833,7 +11381,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 549
+    "aggregatedRank": 549,
+    "countryRank": 108
   },
   {
     "name": "University of Siegen",
@@ -10851,7 +11400,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 550
+    "aggregatedRank": 550,
+    "countryRank": 24
   },
   {
     "name": "Rutgers - The State University of New Jersey",
@@ -10869,7 +11419,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 551
+    "aggregatedRank": 551,
+    "countryRank": 109
   },
   {
     "name": "University of Hohenheim",
@@ -10887,7 +11438,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 552
+    "aggregatedRank": 552,
+    "countryRank": 36
   },
   {
     "name": "The Manchester Metropolitan University",
@@ -10905,7 +11457,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 553
+    "aggregatedRank": 553,
+    "countryRank": 48
   },
   {
     "name": "Institut National des Sciences Appliqu�es de Toulouse",
@@ -10923,7 +11476,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 554
+    "aggregatedRank": 554,
+    "countryRank": 16
   },
   {
     "name": "Aristotle University of Thessaloniki",
@@ -10941,7 +11495,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 555
+    "aggregatedRank": 555,
+    "countryRank": 2
   },
   {
     "name": "Free University of Bozen-Bolzano",
@@ -10959,7 +11514,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 556
+    "aggregatedRank": 556,
+    "countryRank": 25
   },
   {
     "name": "Graz University of Technology",
@@ -10977,7 +11533,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 557
+    "aggregatedRank": 557,
+    "countryRank": 9
   },
   {
     "name": "Konkuk University",
@@ -10995,7 +11552,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 558
+    "aggregatedRank": 558,
+    "countryRank": 16
   },
   {
     "name": "Chang Gung University",
@@ -11013,7 +11571,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 559
+    "aggregatedRank": 559,
+    "countryRank": 9
   },
   {
     "name": "University of Salamanca",
@@ -11031,7 +11590,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 560
+    "aggregatedRank": 560,
+    "countryRank": 14
   },
   {
     "name": "Sunway University",
@@ -11049,7 +11609,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 561
+    "aggregatedRank": 561,
+    "countryRank": 5
   },
   {
     "name": "Technical University of Braunschweig",
@@ -11067,7 +11628,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 562
+    "aggregatedRank": 562,
+    "countryRank": 37
   },
   {
     "name": "Donghua University - Shanghai",
@@ -11085,7 +11647,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 563
+    "aggregatedRank": 563,
+    "countryRank": 59
   },
   {
     "name": "Georgia State University",
@@ -11103,7 +11666,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 564
+    "aggregatedRank": 564,
+    "countryRank": 110
   },
   {
     "name": "St. Louis University",
@@ -11121,7 +11685,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 565
+    "aggregatedRank": 565,
+    "countryRank": 111
   },
   {
     "name": "National University of Sciences and Technology - Islamabad",
@@ -11139,7 +11704,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 566
+    "aggregatedRank": 566,
+    "countryRank": 3
   },
   {
     "name": "University of Ulster",
@@ -11157,7 +11723,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 567
+    "aggregatedRank": 567,
+    "countryRank": 49
   },
   {
     "name": "University of Plymouth",
@@ -11175,7 +11742,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 568
+    "aggregatedRank": 568,
+    "countryRank": 50
   },
   {
     "name": "E�tv�s Lorand University",
@@ -11193,7 +11761,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 569
+    "aggregatedRank": 569,
+    "countryRank": 1
   },
   {
     "name": "Polytechnic University of Bari",
@@ -11211,7 +11780,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 570
+    "aggregatedRank": 570,
+    "countryRank": 26
   },
   {
     "name": "University of Greenwich",
@@ -11229,7 +11799,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 571
+    "aggregatedRank": 571,
+    "countryRank": 51
   },
   {
     "name": "Vellore Institute of Technology",
@@ -11247,7 +11818,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 572
+    "aggregatedRank": 572,
+    "countryRank": 3
   },
   {
     "name": "Technical University of Dortmund",
@@ -11265,7 +11837,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 573
+    "aggregatedRank": 573,
+    "countryRank": 38
   },
   {
     "name": "Asia University",
@@ -11283,7 +11856,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 574
+    "aggregatedRank": 574,
+    "countryRank": 10
   },
   {
     "name": "National Technical University of Athens",
@@ -11301,7 +11875,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 575
+    "aggregatedRank": 575,
+    "countryRank": 3
   },
   {
     "name": "University of Bradford",
@@ -11319,7 +11894,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 576
+    "aggregatedRank": 576,
+    "countryRank": 52
   },
   {
     "name": "University of Portsmouth",
@@ -11337,7 +11913,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 577
+    "aggregatedRank": 577,
+    "countryRank": 53
   },
   {
     "name": "Marche Polytechnic University",
@@ -11355,7 +11932,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 578
+    "aggregatedRank": 578,
+    "countryRank": 27
   },
   {
     "name": "University of Nantes",
@@ -11373,7 +11951,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 579
+    "aggregatedRank": 579,
+    "countryRank": 17
   },
   {
     "name": "Kansas State University",
@@ -11391,7 +11970,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 580
+    "aggregatedRank": 580,
+    "countryRank": 112
   },
   {
     "name": "Oklahoma State University",
@@ -11409,7 +11989,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 581
+    "aggregatedRank": 581,
+    "countryRank": 113
   },
   {
     "name": "Memorial University of Newfoundland",
@@ -11427,7 +12008,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 582
+    "aggregatedRank": 582,
+    "countryRank": 22
   },
   {
     "name": "University of Technology - Petronas",
@@ -11442,7 +12024,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 583
+    "aggregatedRank": 583,
+    "countryRank": 6
   },
   {
     "name": "Federal University of Minas Gerais",
@@ -11460,7 +12043,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 584
+    "aggregatedRank": 584,
+    "countryRank": 6
   },
   {
     "name": "University of Maryland Baltimore County",
@@ -11478,7 +12062,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 585
+    "aggregatedRank": 585,
+    "countryRank": 114
   },
   {
     "name": "University Carlos III de Madrid",
@@ -11496,7 +12081,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 586
+    "aggregatedRank": 586,
+    "countryRank": 15
   },
   {
     "name": "New Jersey Institute of Technology",
@@ -11514,7 +12100,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 587
+    "aggregatedRank": 587,
+    "countryRank": 115
   },
   {
     "name": "Nottingham Trent University",
@@ -11532,7 +12119,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 588
+    "aggregatedRank": 588,
+    "countryRank": 54
   },
   {
     "name": "Rockefeller University",
@@ -11547,7 +12135,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 589
+    "aggregatedRank": 589,
+    "countryRank": 116
   },
   {
     "name": "University of Salzburg",
@@ -11565,7 +12154,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 590
+    "aggregatedRank": 590,
+    "countryRank": 10
   },
   {
     "name": "University of Crete",
@@ -11583,7 +12173,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 591
+    "aggregatedRank": 591,
+    "countryRank": 4
   },
   {
     "name": "Liverpool John Moores University",
@@ -11601,7 +12192,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 592
+    "aggregatedRank": 592,
+    "countryRank": 55
   },
   {
     "name": "Icahn School of Medicine at Mount Sinai",
@@ -11616,7 +12208,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 593
+    "aggregatedRank": 593,
+    "countryRank": 117
   },
   {
     "name": "Yeshiva University",
@@ -11631,7 +12224,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 594
+    "aggregatedRank": 594,
+    "countryRank": 118
   },
   {
     "name": "University of Modena",
@@ -11649,7 +12243,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 595
+    "aggregatedRank": 595,
+    "countryRank": 28
   },
   {
     "name": "Ajou University",
@@ -11667,7 +12262,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 596
+    "aggregatedRank": 596,
+    "countryRank": 17
   },
   {
     "name": "Inha University",
@@ -11685,7 +12281,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 597
+    "aggregatedRank": 597,
+    "countryRank": 18
   },
   {
     "name": "University of Rovira i Virgili",
@@ -11703,7 +12300,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 598
+    "aggregatedRank": 598,
+    "countryRank": 16
   },
   {
     "name": "Novosibirsk State University",
@@ -11721,7 +12319,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 599
+    "aggregatedRank": 599,
+    "countryRank": 4
   },
   {
     "name": "University of Messina",
@@ -11739,7 +12338,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 600
+    "aggregatedRank": 600,
+    "countryRank": 29
   },
   {
     "name": "University of Ferrara",
@@ -11757,7 +12357,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 601
+    "aggregatedRank": 601,
+    "countryRank": 30
   },
   {
     "name": "State University of New York at Albany",
@@ -11775,7 +12376,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 602
+    "aggregatedRank": 602,
+    "countryRank": 119
   },
   {
     "name": "University of Parma",
@@ -11793,7 +12395,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 603
+    "aggregatedRank": 603,
+    "countryRank": 31
   },
   {
     "name": "Yeungnam University",
@@ -11811,7 +12414,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 604
+    "aggregatedRank": 604,
+    "countryRank": 19
   },
   {
     "name": "Auburn University",
@@ -11829,7 +12433,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 605
+    "aggregatedRank": 605,
+    "countryRank": 120
   },
   {
     "name": "University of Tabriz",
@@ -11847,7 +12452,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 606
+    "aggregatedRank": 606,
+    "countryRank": 5
   },
   {
     "name": "University of Technology - Malaysia",
@@ -11862,7 +12468,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 607
+    "aggregatedRank": 607,
+    "countryRank": 7
   },
   {
     "name": "Weizmann Institute of Science",
@@ -11877,7 +12484,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 608
+    "aggregatedRank": 608,
+    "countryRank": 6
   },
   {
     "name": "Lappeenranta University of Technology",
@@ -11892,7 +12500,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 609
+    "aggregatedRank": 609,
+    "countryRank": 7
   },
   {
     "name": "University of the Punjab",
@@ -11910,7 +12519,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 610
+    "aggregatedRank": 610,
+    "countryRank": 4
   },
   {
     "name": "Qassim University",
@@ -11928,7 +12538,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 611
+    "aggregatedRank": 611,
+    "countryRank": 9
   },
   {
     "name": "University of Haifa",
@@ -11946,7 +12557,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 612
+    "aggregatedRank": 612,
+    "countryRank": 7
   },
   {
     "name": "National University of Ireland - Maynooth",
@@ -11964,7 +12576,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 613
+    "aggregatedRank": 613,
+    "countryRank": 7
   },
   {
     "name": "University of Salerno",
@@ -11982,7 +12595,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 614
+    "aggregatedRank": 614,
+    "countryRank": 32
   },
   {
     "name": "Middle East Technical University",
@@ -11997,7 +12611,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 615
+    "aggregatedRank": 615,
+    "countryRank": 5
   },
   {
     "name": "University of Alcal� de Henares",
@@ -12015,7 +12630,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 616
+    "aggregatedRank": 616,
+    "countryRank": 17
   },
   {
     "name": "Bauman Moscow State Technical University",
@@ -12030,7 +12646,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 617
+    "aggregatedRank": 617,
+    "countryRank": 5
   },
   {
     "name": "London School of Hygiene & Tropical Medicine",
@@ -12045,7 +12662,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 618
+    "aggregatedRank": 618,
+    "countryRank": 56
   },
   {
     "name": "Hacettepe University",
@@ -12063,7 +12681,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 619
+    "aggregatedRank": 619,
+    "countryRank": 6
   },
   {
     "name": "Lehigh University",
@@ -12081,7 +12700,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 620
+    "aggregatedRank": 620,
+    "countryRank": 121
   },
   {
     "name": "Daegu Gyeongbuk Institute of Science and Technology",
@@ -12096,7 +12716,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 621
+    "aggregatedRank": 621,
+    "countryRank": 20
   },
   {
     "name": "King Abdullah University of Science and Technology",
@@ -12111,7 +12732,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 622
+    "aggregatedRank": 622,
+    "countryRank": 10
   },
   {
     "name": "University of Palermo",
@@ -12129,7 +12751,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 623
+    "aggregatedRank": 623,
+    "countryRank": 33
   },
   {
     "name": "Okayama University",
@@ -12147,7 +12770,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 624
+    "aggregatedRank": 624,
+    "countryRank": 15
   },
   {
     "name": "Chonnam National University",
@@ -12165,7 +12789,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 625
+    "aggregatedRank": 625,
+    "countryRank": 21
   },
   {
     "name": "Jordan University of Science and Technology",
@@ -12183,7 +12808,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 626
+    "aggregatedRank": 626,
+    "countryRank": 4
   },
   {
     "name": "University of Mannheim",
@@ -12198,7 +12824,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 627
+    "aggregatedRank": 627,
+    "countryRank": 39
   },
   {
     "name": "Abu Dhabi University",
@@ -12213,7 +12840,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 628
+    "aggregatedRank": 628,
+    "countryRank": 5
   },
   {
     "name": "King Faisal University",
@@ -12231,7 +12859,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 629
+    "aggregatedRank": 629,
+    "countryRank": 11
   },
   {
     "name": "City University London",
@@ -12246,7 +12875,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 630
+    "aggregatedRank": 630,
+    "countryRank": 57
   },
   {
     "name": "Ecole des Ponts ParisTech",
@@ -12261,7 +12891,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 631
+    "aggregatedRank": 631,
+    "countryRank": 18
   },
   {
     "name": "University of New Brunswick",
@@ -12279,7 +12910,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 632
+    "aggregatedRank": 632,
+    "countryRank": 23
   },
   {
     "name": "Chonbuk National University",
@@ -12297,7 +12929,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 633
+    "aggregatedRank": 633,
+    "countryRank": 22
   },
   {
     "name": "Baylor College of Medicine",
@@ -12312,7 +12945,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 634
+    "aggregatedRank": 634,
+    "countryRank": 122
   },
   {
     "name": "Federal University of Sao Paulo",
@@ -12330,7 +12964,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 635
+    "aggregatedRank": 635,
+    "countryRank": 7
   },
   {
     "name": "Norwegian University of Life Sciences",
@@ -12348,7 +12983,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 636
+    "aggregatedRank": 636,
+    "countryRank": 3
   },
   {
     "name": "Catholic University of Korea",
@@ -12366,7 +13002,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 637
+    "aggregatedRank": 637,
+    "countryRank": 23
   },
   {
     "name": "University of Alaska - Fairbanks",
@@ -12384,7 +13021,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 638
+    "aggregatedRank": 638,
+    "countryRank": 123
   },
   {
     "name": "Gwangju Institute of Science and Technology",
@@ -12399,7 +13037,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 639
+    "aggregatedRank": 639,
+    "countryRank": 24
   },
   {
     "name": "Prince Mohammad Bin Fahd University",
@@ -12414,7 +13053,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 640
+    "aggregatedRank": 640,
+    "countryRank": 12
   },
   {
     "name": "Aston University",
@@ -12429,7 +13069,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 641
+    "aggregatedRank": 641,
+    "countryRank": 58
   },
   {
     "name": "Anna University",
@@ -12444,7 +13085,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 642
+    "aggregatedRank": 642,
+    "countryRank": 4
   },
   {
     "name": "Monterrey Institute of Technology and Higher Education",
@@ -12459,7 +13101,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 643
+    "aggregatedRank": 643,
+    "countryRank": 2
   },
   {
     "name": "Sabanci University",
@@ -12474,7 +13117,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 644
+    "aggregatedRank": 644,
+    "countryRank": 7
   },
   {
     "name": "Czech University of Life Sciences Prague",
@@ -12492,7 +13136,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 645
+    "aggregatedRank": 645,
+    "countryRank": 3
   },
   {
     "name": "Lincoln University",
@@ -12507,7 +13152,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 646
+    "aggregatedRank": 646,
+    "countryRank": 8
   },
   {
     "name": "University of Brunei Darussalam",
@@ -12522,7 +13168,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 647
+    "aggregatedRank": 647,
+    "countryRank": 1
   },
   {
     "name": "School of Oriental and African Studies - University of London",
@@ -12537,7 +13184,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 648
+    "aggregatedRank": 648,
+    "countryRank": 59
   },
   {
     "name": "University of Hertfordshire",
@@ -12555,7 +13203,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 649
+    "aggregatedRank": 649,
+    "countryRank": 60
   },
   {
     "name": "University of Alabama",
@@ -12573,7 +13222,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 650
+    "aggregatedRank": 650,
+    "countryRank": 124
   },
   {
     "name": "Peoples' Friendship University of Russia",
@@ -12588,7 +13238,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 651
+    "aggregatedRank": 651,
+    "countryRank": 6
   },
   {
     "name": "Missouri University of Science and Technology",
@@ -12603,7 +13254,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 652
+    "aggregatedRank": 652,
+    "countryRank": 125
   },
   {
     "name": "Tomsk State University",
@@ -12618,7 +13270,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 653
+    "aggregatedRank": 653,
+    "countryRank": 7
   },
   {
     "name": "American University of Sharjah",
@@ -12633,7 +13286,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 654
+    "aggregatedRank": 654,
+    "countryRank": 6
   },
   {
     "name": "Sciences Po - Paris",
@@ -12648,7 +13302,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 655
+    "aggregatedRank": 655,
+    "countryRank": 19
   },
   {
     "name": "Illinois Institute of Technology",
@@ -12663,7 +13318,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 656
+    "aggregatedRank": 656,
+    "countryRank": 126
   },
   {
     "name": "National Taiwan Normal University",
@@ -12678,7 +13334,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 657
+    "aggregatedRank": 657,
+    "countryRank": 11
   },
   {
     "name": "Al Ain University",
@@ -12693,7 +13350,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 658
+    "aggregatedRank": 658,
+    "countryRank": 7
   },
   {
     "name": "Sultan Qaboos University",
@@ -12708,7 +13366,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 659
+    "aggregatedRank": 659,
+    "countryRank": 1
   },
   {
     "name": "University of Maryland at Baltimore",
@@ -12723,7 +13382,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 660
+    "aggregatedRank": 660,
+    "countryRank": 127
   },
   {
     "name": "Zayed University",
@@ -12738,7 +13398,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 661
+    "aggregatedRank": 661,
+    "countryRank": 8
   },
   {
     "name": "University of Cantabria",
@@ -12756,7 +13417,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 662
+    "aggregatedRank": 662,
+    "countryRank": 34
   },
   {
     "name": "Indian Institute of Technology Indore",
@@ -12771,7 +13433,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 663
+    "aggregatedRank": 663,
+    "countryRank": 5
   },
   {
     "name": "Bond University",
@@ -12786,7 +13449,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 664
+    "aggregatedRank": 664,
+    "countryRank": 29
   },
   {
     "name": "Shoolini University of Biotechnology and Management Sciences",
@@ -12801,7 +13465,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 665
+    "aggregatedRank": 665,
+    "countryRank": 6
   },
   {
     "name": "Central Queensland University",
@@ -12816,7 +13481,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 666
+    "aggregatedRank": 666,
+    "countryRank": 30
   },
   {
     "name": "National Research Nuclear University",
@@ -12831,7 +13497,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 667
+    "aggregatedRank": 667,
+    "countryRank": 8
   },
   {
     "name": "University of Huddersfield",
@@ -12846,7 +13513,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 668
+    "aggregatedRank": 668,
+    "countryRank": 61
   },
   {
     "name": "University of Indonesia",
@@ -12861,7 +13529,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 669
+    "aggregatedRank": 669,
+    "countryRank": 1
   },
   {
     "name": "American University in Cairo",
@@ -12876,7 +13545,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 670
+    "aggregatedRank": 670,
+    "countryRank": 7
   },
   {
     "name": "American University of the Middle East",
@@ -12891,7 +13561,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 671
+    "aggregatedRank": 671,
+    "countryRank": 1
   },
   {
     "name": "Imam Abdulrahman Bin Faisal University",
@@ -12906,7 +13577,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 672
+    "aggregatedRank": 672,
+    "countryRank": 13
   },
   {
     "name": "Oxford Brookes University",
@@ -12921,7 +13593,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 673
+    "aggregatedRank": 673,
+    "countryRank": 62
   },
   {
     "name": "Charles Darwin University",
@@ -12936,7 +13609,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 674
+    "aggregatedRank": 674,
+    "countryRank": 31
   },
   {
     "name": "South Ural State University",
@@ -12951,7 +13625,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 675
+    "aggregatedRank": 675,
+    "countryRank": 9
   },
   {
     "name": "University of Windsor",
@@ -12966,7 +13641,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 676
+    "aggregatedRank": 676,
+    "countryRank": 24
   },
   {
     "name": "ShanghaiTech University",
@@ -12981,7 +13657,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 677
+    "aggregatedRank": 677,
+    "countryRank": 60
   },
   {
     "name": "Oregon Health and Science University",
@@ -12996,7 +13673,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 678
+    "aggregatedRank": 678,
+    "countryRank": 128
   },
   {
     "name": "University of Tunis El Manar",
@@ -13014,7 +13692,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 679
+    "aggregatedRank": 679,
+    "countryRank": 1
   },
   {
     "name": "Peter the Great St Petersburg Polytechnic University",
@@ -13029,7 +13708,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 680
+    "aggregatedRank": 680,
+    "countryRank": 10
   },
   {
     "name": "Southern Cross University",
@@ -13044,7 +13724,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 681
+    "aggregatedRank": 681,
+    "countryRank": 32
   },
   {
     "name": "Bilkent University",
@@ -13059,7 +13740,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 682
+    "aggregatedRank": 682,
+    "countryRank": 8
   },
   {
     "name": "University of Texas Health Science Center at San Antonio",
@@ -13074,7 +13756,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 683
+    "aggregatedRank": 683,
+    "countryRank": 129
   },
   {
     "name": "University Panth�on-Sorbonne (Paris I)",
@@ -13089,7 +13772,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 684
+    "aggregatedRank": 684,
+    "countryRank": 20
   },
   {
     "name": "Isfahan University of Technology",
@@ -13104,7 +13788,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 685
+    "aggregatedRank": 685,
+    "countryRank": 6
   },
   {
     "name": "University of Vigo",
@@ -13122,7 +13807,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 686
+    "aggregatedRank": 686,
+    "countryRank": 18
   },
   {
     "name": "Ca' Foscari University of Venice",
@@ -13137,7 +13823,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 687
+    "aggregatedRank": 687,
+    "countryRank": 35
   },
   {
     "name": "Stevens Institute of Technology",
@@ -13152,7 +13839,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 688
+    "aggregatedRank": 688,
+    "countryRank": 130
   },
   {
     "name": "University of Mississippi",
@@ -13167,7 +13855,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 689
+    "aggregatedRank": 689,
+    "countryRank": 131
   },
   {
     "name": "Southern Medical University",
@@ -13182,7 +13871,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 690
+    "aggregatedRank": 690,
+    "countryRank": 61
   },
   {
     "name": "University of Klagenfurt",
@@ -13197,7 +13887,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 691
+    "aggregatedRank": 691,
+    "countryRank": 11
   },
   {
     "name": "Abo Akademi University",
@@ -13212,7 +13903,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 692
+    "aggregatedRank": 692,
+    "countryRank": 8
   },
   {
     "name": "Coventry University",
@@ -13227,7 +13919,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 693
+    "aggregatedRank": 693,
+    "countryRank": 63
   },
   {
     "name": "Victoria University - Melbourne",
@@ -13242,7 +13935,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 694
+    "aggregatedRank": 694,
+    "countryRank": 33
   },
   {
     "name": "Indian Institute of Technology - Guwahati",
@@ -13257,7 +13951,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 695
+    "aggregatedRank": 695,
+    "countryRank": 7
   },
   {
     "name": "Tashkent Institute Irrigation and Agricultural Mechanization Engineers",
@@ -13272,7 +13967,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 696
+    "aggregatedRank": 696,
+    "countryRank": 1
   },
   {
     "name": "Charles Sturt University",
@@ -13290,7 +13986,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 697
+    "aggregatedRank": 697,
+    "countryRank": 34
   },
   {
     "name": "University of Regina",
@@ -13308,7 +14005,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 698
+    "aggregatedRank": 698,
+    "countryRank": 25
   },
   {
     "name": "Bournemouth University",
@@ -13323,7 +14021,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 699
+    "aggregatedRank": 699,
+    "countryRank": 64
   },
   {
     "name": "Goldsmiths College - University of London",
@@ -13338,7 +14037,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 700
+    "aggregatedRank": 700,
+    "countryRank": 65
   },
   {
     "name": "Hannover Medical School",
@@ -13353,7 +14053,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 701
+    "aggregatedRank": 701,
+    "countryRank": 40
   },
   {
     "name": "Kazan Federal University",
@@ -13368,7 +14069,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 702
+    "aggregatedRank": 702,
+    "countryRank": 11
   },
   {
     "name": "Swedish University of Agricultural Sciences",
@@ -13383,7 +14085,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 703
+    "aggregatedRank": 703,
+    "countryRank": 10
   },
   {
     "name": "Manipal University",
@@ -13401,7 +14104,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 704
+    "aggregatedRank": 704,
+    "countryRank": 8
   },
   {
     "name": "Roma Tre University",
@@ -13419,7 +14123,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 705
+    "aggregatedRank": 705,
+    "countryRank": 36
   },
   {
     "name": "Pontifical Catholic University of Rio de Janeiro",
@@ -13434,7 +14139,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 706
+    "aggregatedRank": 706,
+    "countryRank": 8
   },
   {
     "name": "Eastern Mediterranean University",
@@ -13449,7 +14155,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 707
+    "aggregatedRank": 707,
+    "countryRank": 2
   },
   {
     "name": "Tallinn University of Technology",
@@ -13464,7 +14171,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 708
+    "aggregatedRank": 708,
+    "countryRank": 2
   },
   {
     "name": "Uit the Arctic University of Norway",
@@ -13479,7 +14187,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 709
+    "aggregatedRank": 709,
+    "countryRank": 4
   },
   {
     "name": "Middlesex University",
@@ -13494,7 +14203,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 710
+    "aggregatedRank": 710,
+    "countryRank": 66
   },
   {
     "name": "Beirut Arab University",
@@ -13509,7 +14219,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 711
+    "aggregatedRank": 711,
+    "countryRank": 3
   },
   {
     "name": "University of Tenaga Nasional",
@@ -13524,7 +14235,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 712
+    "aggregatedRank": 712,
+    "countryRank": 8
   },
   {
     "name": "Symbiosis International University",
@@ -13539,7 +14251,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 713
+    "aggregatedRank": 713,
+    "countryRank": 9
   },
   {
     "name": "Aberystwyth University",
@@ -13554,7 +14267,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 714
+    "aggregatedRank": 714,
+    "countryRank": 67
   },
   {
     "name": "University of C�rdoba",
@@ -13572,7 +14286,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 715
+    "aggregatedRank": 715,
+    "countryRank": 19
   },
   {
     "name": "University of Lahore",
@@ -13590,7 +14305,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 716
+    "aggregatedRank": 716,
+    "countryRank": 5
   },
   {
     "name": "University of Central Lancashire",
@@ -13608,7 +14324,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 717
+    "aggregatedRank": 717,
+    "countryRank": 68
   },
   {
     "name": "Ramon Llull University",
@@ -13623,7 +14340,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 718
+    "aggregatedRank": 718,
+    "countryRank": 20
   },
   {
     "name": "Westlake University",
@@ -13638,7 +14356,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 719
+    "aggregatedRank": 719,
+    "countryRank": 62
   },
   {
     "name": "Keele University",
@@ -13653,7 +14372,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 720
+    "aggregatedRank": 720,
+    "countryRank": 69
   },
   {
     "name": "Central China Normal University (Huazhong Normal University)",
@@ -13668,7 +14388,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 721
+    "aggregatedRank": 721,
+    "countryRank": 63
   },
   {
     "name": "University of Petroleum and Energy Studies",
@@ -13683,7 +14404,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 722
+    "aggregatedRank": 722,
+    "countryRank": 10
   },
   {
     "name": "Edinburgh Napier University",
@@ -13698,7 +14420,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 723
+    "aggregatedRank": 723,
+    "countryRank": 70
   },
   {
     "name": "De Montfort University",
@@ -13713,7 +14436,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 724
+    "aggregatedRank": 724,
+    "countryRank": 71
   },
   {
     "name": "American University",
@@ -13728,7 +14452,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 725
+    "aggregatedRank": 725,
+    "countryRank": 132
   },
   {
     "name": "National University of Science and Technology MISiS",
@@ -13743,7 +14468,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 726
+    "aggregatedRank": 726,
+    "countryRank": 12
   },
   {
     "name": "Lahore University of Management Sciences",
@@ -13758,7 +14484,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 727
+    "aggregatedRank": 727,
+    "countryRank": 6
   },
   {
     "name": "University of the West of England - Bristol",
@@ -13773,7 +14500,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 728
+    "aggregatedRank": 728,
+    "countryRank": 72
   },
   {
     "name": "University of Malaysia - Pahang",
@@ -13788,7 +14516,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 729
+    "aggregatedRank": 729,
+    "countryRank": 9
   },
   {
     "name": "University of Engineering and Technology Taxila",
@@ -13803,7 +14532,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 730
+    "aggregatedRank": 730,
+    "countryRank": 7
   },
   {
     "name": "Applied Science Private University of Jordan",
@@ -13818,7 +14548,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 731
+    "aggregatedRank": 731,
+    "countryRank": 2
   },
   {
     "name": "University of Quebec",
@@ -13833,7 +14564,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 732
+    "aggregatedRank": 732,
+    "countryRank": 26
   },
   {
     "name": "Jamia Millia Islamia University",
@@ -13848,7 +14580,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 733
+    "aggregatedRank": 733,
+    "countryRank": 11
   },
   {
     "name": "Yangzhou University",
@@ -13863,7 +14596,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 734
+    "aggregatedRank": 734,
+    "countryRank": 64
   },
   {
     "name": "Capital University of Medical Sciences",
@@ -13878,7 +14612,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 735
+    "aggregatedRank": 735,
+    "countryRank": 65
   },
   {
     "name": "University of Technology Brunei",
@@ -13893,7 +14628,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 736
+    "aggregatedRank": 736,
+    "countryRank": 2
   },
   {
     "name": "University of Debrecen",
@@ -13908,7 +14644,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 737
+    "aggregatedRank": 737,
+    "countryRank": 2
   },
   {
     "name": "Sogang University",
@@ -13923,7 +14660,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 738
+    "aggregatedRank": 738,
+    "countryRank": 25
   },
   {
     "name": "Tomsk Polytechnic University",
@@ -13938,7 +14676,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 739
+    "aggregatedRank": 739,
+    "countryRank": 13
   },
   {
     "name": "Jawaharlal Nehru University",
@@ -13953,7 +14692,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 740
+    "aggregatedRank": 740,
+    "countryRank": 12
   },
   {
     "name": "Management and Science University",
@@ -13968,7 +14708,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 741
+    "aggregatedRank": 741,
+    "countryRank": 10
   },
   {
     "name": "University of Mons-Hainaut",
@@ -13983,7 +14724,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 742
+    "aggregatedRank": 742,
+    "countryRank": 8
   },
   {
     "name": "Alfaisal University",
@@ -13998,7 +14740,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 743
+    "aggregatedRank": 743,
+    "countryRank": 14
   },
   {
     "name": "ITMO University",
@@ -14013,7 +14756,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 744
+    "aggregatedRank": 744,
+    "countryRank": 14
   },
   {
     "name": "Northern Arizona University",
@@ -14028,7 +14772,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 745
+    "aggregatedRank": 745,
+    "countryRank": 133
   },
   {
     "name": "Kingston University",
@@ -14043,7 +14788,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 746
+    "aggregatedRank": 746,
+    "countryRank": 73
   },
   {
     "name": "Toronto Metropolitan University",
@@ -14058,7 +14804,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 747
+    "aggregatedRank": 747,
+    "countryRank": 27
   },
   {
     "name": "Birla Institute of Technology and Science",
@@ -14073,7 +14820,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 748
+    "aggregatedRank": 748,
+    "countryRank": 13
   },
   {
     "name": "University of Stavanger",
@@ -14088,7 +14836,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 749
+    "aggregatedRank": 749,
+    "countryRank": 5
   },
   {
     "name": "University of Brighton",
@@ -14103,7 +14852,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 750
+    "aggregatedRank": 750,
+    "countryRank": 74
   },
   {
     "name": "London South Bank University",
@@ -14118,7 +14868,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 751
+    "aggregatedRank": 751,
+    "countryRank": 75
   },
   {
     "name": "Al-Ahliyya Amman University",
@@ -14133,7 +14884,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 752
+    "aggregatedRank": 752,
+    "countryRank": 3
   },
   {
     "name": "Semmelweis University",
@@ -14148,7 +14900,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 753
+    "aggregatedRank": 753,
+    "countryRank": 3
   },
   {
     "name": "Savitribai Phule Pune University",
@@ -14163,7 +14916,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 754
+    "aggregatedRank": 754,
+    "countryRank": 14
   },
   {
     "name": "Zagazig University",
@@ -14178,7 +14932,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 755
+    "aggregatedRank": 755,
+    "countryRank": 8
   },
   {
     "name": "Thapar University",
@@ -14193,7 +14948,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 756
+    "aggregatedRank": 756,
+    "countryRank": 15
   },
   {
     "name": "University of Lincoln (England)",
@@ -14208,7 +14964,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 757
+    "aggregatedRank": 757,
+    "countryRank": 76
   },
   {
     "name": "Thomas Jefferson University",
@@ -14223,7 +14980,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 758
+    "aggregatedRank": 758,
+    "countryRank": 134
   },
   {
     "name": "University of California - Merced",
@@ -14238,7 +14996,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 759
+    "aggregatedRank": 759,
+    "countryRank": 135
   },
   {
     "name": "Guangdong University of Technology",
@@ -14253,7 +15012,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 760
+    "aggregatedRank": 760,
+    "countryRank": 66
   },
   {
     "name": "Shiraz University of Technology",
@@ -14268,7 +15028,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 761
+    "aggregatedRank": 761,
+    "countryRank": 7
   },
   {
     "name": "National Institute of Technology Tiruchirappalli",
@@ -14283,7 +15044,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 762
+    "aggregatedRank": 762,
+    "countryRank": 16
   },
   {
     "name": "Future University in Egypt",
@@ -14298,7 +15060,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 763
+    "aggregatedRank": 763,
+    "countryRank": 9
   },
   {
     "name": "Imam Muhammad Ibn Saud Islamic University",
@@ -14313,7 +15076,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 764
+    "aggregatedRank": 764,
+    "countryRank": 15
   },
   {
     "name": "Worcester Polytechnic Institute",
@@ -14328,7 +15092,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 765
+    "aggregatedRank": 765,
+    "countryRank": 136
   },
   {
     "name": "Tuscia University",
@@ -14343,7 +15108,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 766
+    "aggregatedRank": 766,
+    "countryRank": 37
   },
   {
     "name": "University of Westminster",
@@ -14358,7 +15124,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 767
+    "aggregatedRank": 767,
+    "countryRank": 77
   },
   {
     "name": "University of Malta",
@@ -14373,7 +15140,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 768
+    "aggregatedRank": 768,
+    "countryRank": 1
   },
   {
     "name": "University of the Western Cape",
@@ -14388,7 +15156,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 769
+    "aggregatedRank": 769,
+    "countryRank": 8
   },
   {
     "name": "University of Denver",
@@ -14403,7 +15172,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 770
+    "aggregatedRank": 770,
+    "countryRank": 137
   },
   {
     "name": "Clark University",
@@ -14418,7 +15188,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 771
+    "aggregatedRank": 771,
+    "countryRank": 138
   },
   {
     "name": "St George's - University of London",
@@ -14433,7 +15204,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 772
+    "aggregatedRank": 772,
+    "countryRank": 78
   },
   {
     "name": "University of Arkansas at Fayetteville",
@@ -14448,7 +15220,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 773
+    "aggregatedRank": 773,
+    "countryRank": 139
   },
   {
     "name": "Nanjing Medical University",
@@ -14463,7 +15236,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 774
+    "aggregatedRank": 774,
+    "countryRank": 67
   },
   {
     "name": "Jouf University",
@@ -14478,7 +15252,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 775
+    "aggregatedRank": 775,
+    "countryRank": 16
   },
   {
     "name": "Shahid Beheshti University",
@@ -14493,7 +15268,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 776
+    "aggregatedRank": 776,
+    "countryRank": 8
   },
   {
     "name": "Yildiz Technical University",
@@ -14508,7 +15284,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 777
+    "aggregatedRank": 777,
+    "countryRank": 9
   },
   {
     "name": "CY Cergy Paris University",
@@ -14523,7 +15300,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 778
+    "aggregatedRank": 778,
+    "countryRank": 21
   },
   {
     "name": "University of Greifswald",
@@ -14538,7 +15316,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 779
+    "aggregatedRank": 779,
+    "countryRank": 41
   },
   {
     "name": "Mississippi State University",
@@ -14553,7 +15332,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 780
+    "aggregatedRank": 780,
+    "countryRank": 140
   },
   {
     "name": "Binghamton University",
@@ -14568,7 +15348,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 781
+    "aggregatedRank": 781,
+    "countryRank": 141
   },
   {
     "name": "University of Petroleum (East China)",
@@ -14583,7 +15364,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 782
+    "aggregatedRank": 782,
+    "countryRank": 68
   },
   {
     "name": "Nanjing University of Information Science and Technology",
@@ -14598,7 +15380,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 783
+    "aggregatedRank": 783,
+    "countryRank": 69
   },
   {
     "name": "North South University",
@@ -14613,7 +15396,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 784
+    "aggregatedRank": 784,
+    "countryRank": 1
   },
   {
     "name": "Catholic University of Portugal",
@@ -14628,7 +15412,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 785
+    "aggregatedRank": 785,
+    "countryRank": 7
   },
   {
     "name": "The Robert Gordon University",
@@ -14643,7 +15428,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 786
+    "aggregatedRank": 786,
+    "countryRank": 79
   },
   {
     "name": "University of Salford",
@@ -14658,7 +15444,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 787
+    "aggregatedRank": 787,
+    "countryRank": 80
   },
   {
     "name": "University of Chile",
@@ -14673,7 +15460,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 788
+    "aggregatedRank": 788,
+    "countryRank": 2
   },
   {
     "name": "Ferdowsi University of Mashhad",
@@ -14688,7 +15476,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 789
+    "aggregatedRank": 789,
+    "countryRank": 9
   },
   {
     "name": "King Mongkut's University of Technology Thonburi",
@@ -14703,7 +15492,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 790
+    "aggregatedRank": 790,
+    "countryRank": 3
   },
   {
     "name": "Saveetha Institute of Medical and Technical Sciences",
@@ -14718,7 +15508,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 791
+    "aggregatedRank": 791,
+    "countryRank": 17
   },
   {
     "name": "�rebro University",
@@ -14733,7 +15524,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 792
+    "aggregatedRank": 792,
+    "countryRank": 11
   },
   {
     "name": "University of Nevada - Las Vegas",
@@ -14748,7 +15540,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 793
+    "aggregatedRank": 793,
+    "countryRank": 142
   },
   {
     "name": "University of Toledo",
@@ -14763,7 +15556,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 794
+    "aggregatedRank": 794,
+    "countryRank": 143
   },
   {
     "name": "University of Texas at San Antonio",
@@ -14778,7 +15572,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 795
+    "aggregatedRank": 795,
+    "countryRank": 144
   },
   {
     "name": "Wenzhou University",
@@ -14793,7 +15588,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 796
+    "aggregatedRank": 796,
+    "countryRank": 70
   },
   {
     "name": "Prince Sattam Bin Abdulaziz University",
@@ -14808,7 +15604,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 797
+    "aggregatedRank": 797,
+    "countryRank": 17
   },
   {
     "name": "Nanjing Normal University",
@@ -14823,7 +15620,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 798
+    "aggregatedRank": 798,
+    "countryRank": 71
   },
   {
     "name": "Southwest Jiaotong University",
@@ -14838,7 +15636,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 799
+    "aggregatedRank": 799,
+    "countryRank": 72
   },
   {
     "name": "Guangzhou Medical University",
@@ -14853,7 +15652,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 800
+    "aggregatedRank": 800,
+    "countryRank": 73
   },
   {
     "name": "University of Strasbourg",
@@ -14868,7 +15668,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 801
+    "aggregatedRank": 801,
+    "countryRank": 22
   },
   {
     "name": "Universite Paris Cite",
@@ -14880,7 +15681,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 802
+    "aggregatedRank": 802,
+    "countryRank": 23
   },
   {
     "name": "KU Leuven",
@@ -14892,7 +15694,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 803
+    "aggregatedRank": 803,
+    "countryRank": 9
   },
   {
     "name": "University of Munich",
@@ -14904,7 +15707,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 804
+    "aggregatedRank": 804,
+    "countryRank": 42
   },
   {
     "name": "Leiden University",
@@ -14916,7 +15720,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 805
+    "aggregatedRank": 805,
+    "countryRank": 14
   },
   {
     "name": "Sorbonne Universite",
@@ -14928,7 +15733,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 806
+    "aggregatedRank": 806,
+    "countryRank": 24
   },
   {
     "name": "University of Chinese Academy of Sciences",
@@ -14940,7 +15746,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 807
+    "aggregatedRank": 807,
+    "countryRank": 74
   },
   {
     "name": "Vrije Universiteit Amsterdam",
@@ -14952,7 +15759,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 808
+    "aggregatedRank": 808,
+    "countryRank": 15
   },
   {
     "name": "Technical University of Munich",
@@ -14964,7 +15772,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 809
+    "aggregatedRank": 809,
+    "countryRank": 43
   },
   {
     "name": "Tehran University of Medical Sciences",
@@ -14979,7 +15788,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 810
+    "aggregatedRank": 810,
+    "countryRank": 10
   },
   {
     "name": "Campus Bio-Medico University of Rome",
@@ -14994,7 +15804,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 811
+    "aggregatedRank": 811,
+    "countryRank": 38
   },
   {
     "name": "Royal Veterinary College",
@@ -15009,7 +15820,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 812
+    "aggregatedRank": 812,
+    "countryRank": 81
   },
   {
     "name": "University of the Sunshine Coast",
@@ -15024,7 +15836,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 813
+    "aggregatedRank": 813,
+    "countryRank": 35
   },
   {
     "name": "Ohio University",
@@ -15039,7 +15852,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 814
+    "aggregatedRank": 814,
+    "countryRank": 145
   },
   {
     "name": "University of Texas at Arlington",
@@ -15054,7 +15868,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 815
+    "aggregatedRank": 815,
+    "countryRank": 146
   },
   {
     "name": "University of Wyoming",
@@ -15069,7 +15884,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 816
+    "aggregatedRank": 816,
+    "countryRank": 147
   },
   {
     "name": "Shahid Beheshti University of Medical Sciences",
@@ -15084,7 +15900,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 817
+    "aggregatedRank": 817,
+    "countryRank": 11
   },
   {
     "name": "Harbin Engineering University",
@@ -15099,7 +15916,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 818
+    "aggregatedRank": 818,
+    "countryRank": 75
   },
   {
     "name": "Wenzhou Medical University",
@@ -15114,7 +15932,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 819
+    "aggregatedRank": 819,
+    "countryRank": 76
   },
   {
     "name": "Ghent University",
@@ -15126,7 +15945,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 820
+    "aggregatedRank": 820,
+    "countryRank": 10
   },
   {
     "name": "UT Southwestern Medical Center",
@@ -15138,7 +15958,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 821
+    "aggregatedRank": 821,
+    "countryRank": 148
   },
   {
     "name": "Universite PSL",
@@ -15150,7 +15971,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 822
+    "aggregatedRank": 822,
+    "countryRank": 25
   },
   {
     "name": "Universidade de Sao Paulo",
@@ -15162,7 +15984,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 823
+    "aggregatedRank": 823,
+    "countryRank": 9
   },
   {
     "name": "Sapienza University of Rome",
@@ -15174,7 +15997,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 824
+    "aggregatedRank": 824,
+    "countryRank": 39
   },
   {
     "name": "Medical Campus",
@@ -15186,7 +16010,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 825
+    "aggregatedRank": 825,
+    "countryRank": 149
   },
   {
     "name": "University of Gothenburg",
@@ -15198,7 +16023,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 826
+    "aggregatedRank": 826,
+    "countryRank": 12
   },
   {
     "name": "Université de Montréal",
@@ -15210,7 +16036,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 827
+    "aggregatedRank": 827,
+    "countryRank": 28
   },
   {
     "name": "Maastricht University",
@@ -15222,7 +16049,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 828
+    "aggregatedRank": 828,
+    "countryRank": 16
   },
   {
     "name": "University of Leipzig",
@@ -15237,7 +16065,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 829
+    "aggregatedRank": 829,
+    "countryRank": 44
   },
   {
     "name": "Technische Universitat Dresden",
@@ -15249,7 +16078,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 830
+    "aggregatedRank": 830,
+    "countryRank": 45
   },
   {
     "name": "Universite Catholique Louvain",
@@ -15261,7 +16091,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 831
+    "aggregatedRank": 831,
+    "countryRank": 11
   },
   {
     "name": "Indian Institute of Technology - Delhi",
@@ -15276,7 +16107,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 832
+    "aggregatedRank": 832,
+    "countryRank": 18
   },
   {
     "name": "University of Wuppertal",
@@ -15291,7 +16123,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 833
+    "aggregatedRank": 833,
+    "countryRank": 46
   },
   {
     "name": "University of Nebraska Medical Center",
@@ -15306,7 +16139,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 834
+    "aggregatedRank": 834,
+    "countryRank": 150
   },
   {
     "name": "Wroclaw Medical University",
@@ -15321,7 +16155,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 835
+    "aggregatedRank": 835,
+    "countryRank": 3
   },
   {
     "name": "South China Normal University",
@@ -15336,7 +16171,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 836
+    "aggregatedRank": 836,
+    "countryRank": 77
   },
   {
     "name": "Aligarh Muslim University",
@@ -15351,7 +16187,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 837
+    "aggregatedRank": 837,
+    "countryRank": 19
   },
   {
     "name": "University of Cagliari",
@@ -15366,7 +16203,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 838
+    "aggregatedRank": 838,
+    "countryRank": 40
   },
   {
     "name": "Florida Atlantic University",
@@ -15381,7 +16219,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 839
+    "aggregatedRank": 839,
+    "countryRank": 151
   },
   {
     "name": "Gachon University",
@@ -15396,7 +16235,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 840
+    "aggregatedRank": 840,
+    "countryRank": 26
   },
   {
     "name": "North China Electric Power University",
@@ -15411,7 +16251,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 841
+    "aggregatedRank": 841,
+    "countryRank": 78
   },
   {
     "name": "Northeast Agricultural University",
@@ -15426,7 +16267,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 842
+    "aggregatedRank": 842,
+    "countryRank": 79
   },
   {
     "name": "Northeast Normal University",
@@ -15441,7 +16283,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 843
+    "aggregatedRank": 843,
+    "countryRank": 80
   },
   {
     "name": "Jaume I University",
@@ -15456,7 +16299,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 844
+    "aggregatedRank": 844,
+    "countryRank": 21
   },
   {
     "name": "University of the Balearic Islands",
@@ -15471,7 +16315,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 845
+    "aggregatedRank": 845,
+    "countryRank": 22
   },
   {
     "name": "University Clermont Auvergne",
@@ -15486,7 +16331,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 846
+    "aggregatedRank": 846,
+    "countryRank": 26
   },
   {
     "name": "National and Kapodistrian University of Athens",
@@ -15498,7 +16344,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 847
+    "aggregatedRank": 847,
+    "countryRank": 5
   },
   {
     "name": "Universite de Montpellier",
@@ -15510,7 +16357,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 848
+    "aggregatedRank": 848,
+    "countryRank": 27
   },
   {
     "name": "Universidade de Lisboa",
@@ -15522,7 +16370,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 849
+    "aggregatedRank": 849,
+    "countryRank": 8
   },
   {
     "name": "St. Petersburg State University",
@@ -15537,7 +16386,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 850
+    "aggregatedRank": 850,
+    "countryRank": 15
   },
   {
     "name": "Goethe University Frankfurt",
@@ -15549,7 +16399,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 851
+    "aggregatedRank": 851,
+    "countryRank": 47
   },
   {
     "name": "Universite Grenoble Alpes (UGA)",
@@ -15561,7 +16412,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 852
+    "aggregatedRank": 852,
+    "countryRank": 28
   },
   {
     "name": "The London School of Economics and Political Science (LSE)",
@@ -15573,7 +16425,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 853
+    "aggregatedRank": 853,
+    "countryRank": 82
   },
   {
     "name": "Royal Institute of Technology",
@@ -15585,7 +16438,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 854
+    "aggregatedRank": 854,
+    "countryRank": 13
   },
   {
     "name": "Charit� - University Medicine Berlin",
@@ -15597,7 +16451,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 855
+    "aggregatedRank": 855,
+    "countryRank": 48
   },
   {
     "name": "Pompeu Fabra University",
@@ -15609,7 +16464,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 856
+    "aggregatedRank": 856,
+    "countryRank": 23
   },
   {
     "name": "Universidade do Porto",
@@ -15621,7 +16477,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 857
+    "aggregatedRank": 857,
+    "countryRank": 9
   },
   {
     "name": "State University",
@@ -15633,7 +16490,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 858
+    "aggregatedRank": 858,
+    "countryRank": 152
   },
   {
     "name": "Western Sydney University",
@@ -15645,7 +16503,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 859
+    "aggregatedRank": 859,
+    "countryRank": 36
   },
   {
     "name": "Universite de Bordeaux",
@@ -15657,7 +16516,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 860
+    "aggregatedRank": 860,
+    "countryRank": 29
   },
   {
     "name": "Universiti Malaya",
@@ -15669,7 +16529,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 861
+    "aggregatedRank": 861,
+    "countryRank": 11
   },
   {
     "name": "University of Erlangen Nuremberg",
@@ -15681,7 +16542,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 862
+    "aggregatedRank": 862,
+    "countryRank": 49
   },
   {
     "name": "Durham University",
@@ -15693,7 +16555,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 863
+    "aggregatedRank": 863,
+    "countryRank": 83
   },
   {
     "name": "Stellenbosch University",
@@ -15705,7 +16568,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 864
+    "aggregatedRank": 864,
+    "countryRank": 9
   },
   {
     "name": "Soochow University - China",
@@ -15717,7 +16581,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 865
+    "aggregatedRank": 865,
+    "countryRank": 81
   },
   {
     "name": "Universite de Strasbourg",
@@ -15729,7 +16594,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 866
+    "aggregatedRank": 866,
+    "countryRank": 30
   },
   {
     "name": "University of Lagos",
@@ -15741,7 +16607,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 867
+    "aggregatedRank": 867,
+    "countryRank": 1
   },
   {
     "name": "Leipzig University",
@@ -15753,7 +16620,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 868
+    "aggregatedRank": 868,
+    "countryRank": 50
   },
   {
     "name": "Ege University",
@@ -15768,7 +16636,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 869
+    "aggregatedRank": 869,
+    "countryRank": 8
   },
   {
     "name": "Kaiserslautern University of Technology",
@@ -15783,7 +16652,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 870
+    "aggregatedRank": 870,
+    "countryRank": 51
   },
   {
     "name": "Banaras Hindu University",
@@ -15798,7 +16668,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 871
+    "aggregatedRank": 871,
+    "countryRank": 20
   },
   {
     "name": "University of Udine",
@@ -15813,7 +16684,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 872
+    "aggregatedRank": 872,
+    "countryRank": 41
   },
   {
     "name": "Juntendo University",
@@ -15828,7 +16700,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 873
+    "aggregatedRank": 873,
+    "countryRank": 16
   },
   {
     "name": "Xi'an Jiaotong Liverpool University",
@@ -15843,7 +16716,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 874
+    "aggregatedRank": 874,
+    "countryRank": 82
   },
   {
     "name": "University of Castilla-La Mancha",
@@ -15858,7 +16732,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 875
+    "aggregatedRank": 875,
+    "countryRank": 24
   },
   {
     "name": "Open University",
@@ -15873,7 +16748,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 876
+    "aggregatedRank": 876,
+    "countryRank": 84
   },
   {
     "name": "University of Eastern Piedmont",
@@ -15888,7 +16764,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 877
+    "aggregatedRank": 877,
+    "countryRank": 42
   },
   {
     "name": "Qatar University",
@@ -15900,7 +16777,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 878
+    "aggregatedRank": 878,
+    "countryRank": 2
   },
   {
     "name": "Universiti Teknologi Malaysia",
@@ -15912,7 +16790,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 879
+    "aggregatedRank": 879,
+    "countryRank": 12
   },
   {
     "name": "St Georges University London",
@@ -15924,7 +16803,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 880
+    "aggregatedRank": 880,
+    "countryRank": 85
   },
   {
     "name": "University of Ibadan",
@@ -15936,7 +16816,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 881
+    "aggregatedRank": 881,
+    "countryRank": 2
   },
   {
     "name": "Ulm University",
@@ -15948,7 +16829,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 882
+    "aggregatedRank": 882,
+    "countryRank": 52
   },
   {
     "name": "Technology & Design",
@@ -15960,7 +16842,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 883
+    "aggregatedRank": 883,
+    "countryRank": 3
   },
   {
     "name": "University Paul Sabatier - Toulouse III",
@@ -15975,7 +16858,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 884
+    "aggregatedRank": 884,
+    "countryRank": 31
   },
   {
     "name": "Islamic Azad University",
@@ -15987,7 +16871,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 885
+    "aggregatedRank": 885,
+    "countryRank": 12
   },
   {
     "name": "Sant'Anna School of Advanced Studies",
@@ -15999,7 +16884,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 886
+    "aggregatedRank": 886,
+    "countryRank": 43
   },
   {
     "name": "Technology Beijing",
@@ -16011,7 +16897,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 887
+    "aggregatedRank": 887,
+    "countryRank": 83
   },
   {
     "name": "Ruhr University Bochum",
@@ -16023,7 +16910,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 888
+    "aggregatedRank": 888,
+    "countryRank": 53
   },
   {
     "name": "Universite de Lille",
@@ -16035,7 +16923,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 889
+    "aggregatedRank": 889,
+    "countryRank": 32
   },
   {
     "name": "Universiti Sains Malaysia",
@@ -16047,7 +16936,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 890
+    "aggregatedRank": 890,
+    "countryRank": 13
   },
   {
     "name": "Jinan University",
@@ -16059,7 +16949,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 891
+    "aggregatedRank": 891,
+    "countryRank": 84
   },
   {
     "name": "Medical University",
@@ -16071,7 +16962,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 892
+    "aggregatedRank": 892,
+    "countryRank": 16
   },
   {
     "name": "Technical University of Madrid",
@@ -16086,7 +16978,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 893
+    "aggregatedRank": 893,
+    "countryRank": 25
   },
   {
     "name": "Flinders University South Australia",
@@ -16098,7 +16991,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 894
+    "aggregatedRank": 894,
+    "countryRank": 37
   },
   {
     "name": "Royal College of Surgeons",
@@ -16110,7 +17004,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 895
+    "aggregatedRank": 895,
+    "countryRank": 8
   },
   {
     "name": "Universidad Nacional Autónoma de México (UNAM)",
@@ -16122,7 +17017,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 896
+    "aggregatedRank": 896,
+    "countryRank": 3
   },
   {
     "name": "Vilnius University",
@@ -16137,7 +17033,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 897
+    "aggregatedRank": 897,
+    "countryRank": 1
   },
   {
     "name": "Nantes Universite",
@@ -16149,7 +17046,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 898
+    "aggregatedRank": 898,
+    "countryRank": 33
   },
   {
     "name": "Universidad de Chile",
@@ -16161,7 +17059,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 899
+    "aggregatedRank": 899,
+    "countryRank": 3
   },
   {
     "name": "Universite de Lorraine",
@@ -16173,7 +17072,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 900
+    "aggregatedRank": 900,
+    "countryRank": 34
   },
   {
     "name": "Chengdu University of Technology",
@@ -16188,7 +17088,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 901
+    "aggregatedRank": 901,
+    "countryRank": 85
   },
   {
     "name": "China Pharmaceutical University",
@@ -16203,7 +17104,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 902
+    "aggregatedRank": 902,
+    "countryRank": 86
   },
   {
     "name": "University Savoie Mont Blanc",
@@ -16218,7 +17120,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 903
+    "aggregatedRank": 903,
+    "countryRank": 35
   },
   {
     "name": "University of Campania Luigi Vanvitelli",
@@ -16233,7 +17136,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 904
+    "aggregatedRank": 904,
+    "countryRank": 44
   },
   {
     "name": "University of Rhode Island",
@@ -16248,7 +17152,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 905
+    "aggregatedRank": 905,
+    "countryRank": 153
   },
   {
     "name": "University of Texas at El Paso",
@@ -16263,7 +17168,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 906
+    "aggregatedRank": 906,
+    "countryRank": 154
   },
   {
     "name": "Old Dominion University",
@@ -16278,7 +17184,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 907
+    "aggregatedRank": 907,
+    "countryRank": 155
   },
   {
     "name": "University of Girona",
@@ -16293,7 +17200,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 908
+    "aggregatedRank": 908,
+    "countryRank": 26
   },
   {
     "name": "York University - Canada",
@@ -16305,7 +17213,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 909
+    "aggregatedRank": 909,
+    "countryRank": 29
   },
   {
     "name": "Tampere University",
@@ -16317,7 +17226,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 910
+    "aggregatedRank": 910,
+    "countryRank": 9
   },
   {
     "name": "University of Szeged",
@@ -16332,7 +17242,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 911
+    "aggregatedRank": 911,
+    "countryRank": 4
   },
   {
     "name": "Universidade de Coimbra",
@@ -16344,7 +17255,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 912
+    "aggregatedRank": 912,
+    "countryRank": 10
   },
   {
     "name": "Universite de Rennes",
@@ -16356,7 +17268,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 913
+    "aggregatedRank": 913,
+    "countryRank": 36
   },
   {
     "name": "Eotvos Lorand University",
@@ -16368,7 +17281,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 914
+    "aggregatedRank": 914,
+    "countryRank": 5
   },
   {
     "name": "University of Tsukuba",
@@ -16380,7 +17294,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 915
+    "aggregatedRank": 915,
+    "countryRank": 17
   },
   {
     "name": "Assiut University",
@@ -16392,7 +17307,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 916
+    "aggregatedRank": 916,
+    "countryRank": 10
   },
   {
     "name": "University of Indianapolis",
@@ -16404,7 +17320,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 917
+    "aggregatedRank": 917,
+    "countryRank": 156
   },
   {
     "name": "Hohai University",
@@ -16416,7 +17333,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 918
+    "aggregatedRank": 918,
+    "countryRank": 87
   },
   {
     "name": "Saarland University",
@@ -16431,7 +17349,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 919
+    "aggregatedRank": 919,
+    "countryRank": 54
   },
   {
     "name": "Donghua University",
@@ -16443,7 +17362,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 920
+    "aggregatedRank": 920,
+    "countryRank": 88
   },
   {
     "name": "Justus Liebig University Giessen",
@@ -16455,7 +17375,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 921
+    "aggregatedRank": 921,
+    "countryRank": 55
   },
   {
     "name": "University of St.Gallen",
@@ -16467,7 +17388,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 922
+    "aggregatedRank": 922,
+    "countryRank": 10
   },
   {
     "name": "IMT Atlantique",
@@ -16479,7 +17401,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 923
+    "aggregatedRank": 923,
+    "countryRank": 37
   },
   {
     "name": "L'institut Agro",
@@ -16491,7 +17414,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 924
+    "aggregatedRank": 924,
+    "countryRank": 38
   },
   {
     "name": "National University of Colombia",
@@ -16506,7 +17430,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 925
+    "aggregatedRank": 925,
+    "countryRank": 1
   },
   {
     "name": "Istanbul University",
@@ -16521,7 +17446,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 926
+    "aggregatedRank": 926,
+    "countryRank": 10
   },
   {
     "name": "Indian Institute of Technology - Kharagpur",
@@ -16536,7 +17462,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 927
+    "aggregatedRank": 927,
+    "countryRank": 21
   },
   {
     "name": "Indian Institute of Technology - Madras",
@@ -16551,7 +17478,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 928
+    "aggregatedRank": 928,
+    "countryRank": 22
   },
   {
     "name": "Indian Institute of Technology - Roorkee",
@@ -16566,7 +17494,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 929
+    "aggregatedRank": 929,
+    "countryRank": 23
   },
   {
     "name": "University of Regensburg",
@@ -16581,7 +17510,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 930
+    "aggregatedRank": 930,
+    "countryRank": 56
   },
   {
     "name": "University of Zaragoza",
@@ -16596,7 +17526,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 931
+    "aggregatedRank": 931,
+    "countryRank": 27
   },
   {
     "name": "University of Ja�n",
@@ -16611,7 +17542,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 932
+    "aggregatedRank": 932,
+    "countryRank": 28
   },
   {
     "name": "Kaohsiung Medical University",
@@ -16626,7 +17558,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 933
+    "aggregatedRank": 933,
+    "countryRank": 12
   },
   {
     "name": "Abdul Wali Khan University Mardan",
@@ -16641,7 +17574,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 934
+    "aggregatedRank": 934,
+    "countryRank": 9
   },
   {
     "name": "Changsha University of Science and Technology",
@@ -16656,7 +17590,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 935
+    "aggregatedRank": 935,
+    "countryRank": 89
   },
   {
     "name": "Jazan University",
@@ -16671,7 +17606,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 936
+    "aggregatedRank": 936,
+    "countryRank": 18
   },
   {
     "name": "University of Vaasa",
@@ -16683,7 +17619,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 937
+    "aggregatedRank": 937,
+    "countryRank": 10
   },
   {
     "name": "Mahatma Gandhi University",
@@ -16695,7 +17632,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 938
+    "aggregatedRank": 938,
+    "countryRank": 24
   },
   {
     "name": "Federal University of Toulouse Midi-Pyr�n�es",
@@ -16707,7 +17645,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 939
+    "aggregatedRank": 939,
+    "countryRank": 39
   },
   {
     "name": "Federation University Australia",
@@ -16719,7 +17658,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 940
+    "aggregatedRank": 940,
+    "countryRank": 38
   },
   {
     "name": "Leuphana University Luneburg",
@@ -16731,7 +17671,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 941
+    "aggregatedRank": 941,
+    "countryRank": 57
   },
   {
     "name": "Mohammed VI Polytechnic University",
@@ -16743,7 +17684,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 942
+    "aggregatedRank": 942,
+    "countryRank": 1
   },
   {
     "name": "University of Halle-Wittenberg",
@@ -16758,7 +17700,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 943
+    "aggregatedRank": 943,
+    "countryRank": 58
   },
   {
     "name": "Ural Federal University",
@@ -16773,7 +17716,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 944
+    "aggregatedRank": 944,
+    "countryRank": 17
   },
   {
     "name": "Arabian Gulf University",
@@ -16785,7 +17729,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 945
+    "aggregatedRank": 945,
+    "countryRank": 1
   },
   {
     "name": "University of Neuchatel",
@@ -16797,7 +17742,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 946
+    "aggregatedRank": 946,
+    "countryRank": 11
   },
   {
     "name": "University of Paderborn",
@@ -16809,7 +17755,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 947
+    "aggregatedRank": 947,
+    "countryRank": 59
   },
   {
     "name": "University of Passau",
@@ -16821,7 +17768,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 948
+    "aggregatedRank": 948,
+    "countryRank": 60
   },
   {
     "name": "Roskilde University",
@@ -16833,7 +17781,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 949
+    "aggregatedRank": 949,
+    "countryRank": 6
   },
   {
     "name": "Ecole Centrale de Nantes",
@@ -16845,7 +17794,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 950
+    "aggregatedRank": 950,
+    "countryRank": 40
   },
   {
     "name": "National Yunlin University of Science and Technology",
@@ -16857,7 +17807,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 951
+    "aggregatedRank": 951,
+    "countryRank": 13
   },
   {
     "name": "University of Tulsa",
@@ -16869,7 +17820,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 952
+    "aggregatedRank": 952,
+    "countryRank": 157
   },
   {
     "name": "Anglia Ruskin University",
@@ -16881,7 +17833,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 953
+    "aggregatedRank": 953,
+    "countryRank": 86
   },
   {
     "name": "Hamburg University of Technology",
@@ -16893,7 +17846,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 954
+    "aggregatedRank": 954,
+    "countryRank": 61
   },
   {
     "name": "Babol Noshirvani University of Technology",
@@ -16905,7 +17859,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 955
+    "aggregatedRank": 955,
+    "countryRank": 13
   },
   {
     "name": "University of Nicosia",
@@ -16917,7 +17872,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 956
+    "aggregatedRank": 956,
+    "countryRank": 3
   },
   {
     "name": "UEH University",
@@ -16929,7 +17885,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 957
+    "aggregatedRank": 957,
+    "countryRank": 3
   },
   {
     "name": "Constructor University Bremen",
@@ -16941,7 +17898,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 958
+    "aggregatedRank": 958,
+    "countryRank": 62
   },
   {
     "name": "Egypt-Japan University of Science and Technology",
@@ -16953,7 +17911,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 959
+    "aggregatedRank": 959,
+    "countryRank": 11
   },
   {
     "name": "ENSTA Bretagne",
@@ -16965,7 +17924,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 960
+    "aggregatedRank": 960,
+    "countryRank": 41
   },
   {
     "name": "Nazarbayev University",
@@ -16977,7 +17937,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 961
+    "aggregatedRank": 961,
+    "countryRank": 1
   },
   {
     "name": "Northwest Agriculture and Forestry University",
@@ -16992,7 +17953,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 962
+    "aggregatedRank": 962,
+    "countryRank": 90
   },
   {
     "name": "City University of New York - City College",
@@ -17007,7 +17969,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 963
+    "aggregatedRank": 963,
+    "countryRank": 158
   },
   {
     "name": "Indian Institute of Technology - Kanpur",
@@ -17022,7 +17985,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 964
+    "aggregatedRank": 964,
+    "countryRank": 25
   },
   {
     "name": "Chiang Mai University",
@@ -17037,7 +18001,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 965
+    "aggregatedRank": 965,
+    "countryRank": 4
   },
   {
     "name": "Czech Technical University of Prague",
@@ -17052,7 +18017,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 966
+    "aggregatedRank": 966,
+    "countryRank": 4
   },
   {
     "name": "Cyprus International University",
@@ -17064,7 +18030,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 967
+    "aggregatedRank": 967,
+    "countryRank": 1
   },
   {
     "name": "Near East University",
@@ -17076,7 +18043,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 968
+    "aggregatedRank": 968,
+    "countryRank": 2
   },
   {
     "name": "Espiritu Santo University",
@@ -17088,7 +18056,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 969
+    "aggregatedRank": 969,
+    "countryRank": 1
   },
   {
     "name": "Ecole Centrale de Lyon",
@@ -17100,7 +18069,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 970
+    "aggregatedRank": 970,
+    "countryRank": 42
   },
   {
     "name": "Ecole Nationale des Travaux Publics de l'Etat",
@@ -17112,7 +18082,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 971
+    "aggregatedRank": 971,
+    "countryRank": 43
   },
   {
     "name": "Harokopio University",
@@ -17124,7 +18095,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 972
+    "aggregatedRank": 972,
+    "countryRank": 6
   },
   {
     "name": "Panjab University",
@@ -17136,7 +18108,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 973
+    "aggregatedRank": 973,
+    "countryRank": 26
   },
   {
     "name": "Babol University of Medical Sciences",
@@ -17148,7 +18121,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 974
+    "aggregatedRank": 974,
+    "countryRank": 14
   },
   {
     "name": "Gorgan University Of Agricultural Sciences And Natural Resources",
@@ -17160,7 +18134,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 975
+    "aggregatedRank": 975,
+    "countryRank": 15
   },
   {
     "name": "Kurdistan University of Medical Sciences",
@@ -17172,7 +18147,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 976
+    "aggregatedRank": 976,
+    "countryRank": 16
   },
   {
     "name": "Mazandaran University of Medical Sciences",
@@ -17184,7 +18160,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 977
+    "aggregatedRank": 977,
+    "countryRank": 17
   },
   {
     "name": "Qazvin University of Medical Sciences",
@@ -17196,7 +18173,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 978
+    "aggregatedRank": 978,
+    "countryRank": 18
   },
   {
     "name": "Tabriz University of Medical Sciences",
@@ -17208,7 +18186,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 979
+    "aggregatedRank": 979,
+    "countryRank": 19
   },
   {
     "name": "Urmia University of Medical Sciences",
@@ -17220,7 +18199,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 980
+    "aggregatedRank": 980,
+    "countryRank": 20
   },
   {
     "name": "University of Aquila",
@@ -17232,7 +18212,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 981
+    "aggregatedRank": 981,
+    "countryRank": 45
   },
   {
     "name": "University of Sassari",
@@ -17244,7 +18225,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 982
+    "aggregatedRank": 982,
+    "countryRank": 46
   },
   {
     "name": "University of Aizu",
@@ -17256,7 +18238,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 983
+    "aggregatedRank": 983,
+    "countryRank": 18
   },
   {
     "name": "Air University",
@@ -17268,7 +18251,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 984
+    "aggregatedRank": 984,
+    "countryRank": 10
   },
   {
     "name": "University of Beira Interior",
@@ -17280,7 +18264,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 985
+    "aggregatedRank": 985,
+    "countryRank": 11
   },
   {
     "name": "St. Petersburg State Mining Institute (Technical University)",
@@ -17292,7 +18277,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 986
+    "aggregatedRank": 986,
+    "countryRank": 18
   },
   {
     "name": "J�nk�ping University College",
@@ -17304,7 +18290,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 987
+    "aggregatedRank": 987,
+    "countryRank": 14
   },
   {
     "name": "London Metropolitan University",
@@ -17316,7 +18303,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 988
+    "aggregatedRank": 988,
+    "countryRank": 87
   },
   {
     "name": "University of Derby",
@@ -17328,7 +18316,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 989
+    "aggregatedRank": 989,
+    "countryRank": 88
   },
   {
     "name": "Catholic University of America",
@@ -17340,7 +18329,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 990
+    "aggregatedRank": 990,
+    "countryRank": 159
   },
   {
     "name": "Rochester Institute of Technology",
@@ -17352,7 +18342,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 991
+    "aggregatedRank": 991,
+    "countryRank": 160
   },
   {
     "name": "University of North Carolina at Charlotte",
@@ -17364,7 +18355,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 992
+    "aggregatedRank": 992,
+    "countryRank": 161
   },
   {
     "name": "College of William and Mary",
@@ -17376,7 +18368,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 993
+    "aggregatedRank": 993,
+    "countryRank": 162
   },
   {
     "name": "Cyprus University of Technology",
@@ -17388,7 +18381,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 994
+    "aggregatedRank": 994,
+    "countryRank": 4
   },
   {
     "name": "Amity University",
@@ -17400,7 +18394,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 995
+    "aggregatedRank": 995,
+    "countryRank": 27
   },
   {
     "name": "University of the West Scotland",
@@ -17412,7 +18407,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 996
+    "aggregatedRank": 996,
+    "countryRank": 89
   },
   {
     "name": "�cole des Mines de Saint-�tienne",
@@ -17424,7 +18420,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 997
+    "aggregatedRank": 997,
+    "countryRank": 44
   },
   {
     "name": "University of Insubria",
@@ -17436,7 +18433,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 998
+    "aggregatedRank": 998,
+    "countryRank": 47
   },
   {
     "name": "Open University of Catalonia",
@@ -17448,7 +18446,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 999
+    "aggregatedRank": 999,
+    "countryRank": 29
   },
   {
     "name": "Indian Institute of Technology - Patna",
@@ -17460,7 +18459,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1000
+    "aggregatedRank": 1000,
+    "countryRank": 28
   },
   {
     "name": "Parthenope University of Naples",
@@ -17472,7 +18472,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1001
+    "aggregatedRank": 1001,
+    "countryRank": 48
   },
   {
     "name": "Scotland's Rural College",
@@ -17484,7 +18485,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1002
+    "aggregatedRank": 1002,
+    "countryRank": 90
   },
   {
     "name": "Sultan Idris Education University",
@@ -17496,7 +18498,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1003
+    "aggregatedRank": 1003,
+    "countryRank": 14
   },
   {
     "name": "�buda University",
@@ -17508,7 +18511,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1004
+    "aggregatedRank": 1004,
+    "countryRank": 6
   },
   {
     "name": "Alborz University of Medical Sciences",
@@ -17520,7 +18524,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1005
+    "aggregatedRank": 1005,
+    "countryRank": 21
   },
   {
     "name": "Baqiyatallah University of Medical Sciences",
@@ -17532,7 +18537,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1006
+    "aggregatedRank": 1006,
+    "countryRank": 22
   },
   {
     "name": "Golestan University",
@@ -17544,7 +18550,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1007
+    "aggregatedRank": 1007,
+    "countryRank": 23
   },
   {
     "name": "Innopolis University",
@@ -17556,7 +18563,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1008
+    "aggregatedRank": 1008,
+    "countryRank": 19
   },
   {
     "name": "Sukkur IBA University",
@@ -17568,7 +18576,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1009
+    "aggregatedRank": 1009,
+    "countryRank": 11
   },
   {
     "name": "Capital University of Science and Technology",
@@ -17580,7 +18589,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1010
+    "aggregatedRank": 1010,
+    "countryRank": 12
   },
   {
     "name": "Chitkara University",
@@ -17592,7 +18602,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1011
+    "aggregatedRank": 1011,
+    "countryRank": 29
   },
   {
     "name": "KIIT University",
@@ -17604,7 +18615,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1012
+    "aggregatedRank": 1012,
+    "countryRank": 30
   },
   {
     "name": "Lovely Professional University",
@@ -17616,7 +18628,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1013
+    "aggregatedRank": 1013,
+    "countryRank": 31
   },
   {
     "name": "Majmaah University",
@@ -17628,7 +18641,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1014
+    "aggregatedRank": 1014,
+    "countryRank": 19
   },
   {
     "name": "University of Malakand",
@@ -17640,7 +18654,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1015
+    "aggregatedRank": 1015,
+    "countryRank": 13
   },
   {
     "name": "Malaviya National Institute of Technology",
@@ -17652,7 +18667,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1016
+    "aggregatedRank": 1016,
+    "countryRank": 32
   },
   {
     "name": "International Institute of Information Technology Hyderabad",
@@ -17664,7 +18680,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1017
+    "aggregatedRank": 1017,
+    "countryRank": 33
   },
   {
     "name": "Palacky University",
@@ -17679,7 +18696,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1018
+    "aggregatedRank": 1018,
+    "countryRank": 5
   },
   {
     "name": "Toulouse 1 University Capitole",
@@ -17694,7 +18712,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1019
+    "aggregatedRank": 1019,
+    "countryRank": 45
   },
   {
     "name": "China University of Mining Technology - Beijing",
@@ -17709,7 +18728,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1020
+    "aggregatedRank": 1020,
+    "countryRank": 91
   },
   {
     "name": "University of Rostock",
@@ -17724,7 +18744,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1021
+    "aggregatedRank": 1021,
+    "countryRank": 63
   },
   {
     "name": "University of Perugia",
@@ -17739,7 +18760,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1022
+    "aggregatedRank": 1022,
+    "countryRank": 49
   },
   {
     "name": "University of Alabama at Birmingham",
@@ -17754,7 +18776,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1023
+    "aggregatedRank": 1023,
+    "countryRank": 163
   },
   {
     "name": "Brno University of Technology",
@@ -17769,7 +18792,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1024
+    "aggregatedRank": 1024,
+    "countryRank": 6
   },
   {
     "name": "University of Concepci�n",
@@ -17784,7 +18808,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1025
+    "aggregatedRank": 1025,
+    "countryRank": 4
   },
   {
     "name": "Singapore University of Technology & Design",
@@ -17799,7 +18824,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1026
+    "aggregatedRank": 1026,
+    "countryRank": 4
   },
   {
     "name": "Tokyo University of Science",
@@ -17814,7 +18840,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1027
+    "aggregatedRank": 1027,
+    "countryRank": 19
   },
   {
     "name": "Indian Institute of Technology - Bombay",
@@ -17826,7 +18853,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1028
+    "aggregatedRank": 1028,
+    "countryRank": 34
   },
   {
     "name": "Addis Ababa University",
@@ -17841,7 +18869,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1029
+    "aggregatedRank": 1029,
+    "countryRank": 1
   },
   {
     "name": "Chiba University",
@@ -17856,7 +18885,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1030
+    "aggregatedRank": 1030,
+    "countryRank": 20
   },
   {
     "name": "Kermanshah University of Medical Sciences",
@@ -17868,7 +18898,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1031
+    "aggregatedRank": 1031,
+    "countryRank": 24
   },
   {
     "name": "Lorestan University of Medical Sciences",
@@ -17880,7 +18911,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1032
+    "aggregatedRank": 1032,
+    "countryRank": 25
   },
   {
     "name": "Pmas Arid Agricultural University of Rawalpindi",
@@ -17892,7 +18924,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1033
+    "aggregatedRank": 1033,
+    "countryRank": 14
   },
   {
     "name": "University of Leoben",
@@ -17904,7 +18937,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1034
+    "aggregatedRank": 1034,
+    "countryRank": 12
   },
   {
     "name": "Daffodil International University",
@@ -17916,7 +18950,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1035
+    "aggregatedRank": 1035,
+    "countryRank": 2
   },
   {
     "name": "Jahangirnagar University",
@@ -17928,7 +18963,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1036
+    "aggregatedRank": 1036,
+    "countryRank": 3
   },
   {
     "name": "University of Ontario Institute of Technology",
@@ -17940,7 +18976,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1037
+    "aggregatedRank": 1037,
+    "countryRank": 30
   },
   {
     "name": "Wilfrid Laurier University",
@@ -17952,7 +18989,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1038
+    "aggregatedRank": 1038,
+    "countryRank": 31
   },
   {
     "name": "Zhejiang Gongshang University",
@@ -17964,7 +19002,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1039
+    "aggregatedRank": 1039,
+    "countryRank": 92
   },
   {
     "name": "University Pablo de Olavide",
@@ -17976,7 +19015,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1040
+    "aggregatedRank": 1040,
+    "countryRank": 30
   },
   {
     "name": "University of the South Pacific",
@@ -17988,7 +19028,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1041
+    "aggregatedRank": 1041,
+    "countryRank": 1
   },
   {
     "name": "Arts et M�tiers",
@@ -18000,7 +19041,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1042
+    "aggregatedRank": 1042,
+    "countryRank": 46
   },
   {
     "name": "National Veterinary School of Alfort",
@@ -18012,7 +19054,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1043
+    "aggregatedRank": 1043,
+    "countryRank": 47
   },
   {
     "name": "University of Western Brittany",
@@ -18024,7 +19067,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1044
+    "aggregatedRank": 1044,
+    "countryRank": 48
   },
   {
     "name": "University of Cape Coast",
@@ -18036,7 +19080,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1045
+    "aggregatedRank": 1045,
+    "countryRank": 1
   },
   {
     "name": "Alagappa University",
@@ -18048,7 +19093,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1046
+    "aggregatedRank": 1046,
+    "countryRank": 35
   },
   {
     "name": "Bharathiar University",
@@ -18060,7 +19106,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1047
+    "aggregatedRank": 1047,
+    "countryRank": 36
   },
   {
     "name": "Jamia Hamdard University",
@@ -18072,7 +19119,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1048
+    "aggregatedRank": 1048,
+    "countryRank": 37
   },
   {
     "name": "Jawaharlal Nehru Technological University Anantapur",
@@ -18084,7 +19132,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1049
+    "aggregatedRank": 1049,
+    "countryRank": 38
   },
   {
     "name": "Arak University of Medical Sciences",
@@ -18096,7 +19145,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1050
+    "aggregatedRank": 1050,
+    "countryRank": 26
   },
   {
     "name": "Birjand University of Medical Sciences",
@@ -18108,7 +19158,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1051
+    "aggregatedRank": 1051,
+    "countryRank": 27
   },
   {
     "name": "Guilan University of Medical Sciences",
@@ -18120,7 +19171,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1052
+    "aggregatedRank": 1052,
+    "countryRank": 28
   },
   {
     "name": "Isfahan University of Medical Sciences",
@@ -18132,7 +19184,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1053
+    "aggregatedRank": 1053,
+    "countryRank": 29
   },
   {
     "name": "K.N.Toosi University of Technology",
@@ -18144,7 +19197,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1054
+    "aggregatedRank": 1054,
+    "countryRank": 30
   },
   {
     "name": "Kashan University",
@@ -18156,7 +19210,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1055
+    "aggregatedRank": 1055,
+    "countryRank": 31
   },
   {
     "name": "Mashhad University of Medical Sciences",
@@ -18168,7 +19223,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1056
+    "aggregatedRank": 1056,
+    "countryRank": 32
   },
   {
     "name": "Shiraz University of Medical Sciences",
@@ -18180,7 +19236,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1057
+    "aggregatedRank": 1057,
+    "countryRank": 33
   },
   {
     "name": "Urmia University",
@@ -18192,7 +19249,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1058
+    "aggregatedRank": 1058,
+    "countryRank": 34
   },
   {
     "name": "Zahedan University of Medical Sciences",
@@ -18204,7 +19262,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1059
+    "aggregatedRank": 1059,
+    "countryRank": 35
   },
   {
     "name": "Reykjav�k University",
@@ -18216,7 +19275,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1060
+    "aggregatedRank": 1060,
+    "countryRank": 2
   },
   {
     "name": "University of Camerino",
@@ -18228,7 +19288,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1061
+    "aggregatedRank": 1061,
+    "countryRank": 50
   },
   {
     "name": "University of Foggia",
@@ -18240,7 +19301,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1062
+    "aggregatedRank": 1062,
+    "countryRank": 51
   },
   {
     "name": "University of Salento",
@@ -18252,7 +19314,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1063
+    "aggregatedRank": 1063,
+    "countryRank": 52
   },
   {
     "name": "University of Sannio",
@@ -18264,7 +19327,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1064
+    "aggregatedRank": 1064,
+    "countryRank": 53
   },
   {
     "name": "Al al-Bayt University",
@@ -18276,7 +19340,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1065
+    "aggregatedRank": 1065,
+    "countryRank": 4
   },
   {
     "name": "Tokyo Medical University",
@@ -18288,7 +19353,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1066
+    "aggregatedRank": 1066,
+    "countryRank": 21
   },
   {
     "name": "Wakayama Medical University",
@@ -18300,7 +19366,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1067
+    "aggregatedRank": 1067,
+    "countryRank": 22
   },
   {
     "name": "Seoul University",
@@ -18312,7 +19379,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1068
+    "aggregatedRank": 1068,
+    "countryRank": 27
   },
   {
     "name": "Covenant University",
@@ -18324,7 +19392,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1069
+    "aggregatedRank": 1069,
+    "countryRank": 3
   },
   {
     "name": "Islamia University Bahawalpur",
@@ -18336,7 +19405,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1070
+    "aggregatedRank": 1070,
+    "countryRank": 15
   },
   {
     "name": "University of Central Punjab",
@@ -18348,7 +19418,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1071
+    "aggregatedRank": 1071,
+    "countryRank": 16
   },
   {
     "name": "University of Engineering and Technology Peshawar",
@@ -18360,7 +19431,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1072
+    "aggregatedRank": 1072,
+    "countryRank": 17
   },
   {
     "name": "University of Gujrat",
@@ -18372,7 +19444,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1073
+    "aggregatedRank": 1073,
+    "countryRank": 18
   },
   {
     "name": "University of Management and Technology",
@@ -18384,7 +19457,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1074
+    "aggregatedRank": 1074,
+    "countryRank": 19
   },
   {
     "name": "University of Veterinary and Animal Sciences",
@@ -18396,7 +19470,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1075
+    "aggregatedRank": 1075,
+    "countryRank": 20
   },
   {
     "name": "Medical University of Lodz",
@@ -18408,7 +19483,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1076
+    "aggregatedRank": 1076,
+    "countryRank": 4
   },
   {
     "name": "King Saud bin Abdulaziz University for Health Sciences",
@@ -18420,7 +19496,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1077
+    "aggregatedRank": 1077,
+    "countryRank": 20
   },
   {
     "name": "Bahcesehir University",
@@ -18432,7 +19509,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1078
+    "aggregatedRank": 1078,
+    "countryRank": 11
   },
   {
     "name": "Kadir Has University",
@@ -18444,7 +19522,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1079
+    "aggregatedRank": 1079,
+    "countryRank": 12
   },
   {
     "name": "Yuan Ze University",
@@ -18456,7 +19535,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1080
+    "aggregatedRank": 1080,
+    "countryRank": 14
   },
   {
     "name": "Sumy State University",
@@ -18468,7 +19548,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1081
+    "aggregatedRank": 1081,
+    "countryRank": 1
   },
   {
     "name": "Glasgow Caledonian University",
@@ -18480,7 +19561,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1082
+    "aggregatedRank": 1082,
+    "countryRank": 91
   },
   {
     "name": "Roehampton University of Surrey",
@@ -18492,7 +19574,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1083
+    "aggregatedRank": 1083,
+    "countryRank": 92
   },
   {
     "name": "Sheffield Hallam University",
@@ -18504,7 +19587,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1084
+    "aggregatedRank": 1084,
+    "countryRank": 93
   },
   {
     "name": "University of Teesside",
@@ -18516,7 +19600,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1085
+    "aggregatedRank": 1085,
+    "countryRank": 94
   },
   {
     "name": "University of Wolverhampton",
@@ -18528,7 +19613,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1086
+    "aggregatedRank": 1086,
+    "countryRank": 95
   },
   {
     "name": "Hanoi Medical University",
@@ -18540,7 +19626,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1087
+    "aggregatedRank": 1087,
+    "countryRank": 4
   },
   {
     "name": "Florida Institute of Technology",
@@ -18552,7 +19639,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1088
+    "aggregatedRank": 1088,
+    "countryRank": 164
   },
   {
     "name": "Northern Illinois University",
@@ -18564,7 +19652,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1089
+    "aggregatedRank": 1089,
+    "countryRank": 165
   },
   {
     "name": "Southern Illinois University at Carbondale",
@@ -18576,7 +19665,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1090
+    "aggregatedRank": 1090,
+    "countryRank": 166
   },
   {
     "name": "New Mexico State University",
@@ -18588,7 +19678,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1091
+    "aggregatedRank": 1091,
+    "countryRank": 167
   },
   {
     "name": "Portland State University",
@@ -18600,7 +19691,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1092
+    "aggregatedRank": 1092,
+    "countryRank": 168
   },
   {
     "name": "University of Memphis",
@@ -18612,7 +19704,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1093
+    "aggregatedRank": 1093,
+    "countryRank": 169
   },
   {
     "name": "Gabriele D'Annunzio University",
@@ -18624,7 +19717,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1094
+    "aggregatedRank": 1094,
+    "countryRank": 54
   },
   {
     "name": "Leeds Beckett University",
@@ -18636,7 +19730,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1095
+    "aggregatedRank": 1095,
+    "countryRank": 96
   },
   {
     "name": "National Institute of Technology Rourkela",
@@ -18648,7 +19743,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1096
+    "aggregatedRank": 1096,
+    "countryRank": 39
   },
   {
     "name": "Institute of Chemical Technology",
@@ -18660,7 +19756,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1097
+    "aggregatedRank": 1097,
+    "countryRank": 40
   },
   {
     "name": "Indian Institute of Technology - Ropar",
@@ -18672,7 +19769,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1098
+    "aggregatedRank": 1098,
+    "countryRank": 41
   },
   {
     "name": "Indian Institute of Technology Gandhinagar",
@@ -18684,7 +19782,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1099
+    "aggregatedRank": 1099,
+    "countryRank": 42
   },
   {
     "name": "Imam Khomeini International University",
@@ -18696,7 +19795,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1100
+    "aggregatedRank": 1100,
+    "countryRank": 36
   },
   {
     "name": "Birmingham City University",
@@ -18708,7 +19808,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1101
+    "aggregatedRank": 1101,
+    "countryRank": 97
   },
   {
     "name": "Bucharest University of Economic Studies",
@@ -18720,7 +19821,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1102
+    "aggregatedRank": 1102,
+    "countryRank": 1
   },
   {
     "name": "International Islamic University Islamabad",
@@ -18732,7 +19834,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1103
+    "aggregatedRank": 1103,
+    "countryRank": 21
   },
   {
     "name": "JSS Academy of Higher Education and Research",
@@ -18744,7 +19847,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1104
+    "aggregatedRank": 1104,
+    "countryRank": 43
   },
   {
     "name": "Delhi Technological University",
@@ -18756,7 +19860,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1105
+    "aggregatedRank": 1105,
+    "countryRank": 44
   },
   {
     "name": "National Institute of Technology Silchar",
@@ -18768,7 +19873,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1106
+    "aggregatedRank": 1106,
+    "countryRank": 45
   },
   {
     "name": "Ozyegin University",
@@ -18780,7 +19886,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1107
+    "aggregatedRank": 1107,
+    "countryRank": 13
   },
   {
     "name": "Universitat Internacional de Catalunya",
@@ -18792,7 +19899,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1108
+    "aggregatedRank": 1108,
+    "countryRank": 31
   },
   {
     "name": "University of Tabuk",
@@ -18804,7 +19912,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1109
+    "aggregatedRank": 1109,
+    "countryRank": 21
   },
   {
     "name": "Bangabandhu Sheikh Mujibur Rahman Agricultural University",
@@ -18816,7 +19925,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1110
+    "aggregatedRank": 1110,
+    "countryRank": 4
   },
   {
     "name": "European University Cyprus",
@@ -18828,7 +19938,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1111
+    "aggregatedRank": 1111,
+    "countryRank": 5
   },
   {
     "name": "Jashore University of Science and Technology",
@@ -18840,7 +19951,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1112
+    "aggregatedRank": 1112,
+    "countryRank": 5
   },
   {
     "name": "Khwaja Fareed University of Engineering and Information Technology",
@@ -18852,7 +19964,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1113
+    "aggregatedRank": 1113,
+    "countryRank": 22
   },
   {
     "name": "University of Nova Gorica",
@@ -18864,7 +19977,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1114
+    "aggregatedRank": 1114,
+    "countryRank": 2
   },
   {
     "name": "Carol Davila University of Medicine and Pharmacy",
@@ -18876,7 +19990,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1115
+    "aggregatedRank": 1115,
+    "countryRank": 2
   },
   {
     "name": "Jaypee University of Information Technology",
@@ -18888,7 +20003,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1116
+    "aggregatedRank": 1116,
+    "countryRank": 46
   },
   {
     "name": "Kalasalingam Academy of Research and Education",
@@ -18900,7 +20016,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1117
+    "aggregatedRank": 1117,
+    "countryRank": 47
   },
   {
     "name": "KL University",
@@ -18912,7 +20029,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1118
+    "aggregatedRank": 1118,
+    "countryRank": 48
   },
   {
     "name": "Lithuanian University of Health Sciences",
@@ -18924,7 +20042,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1119
+    "aggregatedRank": 1119,
+    "countryRank": 2
   },
   {
     "name": "Najran University",
@@ -18936,7 +20055,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1120
+    "aggregatedRank": 1120,
+    "countryRank": 22
   },
   {
     "name": "University of Namur",
@@ -18948,7 +20068,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1121
+    "aggregatedRank": 1121,
+    "countryRank": 12
   },
   {
     "name": "Reichman University",
@@ -18960,7 +20081,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1122
+    "aggregatedRank": 1122,
+    "countryRank": 8
   },
   {
     "name": "Shahrekord University of Medical Sciences",
@@ -18972,7 +20094,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1123
+    "aggregatedRank": 1123,
+    "countryRank": 37
   },
   {
     "name": "Shri Mata Vaishno Devi University",
@@ -18984,7 +20107,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1124
+    "aggregatedRank": 1124,
+    "countryRank": 49
   },
   {
     "name": "Siksha O Anusandhan",
@@ -18996,7 +20120,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1125
+    "aggregatedRank": 1125,
+    "countryRank": 50
   },
   {
     "name": "Al-Farabi Kazakh National University",
@@ -19008,7 +20133,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1126
+    "aggregatedRank": 1126,
+    "countryRank": 2
   },
   {
     "name": "University of Alicante",
@@ -19023,7 +20149,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1127
+    "aggregatedRank": 1127,
+    "countryRank": 32
   },
   {
     "name": "National Polytechnic Institute",
@@ -19038,7 +20165,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1128
+    "aggregatedRank": 1128,
+    "countryRank": 4
   },
   {
     "name": "Nanjing University of Posts and Telecommunications",
@@ -19053,7 +20181,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1129
+    "aggregatedRank": 1129,
+    "countryRank": 93
   },
   {
     "name": "University of Murcia",
@@ -19068,7 +20197,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1130
+    "aggregatedRank": 1130,
+    "countryRank": 33
   },
   {
     "name": "Beijing Jiaotong University",
@@ -19083,7 +20213,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1131
+    "aggregatedRank": 1131,
+    "countryRank": 94
   },
   {
     "name": "Osaka Metropolitan University",
@@ -19098,7 +20229,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1132
+    "aggregatedRank": 1132,
+    "countryRank": 23
   },
   {
     "name": "University of Los Andes",
@@ -19110,7 +20242,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1133
+    "aggregatedRank": 1133,
+    "countryRank": 2
   },
   {
     "name": "Hamad Bin Khalifa University",
@@ -19122,7 +20255,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1134
+    "aggregatedRank": 1134,
+    "countryRank": 3
   },
   {
     "name": "Warsaw University of Technology",
@@ -19137,7 +20271,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1135
+    "aggregatedRank": 1135,
+    "countryRank": 5
   },
   {
     "name": "University of Bras�lia",
@@ -19152,7 +20287,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1136
+    "aggregatedRank": 1136,
+    "countryRank": 10
   },
   {
     "name": "University of Sherbrooke",
@@ -19167,7 +20303,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1137
+    "aggregatedRank": 1137,
+    "countryRank": 32
   },
   {
     "name": "Gadjah Mada University",
@@ -19179,7 +20316,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1138
+    "aggregatedRank": 1138,
+    "countryRank": 2
   },
   {
     "name": "National Chung Hsing University - Taipei",
@@ -19194,7 +20332,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1139
+    "aggregatedRank": 1139,
+    "countryRank": 15
   },
   {
     "name": "Taylor's University",
@@ -19206,7 +20345,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1140
+    "aggregatedRank": 1140,
+    "countryRank": 15
   },
   {
     "name": "Institute of Technology Bandung",
@@ -19218,7 +20358,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1141
+    "aggregatedRank": 1141,
+    "countryRank": 3
   },
   {
     "name": "Federal University of Santa Catarina",
@@ -19233,7 +20374,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1142
+    "aggregatedRank": 1142,
+    "countryRank": 11
   },
   {
     "name": "UCSI University",
@@ -19245,7 +20387,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1143
+    "aggregatedRank": 1143,
+    "countryRank": 16
   },
   {
     "name": "Dongguk University",
@@ -19260,7 +20403,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1144
+    "aggregatedRank": 1144,
+    "countryRank": 28
   },
   {
     "name": "Airlangga University",
@@ -19272,7 +20416,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1145
+    "aggregatedRank": 1145,
+    "countryRank": 4
   },
   {
     "name": "Budapest University of Technology and Economics",
@@ -19287,7 +20432,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1146
+    "aggregatedRank": 1146,
+    "countryRank": 7
   },
   {
     "name": "L.N. Gumilyov Eurasian National University",
@@ -19299,7 +20445,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1147
+    "aggregatedRank": 1147,
+    "countryRank": 3
   },
   {
     "name": "National Central University",
@@ -19314,7 +20461,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1148
+    "aggregatedRank": 1148,
+    "countryRank": 16
   },
   {
     "name": "University of the Philippines Manila",
@@ -19326,7 +20474,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1149
+    "aggregatedRank": 1149,
+    "countryRank": 1
   },
   {
     "name": "Chungnam National University",
@@ -19341,7 +20490,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1150
+    "aggregatedRank": 1150,
+    "countryRank": 29
   },
   {
     "name": "Pontifical Catholic University of Per�",
@@ -19353,7 +20503,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1151
+    "aggregatedRank": 1151,
+    "countryRank": 1
   },
   {
     "name": "Comenius University in Bratislava",
@@ -19368,7 +20519,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1152
+    "aggregatedRank": 1152,
+    "countryRank": 1
   },
   {
     "name": "Pontificia Universidad Javeriana",
@@ -19380,7 +20532,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1153
+    "aggregatedRank": 1153,
+    "countryRank": 3
   },
   {
     "name": "Technical University of Bergakademie Freiberg",
@@ -19392,7 +20545,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1154
+    "aggregatedRank": 1154,
+    "countryRank": 64
   },
   {
     "name": "Belarusian State University",
@@ -19404,7 +20558,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1155
+    "aggregatedRank": 1155,
+    "countryRank": 1
   },
   {
     "name": "Satbayev Kazakh National Technical University",
@@ -19416,7 +20571,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1156
+    "aggregatedRank": 1156,
+    "countryRank": 4
   },
   {
     "name": "Taras Shevchenko National University of Kyiv",
@@ -19431,7 +20587,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1157
+    "aggregatedRank": 1157,
+    "countryRank": 2
   },
   {
     "name": "Ankara University",
@@ -19446,7 +20603,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1158
+    "aggregatedRank": 1158,
+    "countryRank": 14
   },
   {
     "name": "Gda�sk University of Technology",
@@ -19461,7 +20619,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1159
+    "aggregatedRank": 1159,
+    "countryRank": 6
   },
   {
     "name": "National Taipei University of Technology",
@@ -19473,7 +20632,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1160
+    "aggregatedRank": 1160,
+    "countryRank": 17
   },
   {
     "name": "Bogor Agricultural University (IPB University)",
@@ -19485,7 +20645,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1161
+    "aggregatedRank": 1161,
+    "countryRank": 5
   },
   {
     "name": "IE University",
@@ -19497,7 +20658,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1162
+    "aggregatedRank": 1162,
+    "countryRank": 34
   },
   {
     "name": "University of Santiago de Chile",
@@ -19509,7 +20671,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1163
+    "aggregatedRank": 1163,
+    "countryRank": 5
   },
   {
     "name": "University of Calcutta",
@@ -19524,7 +20687,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1164
+    "aggregatedRank": 1164,
+    "countryRank": 51
   },
   {
     "name": "Nagasaki University",
@@ -19539,7 +20703,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1165
+    "aggregatedRank": 1165,
+    "countryRank": 24
   },
   {
     "name": "Clemson University",
@@ -19554,7 +20719,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1166
+    "aggregatedRank": 1166,
+    "countryRank": 170
   },
   {
     "name": "University of Patras",
@@ -19569,7 +20735,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1167
+    "aggregatedRank": 1167,
+    "countryRank": 7
   },
   {
     "name": "Adam Mickiewicz University in Poznan",
@@ -19584,7 +20751,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1168
+    "aggregatedRank": 1168,
+    "countryRank": 7
   },
   {
     "name": "Pontifical Catholic University Argentina",
@@ -19596,7 +20764,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1169
+    "aggregatedRank": 1169,
+    "countryRank": 2
   },
   {
     "name": "American University of Ras al Khaimah",
@@ -19608,7 +20777,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1170
+    "aggregatedRank": 1170,
+    "countryRank": 9
   },
   {
     "name": "University of Costa Rica",
@@ -19620,7 +20790,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1171
+    "aggregatedRank": 1171,
+    "countryRank": 1
   },
   {
     "name": "Ateneo de Manila University",
@@ -19632,7 +20803,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1172
+    "aggregatedRank": 1172,
+    "countryRank": 2
   },
   {
     "name": "INTI International University",
@@ -19644,7 +20816,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1173
+    "aggregatedRank": 1173,
+    "countryRank": 17
   },
   {
     "name": "Canadian University Dubai",
@@ -19656,7 +20829,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1174
+    "aggregatedRank": 1174,
+    "countryRank": 10
   },
   {
     "name": "Austral University",
@@ -19668,7 +20842,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1175
+    "aggregatedRank": 1175,
+    "countryRank": 3
   },
   {
     "name": "National University de C�rdoba",
@@ -19683,7 +20858,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1176
+    "aggregatedRank": 1176,
+    "countryRank": 4
   },
   {
     "name": "Kanazawa University",
@@ -19698,7 +20874,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1177
+    "aggregatedRank": 1177,
+    "countryRank": 25
   },
   {
     "name": "Indian Institute of Technology (BHU) Varanasi",
@@ -19710,7 +20887,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1178
+    "aggregatedRank": 1178,
+    "countryRank": 52
   },
   {
     "name": "National University de La Plata",
@@ -19722,7 +20900,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1179
+    "aggregatedRank": 1179,
+    "countryRank": 5
   },
   {
     "name": "Hitotsubashi University",
@@ -19734,7 +20913,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1180
+    "aggregatedRank": 1180,
+    "countryRank": 26
   },
   {
     "name": "Applied Science University Bahrain",
@@ -19746,7 +20926,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1181
+    "aggregatedRank": 1181,
+    "countryRank": 2
   },
   {
     "name": "University Pontificia Comillas",
@@ -19758,7 +20939,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1182
+    "aggregatedRank": 1182,
+    "countryRank": 35
   },
   {
     "name": "University of Dhaka",
@@ -19770,7 +20952,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1183
+    "aggregatedRank": 1183,
+    "countryRank": 6
   },
   {
     "name": "Lebanese University Beirut",
@@ -19782,7 +20965,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1184
+    "aggregatedRank": 1184,
+    "countryRank": 4
   },
   {
     "name": "Moscow State Institute of International Relations",
@@ -19794,7 +20978,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1185
+    "aggregatedRank": 1185,
+    "countryRank": 20
   },
   {
     "name": "University of Chemistry and Technology - Prague",
@@ -19806,7 +20991,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1186
+    "aggregatedRank": 1186,
+    "countryRank": 7
   },
   {
     "name": "University of California - San Francisco",
@@ -19818,7 +21004,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1187
+    "aggregatedRank": 1187,
+    "countryRank": 171
   },
   {
     "name": "University Adolfo Ib��ez",
@@ -19830,7 +21017,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1188
+    "aggregatedRank": 1188,
+    "countryRank": 6
   },
   {
     "name": "Singapore Management University",
@@ -19842,7 +21030,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1189
+    "aggregatedRank": 1189,
+    "countryRank": 5
   },
   {
     "name": "Sepuluh Nopember Institute of Technology",
@@ -19854,7 +21043,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1190
+    "aggregatedRank": 1190,
+    "countryRank": 6
   },
   {
     "name": "University of Technology - Mara",
@@ -19866,7 +21056,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1191
+    "aggregatedRank": 1191,
+    "countryRank": 18
   },
   {
     "name": "University of Valladolid",
@@ -19881,7 +21072,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1192
+    "aggregatedRank": 1192,
+    "countryRank": 36
   },
   {
     "name": "University of Ghana",
@@ -19896,7 +21088,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1193
+    "aggregatedRank": 1193,
+    "countryRank": 2
   },
   {
     "name": "Tokyo University of Agriculture and Technology",
@@ -19911,7 +21104,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1194
+    "aggregatedRank": 1194,
+    "countryRank": 27
   },
   {
     "name": "SRM Institute Of Science and Technology ( Deemed University)",
@@ -19926,7 +21120,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1195
+    "aggregatedRank": 1195,
+    "countryRank": 8
   },
   {
     "name": "University of South Africa",
@@ -19941,7 +21136,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1196
+    "aggregatedRank": 1196,
+    "countryRank": 10
   },
   {
     "name": "Padjadjaran University",
@@ -19953,7 +21149,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1197
+    "aggregatedRank": 1197,
+    "countryRank": 7
   },
   {
     "name": "Thammasat University",
@@ -19965,7 +21162,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1198
+    "aggregatedRank": 1198,
+    "countryRank": 5
   },
   {
     "name": "National Chengchi University",
@@ -19977,7 +21175,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1199
+    "aggregatedRank": 1199,
+    "countryRank": 18
   },
   {
     "name": "University of Texas Southwestern Medical Center at Dallas",
@@ -19989,7 +21188,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1200
+    "aggregatedRank": 1200,
+    "countryRank": 172
   },
   {
     "name": "Asia Pacific University of Technology and Innovation",
@@ -20001,7 +21201,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1201
+    "aggregatedRank": 1201,
+    "countryRank": 19
   },
   {
     "name": "Universidad de Palermo",
@@ -20013,7 +21214,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1202
+    "aggregatedRank": 1202,
+    "countryRank": 6
   },
   {
     "name": "American University in Dubai",
@@ -20025,7 +21227,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1203
+    "aggregatedRank": 1203,
+    "countryRank": 11
   },
   {
     "name": "Auezov South Kazakhstan State University",
@@ -20037,7 +21240,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1204
+    "aggregatedRank": 1204,
+    "countryRank": 5
   },
   {
     "name": "Far Eastern Federal University",
@@ -20049,7 +21253,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1205
+    "aggregatedRank": 1205,
+    "countryRank": 21
   },
   {
     "name": "University of Texas MD Anderson Cancer Center",
@@ -20061,7 +21266,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1206
+    "aggregatedRank": 1206,
+    "countryRank": 173
   },
   {
     "name": "Ritsumeikan University",
@@ -20073,7 +21279,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1207
+    "aggregatedRank": 1207,
+    "countryRank": 28
   },
   {
     "name": "De La Salle University",
@@ -20085,7 +21292,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1208
+    "aggregatedRank": 1208,
+    "countryRank": 3
   },
   {
     "name": "Yokohama City University",
@@ -20100,7 +21308,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1209
+    "aggregatedRank": 1209,
+    "countryRank": 29
   },
   {
     "name": "Nicolaus Copernicus University",
@@ -20115,7 +21324,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1210
+    "aggregatedRank": 1210,
+    "countryRank": 9
   },
   {
     "name": "Hankuk University of Foreign Studies",
@@ -20127,7 +21337,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1211
+    "aggregatedRank": 1211,
+    "countryRank": 30
   },
   {
     "name": "Mayo Medical School",
@@ -20139,7 +21350,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1212
+    "aggregatedRank": 1212,
+    "countryRank": 174
   },
   {
     "name": "Sofia University",
@@ -20151,7 +21363,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1213
+    "aggregatedRank": 1213,
+    "countryRank": 1
   },
   {
     "name": "International Islamic University Malaysia",
@@ -20163,7 +21376,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1214
+    "aggregatedRank": 1214,
+    "countryRank": 20
   },
   {
     "name": "University of the Republic",
@@ -20175,7 +21389,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1215
+    "aggregatedRank": 1215,
+    "countryRank": 1
   },
   {
     "name": "Kazakh National Pedagogical University",
@@ -20187,7 +21402,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1216
+    "aggregatedRank": 1216,
+    "countryRank": 6
   },
   {
     "name": "Kazakh National Agrarian University",
@@ -20199,7 +21415,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1217
+    "aggregatedRank": 1217,
+    "countryRank": 7
   },
   {
     "name": "University of Agriculture Faisalabad",
@@ -20211,7 +21428,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1218
+    "aggregatedRank": 1218,
+    "countryRank": 23
   },
   {
     "name": "Indian Institute of Technology - Hyderabad",
@@ -20223,7 +21441,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1219
+    "aggregatedRank": 1219,
+    "countryRank": 53
   },
   {
     "name": "University of Havana",
@@ -20235,7 +21454,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1220
+    "aggregatedRank": 1220,
+    "countryRank": 1
   },
   {
     "name": "Panamerican University",
@@ -20247,7 +21467,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1221
+    "aggregatedRank": 1221,
+    "countryRank": 5
   },
   {
     "name": "University Central de Venezuela",
@@ -20259,7 +21480,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1222
+    "aggregatedRank": 1222,
+    "countryRank": 1
   },
   {
     "name": "Pakistan Institute of Engineering and Applied Sciences",
@@ -20271,7 +21493,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1223
+    "aggregatedRank": 1223,
+    "countryRank": 24
   },
   {
     "name": "Chandigarh University",
@@ -20283,7 +21506,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1224
+    "aggregatedRank": 1224,
+    "countryRank": 54
   },
   {
     "name": "Kumamoto University",
@@ -20298,7 +21522,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1225
+    "aggregatedRank": 1225,
+    "countryRank": 30
   },
   {
     "name": "Hallym University",
@@ -20313,7 +21538,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1226
+    "aggregatedRank": 1226,
+    "countryRank": 31
   },
   {
     "name": "Al Ahlia University",
@@ -20325,7 +21551,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1227
+    "aggregatedRank": 1227,
+    "countryRank": 3
   },
   {
     "name": "University of Franche-Comt�",
@@ -20337,7 +21564,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1228
+    "aggregatedRank": 1228,
+    "countryRank": 49
   },
   {
     "name": "Lingnan University",
@@ -20349,7 +21577,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1229
+    "aggregatedRank": 1229,
+    "countryRank": 7
   },
   {
     "name": "University of Mumbai",
@@ -20361,7 +21590,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1230
+    "aggregatedRank": 1230,
+    "countryRank": 55
   },
   {
     "name": "Plekhanov Russian University of Economics",
@@ -20373,7 +21603,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1231
+    "aggregatedRank": 1231,
+    "countryRank": 22
   },
   {
     "name": "Saint Joseph University of Beirut",
@@ -20385,7 +21616,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1232
+    "aggregatedRank": 1232,
+    "countryRank": 5
   },
   {
     "name": "Diponegoro University",
@@ -20397,7 +21629,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1233
+    "aggregatedRank": 1233,
+    "countryRank": 8
   },
   {
     "name": "Jadavpur University",
@@ -20409,7 +21642,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1234
+    "aggregatedRank": 1234,
+    "countryRank": 56
   },
   {
     "name": "Riga Technical University",
@@ -20421,7 +21655,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1235
+    "aggregatedRank": 1235,
+    "countryRank": 1
   },
   {
     "name": "Effat University",
@@ -20433,7 +21668,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1236
+    "aggregatedRank": 1236,
+    "countryRank": 23
   },
   {
     "name": "Vytautas Magnus University",
@@ -20445,7 +21681,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1237
+    "aggregatedRank": 1237,
+    "countryRank": 3
   },
   {
     "name": "Altai State University",
@@ -20457,7 +21694,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1238
+    "aggregatedRank": 1238,
+    "countryRank": 23
   },
   {
     "name": "University of Montevideo",
@@ -20469,7 +21707,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1239
+    "aggregatedRank": 1239,
+    "countryRank": 2
   },
   {
     "name": "Catholic University Andres Bello",
@@ -20481,7 +21720,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1240
+    "aggregatedRank": 1240,
+    "countryRank": 2
   },
   {
     "name": "V.N. Karazin Kharkiv National University",
@@ -20493,7 +21733,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1241
+    "aggregatedRank": 1241,
+    "countryRank": 3
   },
   {
     "name": "Kaunas University of Technology",
@@ -20505,7 +21746,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1242
+    "aggregatedRank": 1242,
+    "countryRank": 4
   },
   {
     "name": "M�xico Autonomous Institute of Technology",
@@ -20517,7 +21759,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1243
+    "aggregatedRank": 1243,
+    "countryRank": 6
   },
   {
     "name": "Nanchang University",
@@ -20529,7 +21772,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1244
+    "aggregatedRank": 1244,
+    "countryRank": 95
   },
   {
     "name": "University of Massachusetts Medical School",
@@ -20541,7 +21785,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1245
+    "aggregatedRank": 1245,
+    "countryRank": 175
   },
   {
     "name": "Peking Union Medical College",
@@ -20553,7 +21798,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1246
+    "aggregatedRank": 1246,
+    "countryRank": 96
   },
   {
     "name": "Bangladesh University of Engineering and Technology (BUET)",
@@ -20565,7 +21811,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1247
+    "aggregatedRank": 1247,
+    "countryRank": 7
   },
   {
     "name": "University of Rosario",
@@ -20577,7 +21824,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1248
+    "aggregatedRank": 1248,
+    "countryRank": 4
   },
   {
     "name": "University of Pecs",
@@ -20589,7 +21837,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1249
+    "aggregatedRank": 1249,
+    "countryRank": 8
   },
   {
     "name": "Holy Spirit University of Kaslik",
@@ -20601,7 +21850,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1250
+    "aggregatedRank": 1250,
+    "countryRank": 6
   },
   {
     "name": "The College of Mexico",
@@ -20613,7 +21863,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1251
+    "aggregatedRank": 1251,
+    "countryRank": 7
   },
   {
     "name": "University of Latvia",
@@ -20625,7 +21876,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1252
+    "aggregatedRank": 1252,
+    "countryRank": 2
   },
   {
     "name": "Babes-Bolyai University",
@@ -20637,7 +21889,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1253
+    "aggregatedRank": 1253,
+    "countryRank": 3
   },
   {
     "name": "Kasetsart University",
@@ -20649,7 +21902,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1254
+    "aggregatedRank": 1254,
+    "countryRank": 6
   },
   {
     "name": "National University of Uzbekistan",
@@ -20661,7 +21915,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1255
+    "aggregatedRank": 1255,
+    "countryRank": 2
   },
   {
     "name": "The New School",
@@ -20673,7 +21928,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1256
+    "aggregatedRank": 1256,
+    "countryRank": 176
   },
   {
     "name": "Zurich University of Applied Sciences",
@@ -20685,7 +21941,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1257
+    "aggregatedRank": 1257,
+    "countryRank": 12
   },
   {
     "name": "University of Antioqu�a",
@@ -20697,7 +21954,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1258
+    "aggregatedRank": 1258,
+    "countryRank": 5
   },
   {
     "name": "Tbilisi State University",
@@ -20709,7 +21967,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1259
+    "aggregatedRank": 1259,
+    "countryRank": 1
   },
   {
     "name": "I.M. Sechenov First Moscow State Medical University",
@@ -20721,7 +21980,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1260
+    "aggregatedRank": 1260,
+    "countryRank": 24
   },
   {
     "name": "Pontifical Catholic University of Valparaiso",
@@ -20733,7 +21993,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1261
+    "aggregatedRank": 1261,
+    "countryRank": 7
   },
   {
     "name": "University San Francisco de Quito",
@@ -20745,7 +22006,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1262
+    "aggregatedRank": 1262,
+    "countryRank": 2
   },
   {
     "name": "University of Hyderabad",
@@ -20757,7 +22019,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1263
+    "aggregatedRank": 1263,
+    "countryRank": 57
   },
   {
     "name": "Kuwait University",
@@ -20769,7 +22032,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1264
+    "aggregatedRank": 1264,
+    "countryRank": 2
   },
   {
     "name": "An�huac University",
@@ -20781,7 +22045,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1265
+    "aggregatedRank": 1265,
+    "countryRank": 8
   },
   {
     "name": "University of Tunku Abdul Rahman",
@@ -20793,7 +22058,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1266
+    "aggregatedRank": 1266,
+    "countryRank": 21
   },
   {
     "name": "University of Bucharest",
@@ -20805,7 +22071,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1267
+    "aggregatedRank": 1267,
+    "countryRank": 4
   },
   {
     "name": "National Technical University of Ukraine",
@@ -20817,7 +22084,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1268
+    "aggregatedRank": 1268,
+    "countryRank": 4
   },
   {
     "name": "Ibero-American University",
@@ -20829,7 +22097,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1269
+    "aggregatedRank": 1269,
+    "countryRank": 9
   },
   {
     "name": "University of Brawijaya",
@@ -20841,7 +22110,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1270
+    "aggregatedRank": 1270,
+    "countryRank": 9
   },
   {
     "name": "University of Baghdad",
@@ -20853,7 +22123,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1271
+    "aggregatedRank": 1271,
+    "countryRank": 1
   },
   {
     "name": "Belarusian National Technical University",
@@ -20865,7 +22136,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1272
+    "aggregatedRank": 1272,
+    "countryRank": 2
   },
   {
     "name": "Immanuel Kant Baltic Federal University",
@@ -20877,7 +22149,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1273
+    "aggregatedRank": 1273,
+    "countryRank": 25
   },
   {
     "name": "Khoja Akhmet Yassawi International Kazakh-Turkish University",
@@ -20889,7 +22162,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1274
+    "aggregatedRank": 1274,
+    "countryRank": 8
   },
   {
     "name": "Al-Quds University",
@@ -20901,7 +22175,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1275
+    "aggregatedRank": 1275,
+    "countryRank": 1
   },
   {
     "name": "Dubai University College",
@@ -20913,7 +22188,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1276
+    "aggregatedRank": 1276,
+    "countryRank": 12
   },
   {
     "name": "Mendel University of Agriculture and Forestry",
@@ -20925,7 +22201,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1277
+    "aggregatedRank": 1277,
+    "countryRank": 8
   },
   {
     "name": "Kyrgyz Russian Slavic University",
@@ -20937,7 +22214,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1278
+    "aggregatedRank": 1278,
+    "countryRank": 1
   },
   {
     "name": "Gulf University for Science and Technology",
@@ -20949,7 +22227,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1279
+    "aggregatedRank": 1279,
+    "countryRank": 3
   },
   {
     "name": "Karaganda State Technical University",
@@ -20961,7 +22240,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1280
+    "aggregatedRank": 1280,
+    "countryRank": 9
   },
   {
     "name": "Vilnius Gediminas Technical University",
@@ -20973,7 +22253,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1281
+    "aggregatedRank": 1281,
+    "countryRank": 5
   },
   {
     "name": "University of Santo Tomas",
@@ -20985,7 +22266,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1282
+    "aggregatedRank": 1282,
+    "countryRank": 4
   },
   {
     "name": "University of Gdansk",
@@ -20997,7 +22279,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1283
+    "aggregatedRank": 1283,
+    "countryRank": 10
   },
   {
     "name": "University of Wroclaw",
@@ -21009,7 +22292,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1284
+    "aggregatedRank": 1284,
+    "countryRank": 11
   },
   {
     "name": "Pavol Jozef Safarik University in Kosice",
@@ -21021,7 +22305,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1285
+    "aggregatedRank": 1285,
+    "countryRank": 2
   },
   {
     "name": "University ORT Uruguay",
@@ -21033,7 +22318,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1286
+    "aggregatedRank": 1286,
+    "countryRank": 3
   },
   {
     "name": "Clarkson University",
@@ -21045,7 +22331,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1287
+    "aggregatedRank": 1287,
+    "countryRank": 177
   },
   {
     "name": "Swarthmore College",
@@ -21057,7 +22344,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1288
+    "aggregatedRank": 1288,
+    "countryRank": 178
   },
   {
     "name": "Viet Nam National University - Hanoi",
@@ -21069,7 +22357,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1289
+    "aggregatedRank": 1289,
+    "countryRank": 5
   },
   {
     "name": "Technological University Dublin",
@@ -21081,7 +22370,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1290
+    "aggregatedRank": 1290,
+    "countryRank": 9
   },
   {
     "name": "Poznan University of Life Sciences",
@@ -21093,7 +22383,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1291
+    "aggregatedRank": 1291,
+    "countryRank": 12
   },
   {
     "name": "Anhui University",
@@ -21105,7 +22396,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1292
+    "aggregatedRank": 1292,
+    "countryRank": 97
   },
   {
     "name": "Guangxi University",
@@ -21117,7 +22409,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1293
+    "aggregatedRank": 1293,
+    "countryRank": 98
   },
   {
     "name": "University of Shanghai for Science and Technology",
@@ -21129,7 +22422,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1294
+    "aggregatedRank": 1294,
+    "countryRank": 99
   },
   {
     "name": "Indiana University-Purdue University of Indianapolis",
@@ -21141,7 +22435,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1295
+    "aggregatedRank": 1295,
+    "countryRank": 179
   },
   {
     "name": "Albert Einstein College of Medicine - Yeshiva University",
@@ -21153,7 +22448,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1296
+    "aggregatedRank": 1296,
+    "countryRank": 180
   },
   {
     "name": "China University of Geosciences - Beijing",
@@ -21165,7 +22461,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1297
+    "aggregatedRank": 1297,
+    "countryRank": 100
   },
   {
     "name": "Yerevan State University",
@@ -21177,7 +22474,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1298
+    "aggregatedRank": 1298,
+    "countryRank": 1
   },
   {
     "name": "EAFIT University",
@@ -21189,7 +22487,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1299
+    "aggregatedRank": 1299,
+    "countryRank": 6
   },
   {
     "name": "University Externado de Colombia",
@@ -21201,7 +22500,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1300
+    "aggregatedRank": 1300,
+    "countryRank": 7
   },
   {
     "name": "University Marta Abreu of Las Villas",
@@ -21213,7 +22513,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1301
+    "aggregatedRank": 1301,
+    "countryRank": 2
   },
   {
     "name": "University Panth�on-Assas (Paris II)",
@@ -21225,7 +22526,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1302
+    "aggregatedRank": 1302,
+    "countryRank": 50
   },
   {
     "name": "Georgian Technical University",
@@ -21237,7 +22539,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1303
+    "aggregatedRank": 1303,
+    "countryRank": 2
   },
   {
     "name": "German Jordanian University",
@@ -21249,7 +22552,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1304
+    "aggregatedRank": 1304,
+    "countryRank": 5
   },
   {
     "name": "Princess Sumaya University for Technology",
@@ -21261,7 +22565,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1305
+    "aggregatedRank": 1305,
+    "countryRank": 6
   },
   {
     "name": "Ritsumeikan Asia Pacific University",
@@ -21273,7 +22578,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1306
+    "aggregatedRank": 1306,
+    "countryRank": 31
   },
   {
     "name": "University of Nairobi",
@@ -21285,7 +22591,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1307
+    "aggregatedRank": 1307,
+    "countryRank": 1
   },
   {
     "name": "Kyrgyz Turkish Manas University",
@@ -21297,7 +22604,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1308
+    "aggregatedRank": 1308,
+    "countryRank": 2
   },
   {
     "name": "Karaganda State Buketov University",
@@ -21309,7 +22617,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1309
+    "aggregatedRank": 1309,
+    "countryRank": 10
   },
   {
     "name": "National University of San Marcos",
@@ -21321,7 +22630,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1310
+    "aggregatedRank": 1310,
+    "countryRank": 2
   },
   {
     "name": "University of Peshawar",
@@ -21333,7 +22643,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1311
+    "aggregatedRank": 1311,
+    "countryRank": 25
   },
   {
     "name": "University of Lodz",
@@ -21345,7 +22656,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1312
+    "aggregatedRank": 1312,
+    "countryRank": 13
   },
   {
     "name": "Saratov State University",
@@ -21357,7 +22669,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1313
+    "aggregatedRank": 1313,
+    "countryRank": 26
   },
   {
     "name": "University of Maribor",
@@ -21369,7 +22682,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1314
+    "aggregatedRank": 1314,
+    "countryRank": 3
   },
   {
     "name": "Gazi University Ankara",
@@ -21381,7 +22695,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1315
+    "aggregatedRank": 1315,
+    "countryRank": 15
   },
   {
     "name": "Makerere University",
@@ -21393,7 +22708,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1316
+    "aggregatedRank": 1316,
+    "countryRank": 1
   },
   {
     "name": "University of East London",
@@ -21405,7 +22721,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1317
+    "aggregatedRank": 1317,
+    "countryRank": 98
   },
   {
     "name": "Catholic University of Uruguay",
@@ -21417,7 +22734,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1318
+    "aggregatedRank": 1318,
+    "countryRank": 4
   },
   {
     "name": "Michigan Technological University",
@@ -21429,7 +22747,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1319
+    "aggregatedRank": 1319,
+    "countryRank": 181
   },
   {
     "name": "Wroclaw University of Science and Technology",
@@ -21441,7 +22760,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1320
+    "aggregatedRank": 1320,
+    "countryRank": 14
   },
   {
     "name": "Viet Nam National University - Ho Chi Minh City",
@@ -21453,7 +22773,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1321
+    "aggregatedRank": 1321,
+    "countryRank": 6
   },
   {
     "name": "Pontifical Bolivarian University",
@@ -21465,7 +22786,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1322
+    "aggregatedRank": 1322,
+    "countryRank": 8
   },
   {
     "name": "D. Serikbayev East Kazakhstan State Technical University",
@@ -21477,7 +22799,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1323
+    "aggregatedRank": 1323,
+    "countryRank": 11
   },
   {
     "name": "Financial University of Under the Government the Russian Federation",
@@ -21489,7 +22812,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1324
+    "aggregatedRank": 1324,
+    "countryRank": 27
   },
   {
     "name": "Buenos Aires Institute of Technology",
@@ -21501,7 +22825,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1325
+    "aggregatedRank": 1325,
+    "countryRank": 7
   },
   {
     "name": "National University de Rosario",
@@ -21513,7 +22838,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1326
+    "aggregatedRank": 1326,
+    "countryRank": 8
   },
   {
     "name": "University Torcuato di Tella",
@@ -21525,7 +22851,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1327
+    "aggregatedRank": 1327,
+    "countryRank": 9
   },
   {
     "name": "University of San Andres",
@@ -21537,7 +22864,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1328
+    "aggregatedRank": 1328,
+    "countryRank": 10
   },
   {
     "name": "Baku State University",
@@ -21549,7 +22877,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1329
+    "aggregatedRank": 1329,
+    "countryRank": 1
   },
   {
     "name": "University of Bahrain",
@@ -21561,7 +22890,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1330
+    "aggregatedRank": 1330,
+    "countryRank": 4
   },
   {
     "name": "Federico Santa Mar�a Technical University",
@@ -21573,7 +22903,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1331
+    "aggregatedRank": 1331,
+    "countryRank": 8
   },
   {
     "name": "University of the Andes - Chile",
@@ -21585,7 +22916,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1332
+    "aggregatedRank": 1332,
+    "countryRank": 9
   },
   {
     "name": "University of La Sabana",
@@ -21597,7 +22929,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1333
+    "aggregatedRank": 1333,
+    "countryRank": 9
   },
   {
     "name": "University of South Bohemia",
@@ -21609,7 +22942,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1334
+    "aggregatedRank": 1334,
+    "countryRank": 9
   },
   {
     "name": "Pontifical Catholic University of Ecuador",
@@ -21621,7 +22955,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1335
+    "aggregatedRank": 1335,
+    "countryRank": 3
   },
   {
     "name": "University of Le�n",
@@ -21633,7 +22968,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1336
+    "aggregatedRank": 1336,
+    "countryRank": 37
   },
   {
     "name": "University Paris Nord (Paris XIII)",
@@ -21645,7 +22981,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1337
+    "aggregatedRank": 1337,
+    "countryRank": 51
   },
   {
     "name": "Athens University of Economics and Business",
@@ -21657,7 +22994,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1338
+    "aggregatedRank": 1338,
+    "countryRank": 8
   },
   {
     "name": "Bina Nusantara University",
@@ -21669,7 +23007,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1339
+    "aggregatedRank": 1339,
+    "countryRank": 10
   },
   {
     "name": "Yarmouk University",
@@ -21681,7 +23020,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1340
+    "aggregatedRank": 1340,
+    "countryRank": 7
   },
   {
     "name": "Niigata University",
@@ -21693,7 +23033,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1341
+    "aggregatedRank": 1341,
+    "countryRank": 32
   },
   {
     "name": "Sophia University",
@@ -21705,7 +23046,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1342
+    "aggregatedRank": 1342,
+    "countryRank": 33
   },
   {
     "name": "University of Colombo",
@@ -21717,7 +23059,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1343
+    "aggregatedRank": 1343,
+    "countryRank": 1
   },
   {
     "name": "Metropolitan Autonomous University",
@@ -21729,7 +23072,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1344
+    "aggregatedRank": 1344,
+    "countryRank": 10
   },
   {
     "name": "Khon Kaen University",
@@ -21741,7 +23085,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1345
+    "aggregatedRank": 1345,
+    "countryRank": 7
   },
   {
     "name": "Prince of Songkla University",
@@ -21753,7 +23098,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1346
+    "aggregatedRank": 1346,
+    "countryRank": 8
   },
   {
     "name": "Rhodes University",
@@ -21765,7 +23111,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1347
+    "aggregatedRank": 1347,
+    "countryRank": 11
   },
   {
     "name": "Southern Federal University",
@@ -21777,7 +23124,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1348
+    "aggregatedRank": 1348,
+    "countryRank": 28
   },
   {
     "name": "Riga Stradins University",
@@ -21789,7 +23137,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1349
+    "aggregatedRank": 1349,
+    "countryRank": 3
   },
   {
     "name": "Indian Institute of Technology - Bhubaneswar",
@@ -21801,7 +23150,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1350
+    "aggregatedRank": 1350,
+    "countryRank": 58
   },
   {
     "name": "Almaty Technological University",
@@ -21813,7 +23163,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1351
+    "aggregatedRank": 1351,
+    "countryRank": 12
   },
   {
     "name": "Hainan University",
@@ -21825,7 +23176,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1352
+    "aggregatedRank": 1352,
+    "countryRank": 101
   },
   {
     "name": "Hefei University of Technology",
@@ -21837,7 +23189,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1353
+    "aggregatedRank": 1353,
+    "countryRank": 102
   },
   {
     "name": "Henan University",
@@ -21849,7 +23202,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1354
+    "aggregatedRank": 1354,
+    "countryRank": 103
   },
   {
     "name": "National University of Defense Technology",
@@ -21861,7 +23215,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1355
+    "aggregatedRank": 1355,
+    "countryRank": 104
   },
   {
     "name": "Ningbo University",
@@ -21873,7 +23228,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1356
+    "aggregatedRank": 1356,
+    "countryRank": 105
   },
   {
     "name": "Yunnan University",
@@ -21885,7 +23241,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1357
+    "aggregatedRank": 1357,
+    "countryRank": 106
   },
   {
     "name": "The Graduate Center - CUNY",
@@ -21897,7 +23254,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1358
+    "aggregatedRank": 1358,
+    "countryRank": 182
   },
   {
     "name": "University of Texas Medical Branch Galveston",
@@ -21909,7 +23267,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1359
+    "aggregatedRank": 1359,
+    "countryRank": 183
   },
   {
     "name": "Utah State University",
@@ -21921,7 +23280,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1360
+    "aggregatedRank": 1360,
+    "countryRank": 184
   },
   {
     "name": "Kunming University of Science and Technology",
@@ -21933,7 +23293,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1361
+    "aggregatedRank": 1361,
+    "countryRank": 107
   },
   {
     "name": "Okinawa Institute of Science and Technology Graduate University",
@@ -21945,7 +23306,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1362
+    "aggregatedRank": 1362,
+    "countryRank": 34
   },
   {
     "name": "Hohai University Changzhou",
@@ -21957,7 +23319,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1363
+    "aggregatedRank": 1363,
+    "countryRank": 108
   },
   {
     "name": "Anhui Medical University",
@@ -21969,7 +23332,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1364
+    "aggregatedRank": 1364,
+    "countryRank": 109
   },
   {
     "name": "Chongqing Medical University",
@@ -21981,7 +23345,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1365
+    "aggregatedRank": 1365,
+    "countryRank": 110
   },
   {
     "name": "Fujian Medical University",
@@ -21993,7 +23358,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1366
+    "aggregatedRank": 1366,
+    "countryRank": 111
   },
   {
     "name": "Guizhou University",
@@ -22005,7 +23371,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1367
+    "aggregatedRank": 1367,
+    "countryRank": 112
   },
   {
     "name": "Nanjing University of Traditional Chinese Medicine",
@@ -22017,7 +23384,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1368
+    "aggregatedRank": 1368,
+    "countryRank": 113
   },
   {
     "name": "Shaanxi Normal University",
@@ -22029,7 +23397,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1369
+    "aggregatedRank": 1369,
+    "countryRank": 114
   },
   {
     "name": "Shandong University of Science Technology",
@@ -22041,7 +23410,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1370
+    "aggregatedRank": 1370,
+    "countryRank": 115
   },
   {
     "name": "Tianjin Medical University",
@@ -22053,7 +23423,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1371
+    "aggregatedRank": 1371,
+    "countryRank": 116
   },
   {
     "name": "Xi'an University of Technology",
@@ -22065,7 +23436,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1372
+    "aggregatedRank": 1372,
+    "countryRank": 117
   },
   {
     "name": "University of La Laguna",
@@ -22077,7 +23449,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1373
+    "aggregatedRank": 1373,
+    "countryRank": 38
   },
   {
     "name": "University of Tromso",
@@ -22089,7 +23462,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1374
+    "aggregatedRank": 1374,
+    "countryRank": 6
   },
   {
     "name": "San Diego State University",
@@ -22101,7 +23475,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1375
+    "aggregatedRank": 1375,
+    "countryRank": 185
   },
   {
     "name": "University of Maine - Orono",
@@ -22113,7 +23488,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1376
+    "aggregatedRank": 1376,
+    "countryRank": 186
   },
   {
     "name": "Medical University of South Carolina",
@@ -22125,7 +23501,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1377
+    "aggregatedRank": 1377,
+    "countryRank": 187
   },
   {
     "name": "University of North Texas",
@@ -22137,7 +23514,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1378
+    "aggregatedRank": 1378,
+    "countryRank": 188
   },
   {
     "name": "West Virginia University",
@@ -22149,7 +23527,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1379
+    "aggregatedRank": 1379,
+    "countryRank": 189
   },
   {
     "name": "Southwest University",
@@ -22161,7 +23540,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1380
+    "aggregatedRank": 1380,
+    "countryRank": 118
   },
   {
     "name": "Zhejiang Science-Technology University",
@@ -22173,7 +23553,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1381
+    "aggregatedRank": 1381,
+    "countryRank": 119
   },
   {
     "name": "Hangzhou Dianzi University",
@@ -22185,7 +23566,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1382
+    "aggregatedRank": 1382,
+    "countryRank": 120
   },
   {
     "name": "The Chinese University of Hong Kong - Shenzhen",
@@ -22197,7 +23579,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1383
+    "aggregatedRank": 1383,
+    "countryRank": 121
   },
   {
     "name": "Hebei University of Technology",
@@ -22209,7 +23592,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1384
+    "aggregatedRank": 1384,
+    "countryRank": 122
   },
   {
     "name": "Second Military Medical University",
@@ -22221,7 +23605,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1385
+    "aggregatedRank": 1385,
+    "countryRank": 123
   },
   {
     "name": "Air Force Medical University",
@@ -22233,7 +23618,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1386
+    "aggregatedRank": 1386,
+    "countryRank": 124
   },
   {
     "name": "Dalian Maritime University",
@@ -22245,7 +23631,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1387
+    "aggregatedRank": 1387,
+    "countryRank": 125
   },
   {
     "name": "Fujian Normal University",
@@ -22257,7 +23644,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1388
+    "aggregatedRank": 1388,
+    "countryRank": 126
   },
   {
     "name": "Henan Normal University",
@@ -22269,7 +23657,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1389
+    "aggregatedRank": 1389,
+    "countryRank": 127
   },
   {
     "name": "Hunan Normal University",
@@ -22281,7 +23670,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1390
+    "aggregatedRank": 1390,
+    "countryRank": 128
   },
   {
     "name": "Qingdao University of Science and Technology",
@@ -22293,7 +23683,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1391
+    "aggregatedRank": 1391,
+    "countryRank": 129
   },
   {
     "name": "Shandong Agricultural University",
@@ -22305,7 +23696,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1392
+    "aggregatedRank": 1392,
+    "countryRank": 130
   },
   {
     "name": "Shanxi University",
@@ -22317,7 +23709,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1393
+    "aggregatedRank": 1393,
+    "countryRank": 131
   },
   {
     "name": "Taiyuan University of Technology",
@@ -22329,7 +23722,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1394
+    "aggregatedRank": 1394,
+    "countryRank": 132
   },
   {
     "name": "University of Lubeck",
@@ -22341,7 +23735,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1395
+    "aggregatedRank": 1395,
+    "countryRank": 65
   },
   {
     "name": "University of Bielefeld",
@@ -22353,7 +23748,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1396
+    "aggregatedRank": 1396,
+    "countryRank": 66
   },
   {
     "name": "Tarbiat Modares University",
@@ -22365,7 +23761,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1397
+    "aggregatedRank": 1397,
+    "countryRank": 38
   },
   {
     "name": "Shinshu University",
@@ -22377,7 +23774,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1398
+    "aggregatedRank": 1398,
+    "countryRank": 35
   },
   {
     "name": "University of Louisville",
@@ -22389,7 +23787,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1399
+    "aggregatedRank": 1399,
+    "countryRank": 190
   },
   {
     "name": "University of Nevada - Reno",
@@ -22401,7 +23800,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1400
+    "aggregatedRank": 1400,
+    "countryRank": 191
   },
   {
     "name": "University of New Hampshire",
@@ -22413,7 +23813,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1401
+    "aggregatedRank": 1401,
+    "countryRank": 192
   },
   {
     "name": "Brigham Young University",
@@ -22425,7 +23826,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1402
+    "aggregatedRank": 1402,
+    "countryRank": 193
   },
   {
     "name": "Medical College of Wisconsin",
@@ -22437,7 +23839,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1403
+    "aggregatedRank": 1403,
+    "countryRank": 194
   },
   {
     "name": "University of Natural Resources and Life Sciences",
@@ -22449,7 +23852,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1404
+    "aggregatedRank": 1404,
+    "countryRank": 13
   },
   {
     "name": "Nantong University",
@@ -22461,7 +23865,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1405
+    "aggregatedRank": 1405,
+    "countryRank": 133
   },
   {
     "name": "Yanshan University",
@@ -22473,7 +23878,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1406
+    "aggregatedRank": 1406,
+    "countryRank": 134
   },
   {
     "name": "Fujian Agriculture and Forestry University",
@@ -22485,7 +23891,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1407
+    "aggregatedRank": 1407,
+    "countryRank": 135
   },
   {
     "name": "Duke-NUS Medical School",
@@ -22497,7 +23904,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1408
+    "aggregatedRank": 1408,
+    "countryRank": 6
   },
   {
     "name": "Zhejiang Chinese Medical University",
@@ -22509,7 +23917,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1409
+    "aggregatedRank": 1409,
+    "countryRank": 136
   },
   {
     "name": "Qilu University of Technology",
@@ -22521,7 +23930,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1410
+    "aggregatedRank": 1410,
+    "countryRank": 137
   },
   {
     "name": "Shandong First Medical University",
@@ -22533,7 +23943,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1411
+    "aggregatedRank": 1411,
+    "countryRank": 138
   },
   {
     "name": "University of Health Sciences Turkey",
@@ -22545,7 +23956,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1412
+    "aggregatedRank": 1412,
+    "countryRank": 16
   },
   {
     "name": "Federal University of Santa Maria",
@@ -22557,7 +23969,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1413
+    "aggregatedRank": 1413,
+    "countryRank": 12
   },
   {
     "name": "Federal University of Paran�",
@@ -22569,7 +23982,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1414
+    "aggregatedRank": 1414,
+    "countryRank": 13
   },
   {
     "name": "Beijing Forestry University",
@@ -22581,7 +23995,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1415
+    "aggregatedRank": 1415,
+    "countryRank": 139
   },
   {
     "name": "China Medical University",
@@ -22593,7 +24008,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1416
+    "aggregatedRank": 1416,
+    "countryRank": 140
   },
   {
     "name": "Chongqing University of Posts and Telecommunications",
@@ -22605,7 +24021,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1417
+    "aggregatedRank": 1417,
+    "countryRank": 141
   },
   {
     "name": "Harbin Medical University",
@@ -22617,7 +24034,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1418
+    "aggregatedRank": 1418,
+    "countryRank": 142
   },
   {
     "name": "Hubei University",
@@ -22629,7 +24047,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1419
+    "aggregatedRank": 1419,
+    "countryRank": 143
   },
   {
     "name": "Shantou University",
@@ -22641,7 +24060,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1420
+    "aggregatedRank": 1420,
+    "countryRank": 144
   },
   {
     "name": "Xinjiang University",
@@ -22653,7 +24073,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1421
+    "aggregatedRank": 1421,
+    "countryRank": 145
   },
   {
     "name": "University of Oldenburg",
@@ -22665,7 +24086,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1422
+    "aggregatedRank": 1422,
+    "countryRank": 67
   },
   {
     "name": "University of Magdeburg",
@@ -22677,7 +24099,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1423
+    "aggregatedRank": 1423,
+    "countryRank": 68
   },
   {
     "name": "University of Augsburg",
@@ -22689,7 +24112,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1424
+    "aggregatedRank": 1424,
+    "countryRank": 69
   },
   {
     "name": "Copenhagen Business School",
@@ -22701,7 +24125,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1425
+    "aggregatedRank": 1425,
+    "countryRank": 7
   },
   {
     "name": "University of Extremadura",
@@ -22713,7 +24138,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1426
+    "aggregatedRank": 1426,
+    "countryRank": 39
   },
   {
     "name": "University of M�laga",
@@ -22725,7 +24151,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1427
+    "aggregatedRank": 1427,
+    "countryRank": 40
   },
   {
     "name": "Kindai University",
@@ -22737,7 +24164,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1428
+    "aggregatedRank": 1428,
+    "countryRank": 36
   },
   {
     "name": "Kitasato University",
@@ -22749,7 +24177,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1429
+    "aggregatedRank": 1429,
+    "countryRank": 37
   },
   {
     "name": "Chungbuk National University",
@@ -22761,7 +24190,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1430
+    "aggregatedRank": 1430,
+    "countryRank": 32
   },
   {
     "name": "Stockholm School of Economics",
@@ -22773,7 +24203,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1431
+    "aggregatedRank": 1431,
+    "countryRank": 15
   },
   {
     "name": "University of Idaho",
@@ -22785,7 +24216,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1432
+    "aggregatedRank": 1432,
+    "countryRank": 195
   },
   {
     "name": "Kent State University",
@@ -22797,7 +24229,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1433
+    "aggregatedRank": 1433,
+    "countryRank": 196
   },
   {
     "name": "Southern Methodist University",
@@ -22809,7 +24242,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1434
+    "aggregatedRank": 1434,
+    "countryRank": 197
   },
   {
     "name": "University of Tennessee Health Science Center",
@@ -22821,7 +24255,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1435
+    "aggregatedRank": 1435,
+    "countryRank": 198
   },
   {
     "name": "University Paris-Est Cr�teil Val de Marne",
@@ -22833,7 +24268,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1436
+    "aggregatedRank": 1436,
+    "countryRank": 52
   },
   {
     "name": "Army Medical University",
@@ -22845,7 +24281,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1437
+    "aggregatedRank": 1437,
+    "countryRank": 146
   },
   {
     "name": "Southwestern University of Finance and Economics",
@@ -22857,7 +24294,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1438
+    "aggregatedRank": 1438,
+    "countryRank": 147
   },
   {
     "name": "Chang'an University",
@@ -22869,7 +24307,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1439
+    "aggregatedRank": 1439,
+    "countryRank": 148
   },
   {
     "name": "Beijing Technology and Business University",
@@ -22881,7 +24320,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1440
+    "aggregatedRank": 1440,
+    "countryRank": 149
   },
   {
     "name": "Shanghai Ocean University",
@@ -22893,7 +24333,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1441
+    "aggregatedRank": 1441,
+    "countryRank": 150
   },
   {
     "name": "Homi Bhabha National Institute",
@@ -22905,7 +24346,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1442
+    "aggregatedRank": 1442,
+    "countryRank": 59
   },
   {
     "name": "Suzhou University of Science and Technology",
@@ -22917,7 +24359,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1443
+    "aggregatedRank": 1443,
+    "countryRank": 151
   },
   {
     "name": "Federal University of S�o Carlos",
@@ -22929,7 +24372,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1444
+    "aggregatedRank": 1444,
+    "countryRank": 14
   },
   {
     "name": "Federal University of Vi�osa",
@@ -22941,7 +24385,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1445
+    "aggregatedRank": 1445,
+    "countryRank": 15
   },
   {
     "name": "University of Qu�bec at Montreal",
@@ -22953,7 +24398,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1446
+    "aggregatedRank": 1446,
+    "countryRank": 33
   },
   {
     "name": "Capital Normal University",
@@ -22965,7 +24411,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1447
+    "aggregatedRank": 1447,
+    "countryRank": 152
   },
   {
     "name": "Hebei Medical University",
@@ -22977,7 +24424,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1448
+    "aggregatedRank": 1448,
+    "countryRank": 153
   },
   {
     "name": "Heilongjiang University",
@@ -22989,7 +24437,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1449
+    "aggregatedRank": 1449,
+    "countryRank": 154
   },
   {
     "name": "Jiangxi Normal University",
@@ -23001,7 +24450,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1450
+    "aggregatedRank": 1450,
+    "countryRank": 155
   },
   {
     "name": "Jimei University",
@@ -23013,7 +24463,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1451
+    "aggregatedRank": 1451,
+    "countryRank": 156
   },
   {
     "name": "Liaocheng Teachers University",
@@ -23025,7 +24476,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1452
+    "aggregatedRank": 1452,
+    "countryRank": 157
   },
   {
     "name": "Shandong Normal University",
@@ -23037,7 +24489,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1453
+    "aggregatedRank": 1453,
+    "countryRank": 158
   },
   {
     "name": "Shanghai Normal University",
@@ -23049,7 +24502,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1454
+    "aggregatedRank": 1454,
+    "countryRank": 159
   },
   {
     "name": "Sichuan Agricultural University",
@@ -23061,7 +24515,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1455
+    "aggregatedRank": 1455,
+    "countryRank": 160
   },
   {
     "name": "Xi'an University of Architecture and Technology",
@@ -23073,7 +24528,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1456
+    "aggregatedRank": 1456,
+    "countryRank": 161
   },
   {
     "name": "Xiangtan University",
@@ -23085,7 +24541,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1457
+    "aggregatedRank": 1457,
+    "countryRank": 162
   },
   {
     "name": "Zhongnan University of Economics and Law",
@@ -23097,7 +24554,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1458
+    "aggregatedRank": 1458,
+    "countryRank": 163
   },
   {
     "name": "University of Kassel",
@@ -23109,7 +24567,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1459
+    "aggregatedRank": 1459,
+    "countryRank": 70
   },
   {
     "name": "University of Oviedo",
@@ -23121,7 +24580,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1460
+    "aggregatedRank": 1460,
+    "countryRank": 41
   },
   {
     "name": "University of Burgundy",
@@ -23133,7 +24593,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1461
+    "aggregatedRank": 1461,
+    "countryRank": 53
   },
   {
     "name": "University of Thessaly",
@@ -23145,7 +24606,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1462
+    "aggregatedRank": 1462,
+    "countryRank": 9
   },
   {
     "name": "Education University of Hong Kong",
@@ -23157,7 +24619,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1463
+    "aggregatedRank": 1463,
+    "countryRank": 8
   },
   {
     "name": "Graduate University for Advanced Studies",
@@ -23169,7 +24632,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1464
+    "aggregatedRank": 1464,
+    "countryRank": 38
   },
   {
     "name": "Kangwon National University",
@@ -23181,7 +24645,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1465
+    "aggregatedRank": 1465,
+    "countryRank": 33
   },
   {
     "name": "Cranfield University",
@@ -23193,7 +24658,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1466
+    "aggregatedRank": 1466,
+    "countryRank": 99
   },
   {
     "name": "University of Missouri - Kansas City",
@@ -23205,7 +24671,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1467
+    "aggregatedRank": 1467,
+    "countryRank": 199
   },
   {
     "name": "University of Wisconsin-Milwaukee",
@@ -23217,7 +24684,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1468
+    "aggregatedRank": 1468,
+    "countryRank": 200
   },
   {
     "name": "Northeast Forestry University",
@@ -23229,7 +24697,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1469
+    "aggregatedRank": 1469,
+    "countryRank": 164
   },
   {
     "name": "Hangzhou Normal University",
@@ -23241,7 +24710,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1470
+    "aggregatedRank": 1470,
+    "countryRank": 165
   },
   {
     "name": "Southwest Petroleum University",
@@ -23253,7 +24723,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1471
+    "aggregatedRank": 1471,
+    "countryRank": 166
   },
   {
     "name": "Anhui Agricultural University",
@@ -23265,7 +24736,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1472
+    "aggregatedRank": 1472,
+    "countryRank": 167
   },
   {
     "name": "Xuzhou Medical College",
@@ -23277,7 +24749,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1473
+    "aggregatedRank": 1473,
+    "countryRank": 168
   },
   {
     "name": "Shaanxi University of Science and Technology",
@@ -23289,7 +24762,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1474
+    "aggregatedRank": 1474,
+    "countryRank": 169
   },
   {
     "name": "Qingdao Agricultural University",
@@ -23301,7 +24775,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1475
+    "aggregatedRank": 1475,
+    "countryRank": 170
   },
   {
     "name": "Skolkovo Institute of Science and Technology",
@@ -23313,7 +24788,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1476
+    "aggregatedRank": 1476,
+    "countryRank": 29
   },
   {
     "name": "Istanbul University Cerrahpasa",
@@ -23325,7 +24801,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1477
+    "aggregatedRank": 1477,
+    "countryRank": 17
   },
   {
     "name": "SUNY Downstate Health Sciences University",
@@ -23337,7 +24814,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1478
+    "aggregatedRank": 1478,
+    "countryRank": 201
   },
   {
     "name": "University of Texas Rio Grande Valley",
@@ -23349,7 +24827,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1479
+    "aggregatedRank": 1479,
+    "countryRank": 202
   },
   {
     "name": "Federal University of Bahia",
@@ -23361,7 +24840,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1480
+    "aggregatedRank": 1480,
+    "countryRank": 16
   },
   {
     "name": "Federal University of Goi�s",
@@ -23373,7 +24853,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1481
+    "aggregatedRank": 1481,
+    "countryRank": 17
   },
   {
     "name": "Federal University of Pelotas",
@@ -23385,7 +24866,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1482
+    "aggregatedRank": 1482,
+    "countryRank": 18
   },
   {
     "name": "Federal University of Pernambuco",
@@ -23397,7 +24879,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1483
+    "aggregatedRank": 1483,
+    "countryRank": 19
   },
   {
     "name": "Federal University of Cear�",
@@ -23409,7 +24892,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1484
+    "aggregatedRank": 1484,
+    "countryRank": 20
   },
   {
     "name": "Lakehead University",
@@ -23421,7 +24905,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1485
+    "aggregatedRank": 1485,
+    "countryRank": 34
   },
   {
     "name": "National University Andr�s Bello",
@@ -23433,7 +24918,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1486
+    "aggregatedRank": 1486,
+    "countryRank": 10
   },
   {
     "name": "Dalian Medical University",
@@ -23445,7 +24931,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1487
+    "aggregatedRank": 1487,
+    "countryRank": 171
   },
   {
     "name": "Guangzhou University of Traditional Chinese Medicine",
@@ -23457,7 +24944,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1488
+    "aggregatedRank": 1488,
+    "countryRank": 172
   },
   {
     "name": "Harbin University of Science and Technology",
@@ -23469,7 +24957,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1489
+    "aggregatedRank": 1489,
+    "countryRank": 173
   },
   {
     "name": "Henan Agricultural University",
@@ -23481,7 +24970,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1490
+    "aggregatedRank": 1490,
+    "countryRank": 174
   },
   {
     "name": "Inner Mongolia University",
@@ -23493,7 +24983,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1491
+    "aggregatedRank": 1491,
+    "countryRank": 175
   },
   {
     "name": "Huaqiao University",
@@ -23505,7 +24996,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1492
+    "aggregatedRank": 1492,
+    "countryRank": 176
   },
   {
     "name": "North China University of Technology",
@@ -23517,7 +25009,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1493
+    "aggregatedRank": 1493,
+    "countryRank": 177
   },
   {
     "name": "Shanghai University of Finance and Economics",
@@ -23529,7 +25022,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1494
+    "aggregatedRank": 1494,
+    "countryRank": 178
   },
   {
     "name": "Shanghai University of Traditional Chinese Medicine and Pharmacology",
@@ -23541,7 +25035,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1495
+    "aggregatedRank": 1495,
+    "countryRank": 179
   },
   {
     "name": "Yantai University",
@@ -23553,7 +25048,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1496
+    "aggregatedRank": 1496,
+    "countryRank": 180
   },
   {
     "name": "Suez Canal University",
@@ -23565,7 +25061,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1497
+    "aggregatedRank": 1497,
+    "countryRank": 12
   },
   {
     "name": "Tanta University",
@@ -23577,7 +25074,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1498
+    "aggregatedRank": 1498,
+    "countryRank": 13
   },
   {
     "name": "University of C�diz",
@@ -23589,7 +25087,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1499
+    "aggregatedRank": 1499,
+    "countryRank": 42
   },
   {
     "name": "University of Poitiers",
@@ -23601,7 +25100,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1500
+    "aggregatedRank": 1500,
+    "countryRank": 54
   },
   {
     "name": "Tokushima University",
@@ -23613,7 +25113,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1501
+    "aggregatedRank": 1501,
+    "countryRank": 39
   },
   {
     "name": "Gyeongsang National University",
@@ -23625,7 +25126,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1502
+    "aggregatedRank": 1502,
+    "countryRank": 34
   },
   {
     "name": "Ataturk University",
@@ -23637,7 +25139,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1503
+    "aggregatedRank": 1503,
+    "countryRank": 18
   },
   {
     "name": "Cukurova University",
@@ -23649,7 +25152,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1504
+    "aggregatedRank": 1504,
+    "countryRank": 19
   },
   {
     "name": "Augusta State University",
@@ -23661,7 +25165,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1505
+    "aggregatedRank": 1505,
+    "countryRank": 203
   },
   {
     "name": "Loyola University of Chicago",
@@ -23673,7 +25178,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1506
+    "aggregatedRank": 1506,
+    "countryRank": 204
   },
   {
     "name": "Amherst College",
@@ -23685,7 +25191,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1507
+    "aggregatedRank": 1507,
+    "countryRank": 205
   },
   {
     "name": "North Dakota State University",
@@ -23697,7 +25204,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1508
+    "aggregatedRank": 1508,
+    "countryRank": 206
   },
   {
     "name": "Guangxi Medical University",
@@ -23709,7 +25217,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1509
+    "aggregatedRank": 1509,
+    "countryRank": 181
   },
   {
     "name": "University of Novi Sad",
@@ -23721,7 +25230,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1510
+    "aggregatedRank": 1510,
+    "countryRank": 2
   },
   {
     "name": "University of Alabama in Huntsville",
@@ -23733,7 +25243,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1511
+    "aggregatedRank": 1511,
+    "countryRank": 207
   },
   {
     "name": "Liaoning University of Technology",
@@ -23745,7 +25256,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1512
+    "aggregatedRank": 1512,
+    "countryRank": 182
   },
   {
     "name": "Linnaeus University",
@@ -23757,7 +25269,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1513
+    "aggregatedRank": 1513,
+    "countryRank": 16
   },
   {
     "name": "Shanxi Medical University",
@@ -23769,7 +25282,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1514
+    "aggregatedRank": 1514,
+    "countryRank": 183
   },
   {
     "name": "Henan Polytechnic University",
@@ -23781,7 +25295,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1515
+    "aggregatedRank": 1515,
+    "countryRank": 184
   },
   {
     "name": "Yangtze University",
@@ -23793,7 +25308,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1516
+    "aggregatedRank": 1516,
+    "countryRank": 185
   },
   {
     "name": "Western Norway University of Applied Sciences",
@@ -23805,7 +25321,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1517
+    "aggregatedRank": 1517,
+    "countryRank": 7
   },
   {
     "name": "Zhejiang A & F University",
@@ -23817,7 +25334,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1518
+    "aggregatedRank": 1518,
+    "countryRank": 186
   },
   {
     "name": "Dalian Polytechnic University",
@@ -23829,7 +25347,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1519
+    "aggregatedRank": 1519,
+    "countryRank": 187
   },
   {
     "name": "Guangdong Ocean University",
@@ -23841,7 +25360,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1520
+    "aggregatedRank": 1520,
+    "countryRank": 188
   },
   {
     "name": "Guilin University of Electronic Technology",
@@ -23853,7 +25373,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1521
+    "aggregatedRank": 1521,
+    "countryRank": 189
   },
   {
     "name": "Hassan II University of Casablanca",
@@ -23865,6 +25386,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1522
+    "aggregatedRank": 1522,
+    "countryRank": 2
   }
 ]

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -280,6 +280,10 @@ function App() {
                             <Globe className="w-4 h-4" />
                             <span>{university.country}</span>
                           </div>
+                          <div className="flex items-center gap-1">
+                            <TrendingUp className="w-4 h-4" />
+                            <span>#{university.countryRank}</span>
+                          </div>
                         </div>
                       </div>
                       <button
@@ -367,7 +371,7 @@ function App() {
                           Performance Metrics
                         </h4>
                         
-                        <div className="grid grid-cols-2 gap-4 mb-6">
+                        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
                           <div className="bg-white/5 rounded-xl p-4 border border-white/10 text-center">
                             <div className="text-2xl font-bold text-yellow-400 mb-1">
                               {university.aggregatedScore.toFixed(2)}
@@ -379,6 +383,12 @@ function App() {
                               {university.appearances}
                             </div>
                             <div className="text-xs text-purple-200">Rankings Featured</div>
+                          </div>
+                          <div className="bg-white/5 rounded-xl p-4 border border-white/10 text-center">
+                            <div className="text-2xl font-bold text-blue-400 mb-1">
+                              #{university.countryRank}
+                            </div>
+                            <div className="text-xs text-purple-200">Country Rank</div>
                           </div>
                         </div>
                         

--- a/scripts/aggregation.js
+++ b/scripts/aggregation.js
@@ -115,6 +115,17 @@ function aggregateRankings(universitiesData, sourceWeights, sourceMaxRanks, tota
         university.aggregatedRank = index + 1;
     });
 
+    // Calculate country-specific ranks based on the global ordering
+    const countryCounters = {};
+    aggregatedResults.forEach(university => {
+        const country = university.country || 'Unknown';
+        if (!countryCounters[country]) {
+            countryCounters[country] = 0;
+        }
+        countryCounters[country]++;
+        university.countryRank = countryCounters[country];
+    });
+
     return aggregatedResults;
 }
 


### PR DESCRIPTION
## Summary
- include new `countryRank` field in aggregated data
- compute country ranks in aggregation step
- display country rank in UI performance metrics
- show the national rank in the summary badges
- document the meaning of `countryRank`

## Testing
- `npm install`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68428afb91c88320933a2046520f0ad8