### PR TITLE
Add manual mapping for Washington University

### DIFF
--- a/frontend/public/data/aggregated-rankings.json
+++ b/frontend/public/data/aggregated-rankings.json
@@ -1056,6 +1056,28 @@
     "countryRank": 6
   },
   {
+    "name": "Washington University (WUSTL)",
+    "country": "United States",
+    "aggregatedScore": 1637.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 176
+      },
+      "the": {
+        "rank": 69
+      },
+      "arwu": {
+        "rank": 23
+      },
+      "usnews": {
+        "rank": 30
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 49,
+    "countryRank": 19
+  },
+  {
     "name": "University of North Carolina Chapel Hill",
     "country": "United States",
     "aggregatedScore": 1635.5,
@@ -1074,8 +1096,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 49,
-    "countryRank": 19
+    "aggregatedRank": 50,
+    "countryRank": 20
   },
   {
     "name": "Seoul National University (SNU)",
@@ -1096,7 +1118,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 50,
+    "aggregatedRank": 51,
     "countryRank": 1
   },
   {
@@ -1118,8 +1140,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 51,
-    "countryRank": 20
+    "aggregatedRank": 52,
+    "countryRank": 21
   },
   {
     "name": "Kyoto University",
@@ -1140,7 +1162,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 52,
+    "aggregatedRank": 53,
     "countryRank": 1
   },
   {
@@ -1162,7 +1184,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 53,
+    "aggregatedRank": 54,
     "countryRank": 2
   },
   {
@@ -1184,7 +1206,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 54,
+    "aggregatedRank": 55,
     "countryRank": 8
   },
   {
@@ -1206,7 +1228,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 55,
+    "aggregatedRank": 56,
     "countryRank": 9
   },
   {
@@ -1228,8 +1250,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 56,
-    "countryRank": 21
+    "aggregatedRank": 57,
+    "countryRank": 22
   },
   {
     "name": "Boston University",
@@ -1250,8 +1272,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 57,
-    "countryRank": 22
+    "aggregatedRank": 58,
+    "countryRank": 23
   },
   {
     "name": "Hong Kong Polytechnic University",
@@ -1272,7 +1294,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 58,
+    "aggregatedRank": 59,
     "countryRank": 3
   },
   {
@@ -1294,8 +1316,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 59,
-    "countryRank": 23
+    "aggregatedRank": 60,
+    "countryRank": 24
   },
   {
     "name": "University of Groningen",
@@ -1316,7 +1338,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 60,
+    "aggregatedRank": 61,
     "countryRank": 2
   },
   {
@@ -1338,8 +1360,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 61,
-    "countryRank": 24
+    "aggregatedRank": 62,
+    "countryRank": 25
   },
   {
     "name": "Nanjing University",
@@ -1360,7 +1382,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 62,
+    "aggregatedRank": 63,
     "countryRank": 6
   },
   {
@@ -1382,8 +1404,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 63,
-    "countryRank": 25
+    "aggregatedRank": 64,
+    "countryRank": 26
   },
   {
     "name": "Lund University",
@@ -1404,7 +1426,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 64,
+    "aggregatedRank": 65,
     "countryRank": 1
   },
   {
@@ -1426,8 +1448,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 65,
-    "countryRank": 26
+    "aggregatedRank": 66,
+    "countryRank": 27
   },
   {
     "name": "University of Minnesota Twin Cities",
@@ -1448,8 +1470,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 66,
-    "countryRank": 27
+    "aggregatedRank": 67,
+    "countryRank": 28
   },
   {
     "name": "University of Oslo",
@@ -1470,7 +1492,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 67,
+    "aggregatedRank": 68,
     "countryRank": 1
   },
   {
@@ -1492,7 +1514,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 68,
+    "aggregatedRank": 69,
     "countryRank": 7
   },
   {
@@ -1514,7 +1536,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 69,
+    "aggregatedRank": 70,
     "countryRank": 10
   },
   {
@@ -1536,8 +1558,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 70,
-    "countryRank": 28
+    "aggregatedRank": 71,
+    "countryRank": 29
   },
   {
     "name": "University of Helsinki",
@@ -1558,7 +1580,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 71,
+    "aggregatedRank": 72,
     "countryRank": 1
   },
   {
@@ -1580,7 +1602,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 72,
+    "aggregatedRank": 73,
     "countryRank": 3
   },
   {
@@ -1602,7 +1624,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 73,
+    "aggregatedRank": 74,
     "countryRank": 4
   },
   {
@@ -1624,7 +1646,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 74,
+    "aggregatedRank": 75,
     "countryRank": 11
   },
   {
@@ -1646,7 +1668,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 75,
+    "aggregatedRank": 76,
     "countryRank": 2
   },
   {
@@ -1668,7 +1690,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 76,
+    "aggregatedRank": 77,
     "countryRank": 8
   },
   {
@@ -1690,8 +1712,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 77,
-    "countryRank": 29
+    "aggregatedRank": 78,
+    "countryRank": 30
   },
   {
     "name": "University of Maryland College Park",
@@ -1712,8 +1734,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 78,
-    "countryRank": 30
+    "aggregatedRank": 79,
+    "countryRank": 31
   },
   {
     "name": "University of Alberta",
@@ -1734,7 +1756,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 79,
+    "aggregatedRank": 80,
     "countryRank": 4
   },
   {
@@ -1756,8 +1778,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 80,
-    "countryRank": 31
+    "aggregatedRank": 81,
+    "countryRank": 32
   },
   {
     "name": "Vanderbilt University",
@@ -1778,8 +1800,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 81,
-    "countryRank": 32
+    "aggregatedRank": 82,
+    "countryRank": 33
   },
   {
     "name": "University of Southampton",
@@ -1800,7 +1822,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 82,
+    "aggregatedRank": 83,
     "countryRank": 12
   },
   {
@@ -1822,7 +1844,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 83,
+    "aggregatedRank": 84,
     "countryRank": 2
   },
   {
@@ -1844,7 +1866,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 84,
+    "aggregatedRank": 85,
     "countryRank": 2
   },
   {
@@ -1866,7 +1888,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 85,
+    "aggregatedRank": 86,
     "countryRank": 13
   },
   {
@@ -1888,7 +1910,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 86,
+    "aggregatedRank": 87,
     "countryRank": 14
   },
   {
@@ -1910,7 +1932,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 87,
+    "aggregatedRank": 88,
     "countryRank": 15
   },
   {
@@ -1932,7 +1954,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 88,
+    "aggregatedRank": 89,
     "countryRank": 3
   },
   {
@@ -1954,7 +1976,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 89,
+    "aggregatedRank": 90,
     "countryRank": 5
   },
   {
@@ -1976,7 +1998,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 90,
+    "aggregatedRank": 91,
     "countryRank": 7
   },
   {
@@ -1998,7 +2020,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 91,
+    "aggregatedRank": 92,
     "countryRank": 9
   },
   {
@@ -2020,7 +2042,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 92,
+    "aggregatedRank": 93,
     "countryRank": 3
   },
   {
@@ -2042,7 +2064,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 93,
+    "aggregatedRank": 94,
     "countryRank": 1
   },
   {
@@ -2064,8 +2086,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 94,
-    "countryRank": 33
+    "aggregatedRank": 95,
+    "countryRank": 34
   },
   {
     "name": "University of Geneva",
@@ -2086,7 +2108,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 95,
+    "aggregatedRank": 96,
     "countryRank": 4
   },
   {
@@ -2108,7 +2130,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 96,
+    "aggregatedRank": 97,
     "countryRank": 1
   },
   {
@@ -2130,8 +2152,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 97,
-    "countryRank": 34
+    "aggregatedRank": 98,
+    "countryRank": 35
   },
   {
     "name": "University of Pittsburgh",
@@ -2152,8 +2174,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 98,
-    "countryRank": 35
+    "aggregatedRank": 99,
+    "countryRank": 36
   },
   {
     "name": "University of Vienna",
@@ -2174,7 +2196,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 99,
+    "aggregatedRank": 100,
     "countryRank": 1
   },
   {
@@ -2196,7 +2218,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 100,
+    "aggregatedRank": 101,
     "countryRank": 16
   },
   {
@@ -2218,7 +2240,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 101,
+    "aggregatedRank": 102,
     "countryRank": 2
   },
   {
@@ -2240,7 +2262,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 102,
+    "aggregatedRank": 103,
     "countryRank": 3
   },
   {
@@ -2262,7 +2284,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 103,
+    "aggregatedRank": 104,
     "countryRank": 3
   },
   {
@@ -2284,8 +2306,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 104,
-    "countryRank": 36
+    "aggregatedRank": 105,
+    "countryRank": 37
   },
   {
     "name": "RWTH Aachen University",
@@ -2306,7 +2328,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 105,
+    "aggregatedRank": 106,
     "countryRank": 4
   },
   {
@@ -2328,7 +2350,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 106,
+    "aggregatedRank": 107,
     "countryRank": 1
   },
   {
@@ -2350,7 +2372,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 107,
+    "aggregatedRank": 108,
     "countryRank": 17
   },
   {
@@ -2372,7 +2394,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 108,
+    "aggregatedRank": 109,
     "countryRank": 4
   },
   {
@@ -2394,7 +2416,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 109,
+    "aggregatedRank": 110,
     "countryRank": 6
   },
   {
@@ -2416,7 +2438,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 110,
+    "aggregatedRank": 111,
     "countryRank": 4
   },
   {
@@ -2438,7 +2460,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 111,
+    "aggregatedRank": 112,
     "countryRank": 3
   },
   {
@@ -2460,7 +2482,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 112,
+    "aggregatedRank": 113,
     "countryRank": 1
   },
   {
@@ -2482,7 +2504,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 113,
+    "aggregatedRank": 114,
     "countryRank": 5
   },
   {
@@ -2504,7 +2526,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 114,
+    "aggregatedRank": 115,
     "countryRank": 8
   },
   {
@@ -2526,7 +2548,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 115,
+    "aggregatedRank": 116,
     "countryRank": 4
   },
   {
@@ -2548,7 +2570,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 116,
+    "aggregatedRank": 117,
     "countryRank": 5
   },
   {
@@ -2570,7 +2592,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 117,
+    "aggregatedRank": 118,
     "countryRank": 9
   },
   {
@@ -2592,7 +2614,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 118,
+    "aggregatedRank": 119,
     "countryRank": 1
   },
   {
@@ -2614,7 +2636,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 119,
+    "aggregatedRank": 120,
     "countryRank": 6
   },
   {
@@ -2636,7 +2658,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 120,
+    "aggregatedRank": 121,
     "countryRank": 1
   },
   {
@@ -2658,7 +2680,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 121,
+    "aggregatedRank": 122,
     "countryRank": 1
   },
   {
@@ -2680,8 +2702,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 122,
-    "countryRank": 37
+    "aggregatedRank": 123,
+    "countryRank": 38
   },
   {
     "name": "Macquarie University",
@@ -2702,7 +2724,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 123,
+    "aggregatedRank": 124,
     "countryRank": 10
   },
   {
@@ -2724,7 +2746,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 124,
+    "aggregatedRank": 125,
     "countryRank": 10
   },
   {
@@ -2746,8 +2768,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 125,
-    "countryRank": 38
+    "aggregatedRank": 126,
+    "countryRank": 39
   },
   {
     "name": "Cardiff University",
@@ -2768,7 +2790,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 126,
+    "aggregatedRank": 127,
     "countryRank": 18
   },
   {
@@ -2790,8 +2812,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 127,
-    "countryRank": 39
+    "aggregatedRank": 128,
+    "countryRank": 40
   },
   {
     "name": "Arizona State University-Tempe",
@@ -2812,8 +2834,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 128,
-    "countryRank": 40
+    "aggregatedRank": 129,
+    "countryRank": 41
   },
   {
     "name": "Tohoku University",
@@ -2834,7 +2856,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 129,
+    "aggregatedRank": 130,
     "countryRank": 2
   },
   {
@@ -2856,7 +2878,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 130,
+    "aggregatedRank": 131,
     "countryRank": 7
   },
   {
@@ -2878,7 +2900,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 131,
+    "aggregatedRank": 132,
     "countryRank": 5
   },
   {
@@ -2900,7 +2922,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 132,
+    "aggregatedRank": 133,
     "countryRank": 7
   },
   {
@@ -2922,7 +2944,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 133,
+    "aggregatedRank": 134,
     "countryRank": 3
   },
   {
@@ -2944,7 +2966,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 134,
+    "aggregatedRank": 135,
     "countryRank": 11
   },
   {
@@ -2966,7 +2988,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 135,
+    "aggregatedRank": 136,
     "countryRank": 2
   },
   {
@@ -2988,7 +3010,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 136,
+    "aggregatedRank": 137,
     "countryRank": 12
   },
   {
@@ -3010,7 +3032,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 137,
+    "aggregatedRank": 138,
     "countryRank": 13
   },
   {
@@ -3032,7 +3054,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 138,
+    "aggregatedRank": 139,
     "countryRank": 2
   },
   {
@@ -3054,7 +3076,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 139,
+    "aggregatedRank": 140,
     "countryRank": 11
   },
   {
@@ -3076,7 +3098,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 140,
+    "aggregatedRank": 141,
     "countryRank": 8
   },
   {
@@ -3098,7 +3120,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 141,
+    "aggregatedRank": 142,
     "countryRank": 14
   },
   {
@@ -3120,8 +3142,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 142,
-    "countryRank": 41
+    "aggregatedRank": 143,
+    "countryRank": 42
   },
   {
     "name": "Tel Aviv University",
@@ -3142,7 +3164,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 143,
+    "aggregatedRank": 144,
     "countryRank": 1
   },
   {
@@ -3164,7 +3186,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 144,
+    "aggregatedRank": 145,
     "countryRank": 12
   },
   {
@@ -3186,7 +3208,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 145,
+    "aggregatedRank": 146,
     "countryRank": 1
   },
   {
@@ -3208,7 +3230,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 146,
+    "aggregatedRank": 147,
     "countryRank": 8
   },
   {
@@ -3230,7 +3252,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 147,
+    "aggregatedRank": 148,
     "countryRank": 13
   },
   {
@@ -3252,7 +3274,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 148,
+    "aggregatedRank": 149,
     "countryRank": 2
   },
   {
@@ -3274,7 +3296,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 149,
+    "aggregatedRank": 150,
     "countryRank": 4
   },
   {
@@ -3296,7 +3318,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 150,
+    "aggregatedRank": 151,
     "countryRank": 3
   },
   {
@@ -3318,7 +3340,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 151,
+    "aggregatedRank": 152,
     "countryRank": 9
   },
   {
@@ -3340,7 +3362,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 152,
+    "aggregatedRank": 153,
     "countryRank": 9
   },
   {
@@ -3362,7 +3384,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 153,
+    "aggregatedRank": 154,
     "countryRank": 19
   },
   {
@@ -3384,7 +3406,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 154,
+    "aggregatedRank": 155,
     "countryRank": 15
   },
   {
@@ -3406,8 +3428,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 155,
-    "countryRank": 42
+    "aggregatedRank": 156,
+    "countryRank": 43
   },
   {
     "name": "University of Wollongong",
@@ -3428,7 +3450,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 156,
+    "aggregatedRank": 157,
     "countryRank": 14
   },
   {
@@ -3450,7 +3472,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 157,
+    "aggregatedRank": 158,
     "countryRank": 5
   },
   {
@@ -3472,7 +3494,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 158,
+    "aggregatedRank": 159,
     "countryRank": 20
   },
   {
@@ -3494,7 +3516,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 159,
+    "aggregatedRank": 160,
     "countryRank": 2
   },
   {
@@ -3516,7 +3538,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 160,
+    "aggregatedRank": 161,
     "countryRank": 15
   },
   {
@@ -3538,7 +3560,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 161,
+    "aggregatedRank": 162,
     "countryRank": 21
   },
   {
@@ -3560,7 +3582,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 162,
+    "aggregatedRank": 163,
     "countryRank": 16
   },
   {
@@ -3582,7 +3604,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 163,
+    "aggregatedRank": 164,
     "countryRank": 17
   },
   {
@@ -3604,7 +3626,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 164,
+    "aggregatedRank": 165,
     "countryRank": 2
   },
   {
@@ -3626,8 +3648,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 165,
-    "countryRank": 43
+    "aggregatedRank": 166,
+    "countryRank": 44
   },
   {
     "name": "University of Antwerp",
@@ -3648,7 +3670,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 166,
+    "aggregatedRank": 167,
     "countryRank": 2
   },
   {
@@ -3670,7 +3692,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 167,
+    "aggregatedRank": 168,
     "countryRank": 22
   },
   {
@@ -3692,7 +3714,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 168,
+    "aggregatedRank": 169,
     "countryRank": 23
   },
   {
@@ -3714,7 +3736,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 169,
+    "aggregatedRank": 170,
     "countryRank": 2
   },
   {
@@ -3736,8 +3758,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 170,
-    "countryRank": 44
+    "aggregatedRank": 171,
+    "countryRank": 45
   },
   {
     "name": "University of St Andrews",
@@ -3758,7 +3780,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 171,
+    "aggregatedRank": 172,
     "countryRank": 24
   },
   {
@@ -3780,7 +3802,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 172,
+    "aggregatedRank": 173,
     "countryRank": 1
   },
   {
@@ -3802,7 +3824,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 173,
+    "aggregatedRank": 174,
     "countryRank": 16
   },
   {
@@ -3824,7 +3846,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 174,
+    "aggregatedRank": 175,
     "countryRank": 3
   },
   {
@@ -3846,7 +3868,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 175,
+    "aggregatedRank": 176,
     "countryRank": 25
   },
   {
@@ -3868,7 +3890,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 176,
+    "aggregatedRank": 177,
     "countryRank": 2
   },
   {
@@ -3890,7 +3912,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 177,
+    "aggregatedRank": 178,
     "countryRank": 3
   },
   {
@@ -3912,7 +3934,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 178,
+    "aggregatedRank": 179,
     "countryRank": 18
   },
   {
@@ -3934,7 +3956,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 179,
+    "aggregatedRank": 180,
     "countryRank": 19
   },
   {
@@ -3956,7 +3978,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 180,
+    "aggregatedRank": 181,
     "countryRank": 20
   },
   {
@@ -3978,8 +4000,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 181,
-    "countryRank": 45
+    "aggregatedRank": 182,
+    "countryRank": 46
   },
   {
     "name": "Kyushu University",
@@ -4000,7 +4022,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 182,
+    "aggregatedRank": 183,
     "countryRank": 6
   },
   {
@@ -4022,8 +4044,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 183,
-    "countryRank": 46
+    "aggregatedRank": 184,
+    "countryRank": 47
   },
   {
     "name": "La Trobe University",
@@ -4044,7 +4066,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 184,
+    "aggregatedRank": 185,
     "countryRank": 17
   },
   {
@@ -4066,7 +4088,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 185,
+    "aggregatedRank": 186,
     "countryRank": 21
   },
   {
@@ -4088,7 +4110,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 186,
+    "aggregatedRank": 187,
     "countryRank": 18
   },
   {
@@ -4110,8 +4132,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 187,
-    "countryRank": 47
+    "aggregatedRank": 188,
+    "countryRank": 48
   },
   {
     "name": "Ulsan National Institute of Science & Technology (UNIST)",
@@ -4132,7 +4154,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 188,
+    "aggregatedRank": 189,
     "countryRank": 6
   },
   {
@@ -4154,7 +4176,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 189,
+    "aggregatedRank": 190,
     "countryRank": 22
   },
   {
@@ -4176,7 +4198,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 190,
+    "aggregatedRank": 191,
     "countryRank": 5
   },
   {
@@ -4198,7 +4220,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 191,
+    "aggregatedRank": 192,
     "countryRank": 3
   },
   {
@@ -4220,7 +4242,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 192,
+    "aggregatedRank": 193,
     "countryRank": 4
   },
   {
@@ -4242,7 +4264,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 193,
+    "aggregatedRank": 194,
     "countryRank": 5
   },
   {
@@ -4264,7 +4286,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 194,
+    "aggregatedRank": 195,
     "countryRank": 4
   },
   {
@@ -4286,7 +4308,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 195,
+    "aggregatedRank": 196,
     "countryRank": 6
   },
   {
@@ -4308,8 +4330,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 196,
-    "countryRank": 48
+    "aggregatedRank": 197,
+    "countryRank": 49
   },
   {
     "name": "Autonomous University of Madrid",
@@ -4330,7 +4352,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 197,
+    "aggregatedRank": 198,
     "countryRank": 4
   },
   {
@@ -4352,7 +4374,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 198,
+    "aggregatedRank": 199,
     "countryRank": 5
   },
   {
@@ -4374,7 +4396,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 199,
+    "aggregatedRank": 200,
     "countryRank": 19
   },
   {
@@ -4396,7 +4418,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 200,
+    "aggregatedRank": 201,
     "countryRank": 2
   },
   {
@@ -4418,8 +4440,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 201,
-    "countryRank": 49
+    "aggregatedRank": 202,
+    "countryRank": 50
   },
   {
     "name": "University of Reading",
@@ -4440,7 +4462,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 202,
+    "aggregatedRank": 203,
     "countryRank": 26
   },
   {
@@ -4462,7 +4484,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 203,
+    "aggregatedRank": 204,
     "countryRank": 23
   },
   {
@@ -4484,7 +4506,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 204,
+    "aggregatedRank": 205,
     "countryRank": 7
   },
   {
@@ -4506,7 +4528,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 205,
+    "aggregatedRank": 206,
     "countryRank": 7
   },
   {
@@ -4528,7 +4550,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 206,
+    "aggregatedRank": 207,
     "countryRank": 27
   },
   {
@@ -4550,7 +4572,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 207,
+    "aggregatedRank": 208,
     "countryRank": 2
   },
   {
@@ -4572,8 +4594,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 208,
-    "countryRank": 50
+    "aggregatedRank": 209,
+    "countryRank": 51
   },
   {
     "name": "University of Turin",
@@ -4594,7 +4616,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 209,
+    "aggregatedRank": 210,
     "countryRank": 6
   },
   {
@@ -4616,7 +4638,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 210,
+    "aggregatedRank": 211,
     "countryRank": 24
   },
   {
@@ -4638,7 +4660,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 211,
+    "aggregatedRank": 212,
     "countryRank": 7
   },
   {
@@ -4660,7 +4682,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 212,
+    "aggregatedRank": 213,
     "countryRank": 1
   },
   {
@@ -4682,7 +4704,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 213,
+    "aggregatedRank": 214,
     "countryRank": 25
   },
   {
@@ -4704,7 +4726,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 214,
+    "aggregatedRank": 215,
     "countryRank": 28
   },
   {
@@ -4726,7 +4748,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 215,
+    "aggregatedRank": 216,
     "countryRank": 6
   },
   {
@@ -4748,7 +4770,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 216,
+    "aggregatedRank": 217,
     "countryRank": 10
   },
   {
@@ -4770,7 +4792,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 217,
+    "aggregatedRank": 218,
     "countryRank": 5
   },
   {
@@ -4792,8 +4814,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 218,
-    "countryRank": 51
+    "aggregatedRank": 219,
+    "countryRank": 52
   },
   {
     "name": "Technion Israel Institute of Technology",
@@ -4814,7 +4836,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 219,
+    "aggregatedRank": 220,
     "countryRank": 3
   },
   {
@@ -4836,7 +4858,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 220,
+    "aggregatedRank": 221,
     "countryRank": 2
   },
   {
@@ -4858,7 +4880,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 221,
+    "aggregatedRank": 222,
     "countryRank": 8
   },
   {
@@ -4880,7 +4902,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 222,
+    "aggregatedRank": 223,
     "countryRank": 2
   },
   {
@@ -4902,7 +4924,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 223,
+    "aggregatedRank": 224,
     "countryRank": 26
   },
   {
@@ -4924,7 +4946,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 224,
+    "aggregatedRank": 225,
     "countryRank": 5
   },
   {
@@ -4946,8 +4968,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 225,
-    "countryRank": 52
+    "aggregatedRank": 226,
+    "countryRank": 53
   },
   {
     "name": "King Fahd University of Petroleum & Minerals",
@@ -4968,7 +4990,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 226,
+    "aggregatedRank": 227,
     "countryRank": 3
   },
   {
@@ -4990,7 +5012,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 227,
+    "aggregatedRank": 228,
     "countryRank": 9
   },
   {
@@ -5012,8 +5034,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 228,
-    "countryRank": 53
+    "aggregatedRank": 229,
+    "countryRank": 54
   },
   {
     "name": "Simon Fraser University",
@@ -5034,7 +5056,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 229,
+    "aggregatedRank": 230,
     "countryRank": 11
   },
   {
@@ -5056,7 +5078,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 230,
+    "aggregatedRank": 231,
     "countryRank": 29
   },
   {
@@ -5078,7 +5100,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 231,
+    "aggregatedRank": 232,
     "countryRank": 12
   },
   {
@@ -5100,7 +5122,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 232,
+    "aggregatedRank": 233,
     "countryRank": 3
   },
   {
@@ -5122,7 +5144,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 233,
+    "aggregatedRank": 234,
     "countryRank": 8
   },
   {
@@ -5144,7 +5166,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 234,
+    "aggregatedRank": 235,
     "countryRank": 27
   },
   {
@@ -5166,7 +5188,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 235,
+    "aggregatedRank": 236,
     "countryRank": 10
   },
   {
@@ -5188,8 +5210,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 236,
-    "countryRank": 54
+    "aggregatedRank": 237,
+    "countryRank": 55
   },
   {
     "name": "University of Iowa",
@@ -5210,8 +5232,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 237,
-    "countryRank": 55
+    "aggregatedRank": 238,
+    "countryRank": 56
   },
   {
     "name": "University of Navarra",
@@ -5232,7 +5254,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 238,
+    "aggregatedRank": 239,
     "countryRank": 6
   },
   {
@@ -5254,7 +5276,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 239,
+    "aggregatedRank": 240,
     "countryRank": 7
   },
   {
@@ -5276,7 +5298,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 240,
+    "aggregatedRank": 241,
     "countryRank": 13
   },
   {
@@ -5298,7 +5320,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 241,
+    "aggregatedRank": 242,
     "countryRank": 3
   },
   {
@@ -5320,7 +5342,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 242,
+    "aggregatedRank": 243,
     "countryRank": 28
   },
   {
@@ -5342,7 +5364,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 243,
+    "aggregatedRank": 244,
     "countryRank": 20
   },
   {
@@ -5364,7 +5386,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 244,
+    "aggregatedRank": 245,
     "countryRank": 10
   },
   {
@@ -5386,7 +5408,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 245,
+    "aggregatedRank": 246,
     "countryRank": 4
   },
   {
@@ -5408,8 +5430,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 246,
-    "countryRank": 56
+    "aggregatedRank": 247,
+    "countryRank": 57
   },
   {
     "name": "University of Kiel",
@@ -5430,7 +5452,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 247,
+    "aggregatedRank": 248,
     "countryRank": 11
   },
   {
@@ -5452,7 +5474,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 248,
+    "aggregatedRank": 249,
     "countryRank": 1
   },
   {
@@ -5474,8 +5496,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 249,
-    "countryRank": 57
+    "aggregatedRank": 250,
+    "countryRank": 58
   },
   {
     "name": "University of Pavia",
@@ -5496,7 +5518,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 250,
+    "aggregatedRank": 251,
     "countryRank": 11
   },
   {
@@ -5518,7 +5540,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 251,
+    "aggregatedRank": 252,
     "countryRank": 12
   },
   {
@@ -5540,7 +5562,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 252,
+    "aggregatedRank": 253,
     "countryRank": 3
   },
   {
@@ -5562,8 +5584,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 253,
-    "countryRank": 58
+    "aggregatedRank": 254,
+    "countryRank": 59
   },
   {
     "name": "University of Dundee",
@@ -5584,7 +5606,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 254,
+    "aggregatedRank": 255,
     "countryRank": 30
   },
   {
@@ -5606,8 +5628,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 255,
-    "countryRank": 59
+    "aggregatedRank": 256,
+    "countryRank": 60
   },
   {
     "name": "Catholic University of the Sacred Heart",
@@ -5628,7 +5650,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 256,
+    "aggregatedRank": 257,
     "countryRank": 13
   },
   {
@@ -5650,8 +5672,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 257,
-    "countryRank": 60
+    "aggregatedRank": 258,
+    "countryRank": 61
   },
   {
     "name": "Kyung Hee University",
@@ -5672,7 +5694,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 258,
+    "aggregatedRank": 259,
     "countryRank": 9
   },
   {
@@ -5694,7 +5716,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 259,
+    "aggregatedRank": 260,
     "countryRank": 1
   },
   {
@@ -5716,7 +5738,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 260,
+    "aggregatedRank": 261,
     "countryRank": 2
   },
   {
@@ -5738,7 +5760,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 261,
+    "aggregatedRank": 262,
     "countryRank": 31
   },
   {
@@ -5760,7 +5782,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 262,
+    "aggregatedRank": 263,
     "countryRank": 21
   },
   {
@@ -5782,7 +5804,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 263,
+    "aggregatedRank": 264,
     "countryRank": 32
   },
   {
@@ -5804,7 +5826,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 264,
+    "aggregatedRank": 265,
     "countryRank": 5
   },
   {
@@ -5826,7 +5848,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 265,
+    "aggregatedRank": 266,
     "countryRank": 14
   },
   {
@@ -5848,8 +5870,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 266,
-    "countryRank": 61
+    "aggregatedRank": 267,
+    "countryRank": 62
   },
   {
     "name": "Soochow University - China",
@@ -5870,7 +5892,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 267,
+    "aggregatedRank": 268,
     "countryRank": 29
   },
   {
@@ -5892,7 +5914,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 268,
+    "aggregatedRank": 269,
     "countryRank": 8
   },
   {
@@ -5914,7 +5936,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 269,
+    "aggregatedRank": 270,
     "countryRank": 14
   },
   {
@@ -5936,7 +5958,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 270,
+    "aggregatedRank": 271,
     "countryRank": 15
   },
   {
@@ -5958,7 +5980,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 271,
+    "aggregatedRank": 272,
     "countryRank": 30
   },
   {
@@ -5980,7 +6002,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 272,
+    "aggregatedRank": 273,
     "countryRank": 22
   },
   {
@@ -6002,8 +6024,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 273,
-    "countryRank": 62
+    "aggregatedRank": 274,
+    "countryRank": 63
   },
   {
     "name": "University of Luxembourg",
@@ -6024,7 +6046,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 274,
+    "aggregatedRank": 275,
     "countryRank": 1
   },
   {
@@ -6046,8 +6068,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 275,
-    "countryRank": 63
+    "aggregatedRank": 276,
+    "countryRank": 64
   },
   {
     "name": "University of Manitoba",
@@ -6068,7 +6090,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 276,
+    "aggregatedRank": 277,
     "countryRank": 16
   },
   {
@@ -6090,7 +6112,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 277,
+    "aggregatedRank": 278,
     "countryRank": 8
   },
   {
@@ -6112,8 +6134,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 278,
-    "countryRank": 64
+    "aggregatedRank": 279,
+    "countryRank": 65
   },
   {
     "name": "Jinan University",
@@ -6134,7 +6156,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 279,
+    "aggregatedRank": 280,
     "countryRank": 31
   },
   {
@@ -6156,7 +6178,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 280,
+    "aggregatedRank": 281,
     "countryRank": 1
   },
   {
@@ -6178,7 +6200,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 281,
+    "aggregatedRank": 282,
     "countryRank": 1
   },
   {
@@ -6200,7 +6222,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 282,
+    "aggregatedRank": 283,
     "countryRank": 3
   },
   {
@@ -6222,7 +6244,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 283,
+    "aggregatedRank": 284,
     "countryRank": 7
   },
   {
@@ -6244,7 +6266,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 284,
+    "aggregatedRank": 285,
     "countryRank": 2
   },
   {
@@ -6266,8 +6288,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 285,
-    "countryRank": 65
+    "aggregatedRank": 286,
+    "countryRank": 66
   },
   {
     "name": "Cairo University",
@@ -6288,7 +6310,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 286,
+    "aggregatedRank": 287,
     "countryRank": 1
   },
   {
@@ -6310,7 +6332,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 287,
+    "aggregatedRank": 288,
     "countryRank": 2
   },
   {
@@ -6332,7 +6354,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 288,
+    "aggregatedRank": 289,
     "countryRank": 15
   },
   {
@@ -6354,7 +6376,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 289,
+    "aggregatedRank": 290,
     "countryRank": 33
   },
   {
@@ -6376,7 +6398,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 290,
+    "aggregatedRank": 291,
     "countryRank": 4
   },
   {
@@ -6398,8 +6420,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 291,
-    "countryRank": 66
+    "aggregatedRank": 292,
+    "countryRank": 67
   },
   {
     "name": "Virginia Commonwealth University",
@@ -6420,8 +6442,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 292,
-    "countryRank": 67
+    "aggregatedRank": 293,
+    "countryRank": 68
   },
   {
     "name": "Sharif University of Technology",
@@ -6442,7 +6464,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 293,
+    "aggregatedRank": 294,
     "countryRank": 2
   },
   {
@@ -6464,8 +6486,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 294,
-    "countryRank": 68
+    "aggregatedRank": 295,
+    "countryRank": 69
   },
   {
     "name": "Murdoch University",
@@ -6486,7 +6508,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 295,
+    "aggregatedRank": 296,
     "countryRank": 23
   },
   {
@@ -6508,7 +6530,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 296,
+    "aggregatedRank": 297,
     "countryRank": 34
   },
   {
@@ -6530,7 +6552,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 297,
+    "aggregatedRank": 298,
     "countryRank": 4
   },
   {
@@ -6552,7 +6574,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 298,
+    "aggregatedRank": 299,
     "countryRank": 17
   },
   {
@@ -6574,8 +6596,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 299,
-    "countryRank": 69
+    "aggregatedRank": 300,
+    "countryRank": 70
   },
   {
     "name": "Boston College",
@@ -6596,8 +6618,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 300,
-    "countryRank": 70
+    "aggregatedRank": 301,
+    "countryRank": 71
   },
   {
     "name": "Edith Cowan University",
@@ -6618,7 +6640,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 301,
+    "aggregatedRank": 302,
     "countryRank": 24
   },
   {
@@ -6640,7 +6662,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 302,
+    "aggregatedRank": 303,
     "countryRank": 1
   },
   {
@@ -6662,8 +6684,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 303,
-    "countryRank": 71
+    "aggregatedRank": 304,
+    "countryRank": 72
   },
   {
     "name": "Chulalongkorn University",
@@ -6684,7 +6706,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 304,
+    "aggregatedRank": 305,
     "countryRank": 1
   },
   {
@@ -6706,8 +6728,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 305,
-    "countryRank": 72
+    "aggregatedRank": 306,
+    "countryRank": 73
   },
   {
     "name": "University of Central Florida",
@@ -6728,8 +6750,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 306,
-    "countryRank": 73
+    "aggregatedRank": 307,
+    "countryRank": 74
   },
   {
     "name": "Koc University",
@@ -6750,7 +6772,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 307,
+    "aggregatedRank": 308,
     "countryRank": 1
   },
   {
@@ -6772,8 +6794,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 308,
-    "countryRank": 74
+    "aggregatedRank": 309,
+    "countryRank": 75
   },
   {
     "name": "Humboldt University of Berlin",
@@ -6791,7 +6813,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 309,
+    "aggregatedRank": 310,
     "countryRank": 12
   },
   {
@@ -6810,7 +6832,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 310,
+    "aggregatedRank": 311,
     "countryRank": 13
   },
   {
@@ -6832,7 +6854,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 311,
+    "aggregatedRank": 312,
     "countryRank": 16
   },
   {
@@ -6854,7 +6876,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 312,
+    "aggregatedRank": 313,
     "countryRank": 2
   },
   {
@@ -6876,7 +6898,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 313,
+    "aggregatedRank": 314,
     "countryRank": 17
   },
   {
@@ -6898,8 +6920,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 314,
-    "countryRank": 75
+    "aggregatedRank": 315,
+    "countryRank": 76
   },
   {
     "name": "Nanjing University of Aeronautics & Astronautics",
@@ -6920,7 +6942,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 315,
+    "aggregatedRank": 316,
     "countryRank": 32
   },
   {
@@ -6942,7 +6964,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 316,
+    "aggregatedRank": 317,
     "countryRank": 4
   },
   {
@@ -6964,7 +6986,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 317,
+    "aggregatedRank": 318,
     "countryRank": 1
   },
   {
@@ -6986,7 +7008,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 318,
+    "aggregatedRank": 319,
     "countryRank": 9
   },
   {
@@ -7008,7 +7030,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 319,
+    "aggregatedRank": 320,
     "countryRank": 1
   },
   {
@@ -7030,7 +7052,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 320,
+    "aggregatedRank": 321,
     "countryRank": 1
   },
   {
@@ -7052,7 +7074,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 321,
+    "aggregatedRank": 322,
     "countryRank": 33
   },
   {
@@ -7074,7 +7096,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 322,
+    "aggregatedRank": 323,
     "countryRank": 25
   },
   {
@@ -7096,7 +7118,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 323,
+    "aggregatedRank": 324,
     "countryRank": 18
   },
   {
@@ -7118,7 +7140,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 324,
+    "aggregatedRank": 325,
     "countryRank": 5
   },
   {
@@ -7140,8 +7162,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 325,
-    "countryRank": 76
+    "aggregatedRank": 326,
+    "countryRank": 77
   },
   {
     "name": "Wayne State University",
@@ -7162,8 +7184,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 326,
-    "countryRank": 77
+    "aggregatedRank": 327,
+    "countryRank": 78
   },
   {
     "name": "Donghua University",
@@ -7184,7 +7206,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 327,
+    "aggregatedRank": 328,
     "countryRank": 34
   },
   {
@@ -7206,8 +7228,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 328,
-    "countryRank": 78
+    "aggregatedRank": 329,
+    "countryRank": 79
   },
   {
     "name": "University of Ljubljana",
@@ -7228,7 +7250,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 329,
+    "aggregatedRank": 330,
     "countryRank": 1
   },
   {
@@ -7250,8 +7272,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 330,
-    "countryRank": 79
+    "aggregatedRank": 331,
+    "countryRank": 80
   },
   {
     "name": "Karolinska Institutet",
@@ -7269,7 +7291,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 331,
+    "aggregatedRank": 332,
     "countryRank": 8
   },
   {
@@ -7291,7 +7313,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 332,
+    "aggregatedRank": 333,
     "countryRank": 2
   },
   {
@@ -7313,7 +7335,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 333,
+    "aggregatedRank": 334,
     "countryRank": 2
   },
   {
@@ -7335,7 +7357,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 334,
+    "aggregatedRank": 335,
     "countryRank": 3
   },
   {
@@ -7357,7 +7379,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 335,
+    "aggregatedRank": 336,
     "countryRank": 35
   },
   {
@@ -7379,7 +7401,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 336,
+    "aggregatedRank": 337,
     "countryRank": 19
   },
   {
@@ -7401,7 +7423,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 337,
+    "aggregatedRank": 338,
     "countryRank": 20
   },
   {
@@ -7423,7 +7445,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 338,
+    "aggregatedRank": 339,
     "countryRank": 21
   },
   {
@@ -7445,7 +7467,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 339,
+    "aggregatedRank": 340,
     "countryRank": 22
   },
   {
@@ -7464,7 +7486,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 340,
+    "aggregatedRank": 341,
     "countryRank": 3
   },
   {
@@ -7483,7 +7505,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 341,
+    "aggregatedRank": 342,
     "countryRank": 2
   },
   {
@@ -7502,7 +7524,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 342,
+    "aggregatedRank": 343,
     "countryRank": 1
   },
   {
@@ -7521,8 +7543,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 343,
-    "countryRank": 80
+    "aggregatedRank": 344,
+    "countryRank": 81
   },
   {
     "name": "Utrecht University",
@@ -7540,7 +7562,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 344,
+    "aggregatedRank": 345,
     "countryRank": 7
   },
   {
@@ -7559,7 +7581,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 345,
+    "aggregatedRank": 346,
     "countryRank": 6
   },
   {
@@ -7578,7 +7600,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 346,
+    "aggregatedRank": 347,
     "countryRank": 9
   },
   {
@@ -7597,7 +7619,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 347,
+    "aggregatedRank": 348,
     "countryRank": 3
   },
   {
@@ -7616,7 +7638,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 348,
+    "aggregatedRank": 349,
     "countryRank": 7
   },
   {
@@ -7635,7 +7657,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 349,
+    "aggregatedRank": 350,
     "countryRank": 3
   },
   {
@@ -7654,7 +7676,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 350,
+    "aggregatedRank": 351,
     "countryRank": 5
   },
   {
@@ -7673,7 +7695,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 351,
+    "aggregatedRank": 352,
     "countryRank": 4
   },
   {
@@ -7692,8 +7714,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 352,
-    "countryRank": 81
+    "aggregatedRank": 353,
+    "countryRank": 82
   },
   {
     "name": "University of Illinois at Urbana-Champaign",
@@ -7711,8 +7733,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 353,
-    "countryRank": 82
+    "aggregatedRank": 354,
+    "countryRank": 83
   },
   {
     "name": "University of Heidelberg",
@@ -7730,7 +7752,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 354,
+    "aggregatedRank": 355,
     "countryRank": 14
   },
   {
@@ -7749,7 +7771,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 355,
+    "aggregatedRank": 356,
     "countryRank": 4
   },
   {
@@ -7768,7 +7790,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 356,
+    "aggregatedRank": 357,
     "countryRank": 2
   },
   {
@@ -7787,8 +7809,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 357,
-    "countryRank": 83
+    "aggregatedRank": 358,
+    "countryRank": 84
   },
   {
     "name": "University of Electronic Science and Technology of China",
@@ -7806,7 +7828,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 358,
+    "aggregatedRank": 359,
     "countryRank": 35
   },
   {
@@ -7825,7 +7847,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 359,
+    "aggregatedRank": 360,
     "countryRank": 36
   },
   {
@@ -7844,27 +7866,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 360,
-    "countryRank": 4
-  },
-  {
-    "name": "Washington University in St. Louis",
-    "country": "United States",
-    "aggregatedScore": 897.96875,
-    "originalRankings": {
-      "qs": {
-        "rank": 176
-      },
-      "the": {
-        "rank": 69
-      },
-      "arwu": {
-        "rank": 23
-      }
-    },
-    "appearances": 3,
     "aggregatedRank": 361,
-    "countryRank": 84
+    "countryRank": 4
   },
   {
     "name": "Swedish University of Agricultural Sciences",
@@ -16258,19 +16261,6 @@
     "countryRank": 1
   },
   {
-    "name": "Washington University (WUSTL)",
-    "country": "united states",
-    "aggregatedScore": 275.234375,
-    "originalRankings": {
-      "usnews": {
-        "rank": 30
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 833,
-    "countryRank": 2
-  },
-  {
     "name": "Universite Paris Cite",
     "country": "France",
     "aggregatedScore": 273.203125,
@@ -16280,7 +16270,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 834,
+    "aggregatedRank": 833,
     "countryRank": 23
   },
   {
@@ -16293,7 +16283,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 835,
+    "aggregatedRank": 834,
     "countryRank": 9
   },
   {
@@ -16306,7 +16296,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 836,
+    "aggregatedRank": 835,
     "countryRank": 43
   },
   {
@@ -16319,7 +16309,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 837,
+    "aggregatedRank": 836,
     "countryRank": 14
   },
   {
@@ -16332,8 +16322,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 838,
-    "countryRank": 3
+    "aggregatedRank": 837,
+    "countryRank": 2
   },
   {
     "name": "University of Science and Technology Beijing",
@@ -16348,7 +16338,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 839,
+    "aggregatedRank": 838,
     "countryRank": 85
   },
   {
@@ -16361,7 +16351,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 840,
+    "aggregatedRank": 839,
     "countryRank": 86
   },
   {
@@ -16374,8 +16364,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 841,
-    "countryRank": 4
+    "aggregatedRank": 840,
+    "countryRank": 3
   },
   {
     "name": "Universite Paris Saclay",
@@ -16387,7 +16377,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 842,
+    "aggregatedRank": 841,
     "countryRank": 24
   },
   {
@@ -16400,7 +16390,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 843,
+    "aggregatedRank": 842,
     "countryRank": 15
   },
   {
@@ -16413,7 +16403,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 844,
+    "aggregatedRank": 843,
     "countryRank": 87
   },
   {
@@ -16426,7 +16416,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 845,
+    "aggregatedRank": 844,
     "countryRank": 16
   },
   {
@@ -16439,8 +16429,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 846,
-    "countryRank": 5
+    "aggregatedRank": 845,
+    "countryRank": 4
   },
   {
     "name": "University of California Davis",
@@ -16452,8 +16442,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 847,
-    "countryRank": 6
+    "aggregatedRank": 846,
+    "countryRank": 5
   },
   {
     "name": "Campus Bio-Medico University of Rome",
@@ -16468,7 +16458,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 848,
+    "aggregatedRank": 847,
     "countryRank": 39
   },
   {
@@ -16484,7 +16474,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 849,
+    "aggregatedRank": 848,
     "countryRank": 81
   },
   {
@@ -16500,7 +16490,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 850,
+    "aggregatedRank": 849,
     "countryRank": 36
   },
   {
@@ -16516,7 +16506,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 851,
+    "aggregatedRank": 850,
     "countryRank": 152
   },
   {
@@ -16532,7 +16522,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 852,
+    "aggregatedRank": 851,
     "countryRank": 153
   },
   {
@@ -16548,7 +16538,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 853,
+    "aggregatedRank": 852,
     "countryRank": 154
   },
   {
@@ -16564,7 +16554,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 854,
+    "aggregatedRank": 853,
     "countryRank": 11
   },
   {
@@ -16580,7 +16570,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 855,
+    "aggregatedRank": 854,
     "countryRank": 88
   },
   {
@@ -16596,7 +16586,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 856,
+    "aggregatedRank": 855,
     "countryRank": 89
   },
   {
@@ -16609,7 +16599,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 857,
+    "aggregatedRank": 856,
     "countryRank": 82
   },
   {
@@ -16622,8 +16612,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 858,
-    "countryRank": 7
+    "aggregatedRank": 857,
+    "countryRank": 6
   },
   {
     "name": "Huazhong University of Science & Technology",
@@ -16635,7 +16625,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 859,
+    "aggregatedRank": 858,
     "countryRank": 90
   },
   {
@@ -16648,7 +16638,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 860,
+    "aggregatedRank": 859,
     "countryRank": 1
   },
   {
@@ -16661,8 +16651,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 861,
-    "countryRank": 8
+    "aggregatedRank": 860,
+    "countryRank": 7
   },
   {
     "name": "University of Illinois Urbana-Champaign",
@@ -16674,8 +16664,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 862,
-    "countryRank": 9
+    "aggregatedRank": 861,
+    "countryRank": 8
   },
   {
     "name": "Hong Kong University of Science & Technology",
@@ -16687,7 +16677,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 863,
+    "aggregatedRank": 862,
     "countryRank": 7
   },
   {
@@ -16700,7 +16690,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 864,
+    "aggregatedRank": 863,
     "countryRank": 10
   },
   {
@@ -16713,7 +16703,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 865,
+    "aggregatedRank": 864,
     "countryRank": 25
   },
   {
@@ -16726,7 +16716,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 866,
+    "aggregatedRank": 865,
     "countryRank": 16
   },
   {
@@ -16739,7 +16729,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 867,
+    "aggregatedRank": 866,
     "countryRank": 17
   },
   {
@@ -16752,7 +16742,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 868,
+    "aggregatedRank": 867,
     "countryRank": 9
   },
   {
@@ -16765,8 +16755,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 869,
-    "countryRank": 10
+    "aggregatedRank": 868,
+    "countryRank": 9
   },
   {
     "name": "Sapienza University Rome",
@@ -16778,7 +16768,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 870,
+    "aggregatedRank": 869,
     "countryRank": 40
   },
   {
@@ -16791,11 +16781,24 @@
       }
     },
     "appearances": 1,
+    "aggregatedRank": 870,
+    "countryRank": 10
+  },
+  {
+    "name": "Oregon Health & Science University",
+    "country": "united states",
+    "aggregatedScore": 256.796875,
+    "originalRankings": {
+      "usnews": {
+        "rank": 148
+      }
+    },
+    "appearances": 1,
     "aggregatedRank": 871,
     "countryRank": 11
   },
   {
-    "name": "Oregon Health & Science University",
+    "name": "Rutgers University New Brunswick",
     "country": "united states",
     "aggregatedScore": 256.796875,
     "originalRankings": {
@@ -16808,19 +16811,6 @@
     "countryRank": 12
   },
   {
-    "name": "Rutgers University New Brunswick",
-    "country": "united states",
-    "aggregatedScore": 256.796875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 148
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 873,
-    "countryRank": 13
-  },
-  {
     "name": "Southern University of Science & Technology",
     "country": "China",
     "aggregatedScore": 255.390625,
@@ -16830,7 +16820,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 874,
+    "aggregatedRank": 873,
     "countryRank": 91
   },
   {
@@ -16843,7 +16833,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 875,
+    "aggregatedRank": 874,
     "countryRank": 83
   },
   {
@@ -16856,7 +16846,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 876,
+    "aggregatedRank": 875,
     "countryRank": 12
   },
   {
@@ -16869,8 +16859,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 877,
-    "countryRank": 14
+    "aggregatedRank": 876,
+    "countryRank": 13
   },
   {
     "name": "University of Gottingen",
@@ -16882,7 +16872,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 878,
+    "aggregatedRank": 877,
     "countryRank": 44
   },
   {
@@ -16895,7 +16885,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 879,
+    "aggregatedRank": 878,
     "countryRank": 28
   },
   {
@@ -16908,8 +16898,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 880,
-    "countryRank": 15
+    "aggregatedRank": 879,
+    "countryRank": 14
   },
   {
     "name": "Maastricht University",
@@ -16921,7 +16911,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 881,
+    "aggregatedRank": 880,
     "countryRank": 18
   },
   {
@@ -16937,7 +16927,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 882,
+    "aggregatedRank": 881,
     "countryRank": 45
   },
   {
@@ -16950,7 +16940,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 883,
+    "aggregatedRank": 882,
     "countryRank": 37
   },
   {
@@ -16963,7 +16953,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 884,
+    "aggregatedRank": 883,
     "countryRank": 46
   },
   {
@@ -16976,7 +16966,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 885,
+    "aggregatedRank": 884,
     "countryRank": 47
   },
   {
@@ -16989,7 +16979,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 886,
+    "aggregatedRank": 885,
     "countryRank": 11
   },
   {
@@ -17005,7 +16995,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 887,
+    "aggregatedRank": 886,
     "countryRank": 18
   },
   {
@@ -17018,7 +17008,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 888,
+    "aggregatedRank": 887,
     "countryRank": 48
   },
   {
@@ -17034,7 +17024,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 889,
+    "aggregatedRank": 888,
     "countryRank": 49
   },
   {
@@ -17050,7 +17040,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 890,
+    "aggregatedRank": 889,
     "countryRank": 155
   },
   {
@@ -17066,7 +17056,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 891,
+    "aggregatedRank": 890,
     "countryRank": 3
   },
   {
@@ -17082,7 +17072,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 892,
+    "aggregatedRank": 891,
     "countryRank": 92
   },
   {
@@ -17098,7 +17088,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 893,
+    "aggregatedRank": 892,
     "countryRank": 19
   },
   {
@@ -17114,7 +17104,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 894,
+    "aggregatedRank": 893,
     "countryRank": 41
   },
   {
@@ -17130,7 +17120,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 895,
+    "aggregatedRank": 894,
     "countryRank": 156
   },
   {
@@ -17146,7 +17136,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 896,
+    "aggregatedRank": 895,
     "countryRank": 26
   },
   {
@@ -17162,7 +17152,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 897,
+    "aggregatedRank": 896,
     "countryRank": 93
   },
   {
@@ -17178,7 +17168,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 898,
+    "aggregatedRank": 897,
     "countryRank": 94
   },
   {
@@ -17194,7 +17184,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 899,
+    "aggregatedRank": 898,
     "countryRank": 95
   },
   {
@@ -17210,7 +17200,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 900,
+    "aggregatedRank": 899,
     "countryRank": 21
   },
   {
@@ -17226,7 +17216,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 901,
+    "aggregatedRank": 900,
     "countryRank": 22
   },
   {
@@ -17242,7 +17232,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 902,
+    "aggregatedRank": 901,
     "countryRank": 26
   },
   {
@@ -17255,7 +17245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 903,
+    "aggregatedRank": 902,
     "countryRank": 1
   },
   {
@@ -17268,7 +17258,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 904,
+    "aggregatedRank": 903,
     "countryRank": 27
   },
   {
@@ -17281,8 +17271,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 905,
-    "countryRank": 16
+    "aggregatedRank": 904,
+    "countryRank": 15
   },
   {
     "name": "Universidade de Lisboa",
@@ -17294,7 +17284,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 906,
+    "aggregatedRank": 905,
     "countryRank": 1
   },
   {
@@ -17310,7 +17300,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 907,
+    "aggregatedRank": 906,
     "countryRank": 16
   },
   {
@@ -17323,7 +17313,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 908,
+    "aggregatedRank": 907,
     "countryRank": 50
   },
   {
@@ -17336,7 +17326,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 909,
+    "aggregatedRank": 908,
     "countryRank": 51
   },
   {
@@ -17349,7 +17339,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 910,
+    "aggregatedRank": 909,
     "countryRank": 52
   },
   {
@@ -17362,7 +17352,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 911,
+    "aggregatedRank": 910,
     "countryRank": 28
   },
   {
@@ -17375,7 +17365,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 912,
+    "aggregatedRank": 911,
     "countryRank": 84
   },
   {
@@ -17388,8 +17378,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 913,
-    "countryRank": 17
+    "aggregatedRank": 912,
+    "countryRank": 16
   },
   {
     "name": "University of Milano-Bicocca",
@@ -17401,7 +17391,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 914,
+    "aggregatedRank": 913,
     "countryRank": 42
   },
   {
@@ -17414,7 +17404,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 915,
+    "aggregatedRank": 914,
     "countryRank": 53
   },
   {
@@ -17427,8 +17417,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 916,
-    "countryRank": 18
+    "aggregatedRank": 915,
+    "countryRank": 17
   },
   {
     "name": "Universidade do Porto",
@@ -17440,7 +17430,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 917,
+    "aggregatedRank": 916,
     "countryRank": 1
   },
   {
@@ -17453,7 +17443,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 918,
+    "aggregatedRank": 917,
     "countryRank": 38
   },
   {
@@ -17466,7 +17456,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 919,
+    "aggregatedRank": 918,
     "countryRank": 29
   },
   {
@@ -17479,7 +17469,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 920,
+    "aggregatedRank": 919,
     "countryRank": 1
   },
   {
@@ -17492,7 +17482,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 921,
+    "aggregatedRank": 920,
     "countryRank": 54
   },
   {
@@ -17505,7 +17495,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 922,
+    "aggregatedRank": 921,
     "countryRank": 12
   },
   {
@@ -17518,7 +17508,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 923,
+    "aggregatedRank": 922,
     "countryRank": 30
   },
   {
@@ -17531,8 +17521,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 924,
-    "countryRank": 19
+    "aggregatedRank": 923,
+    "countryRank": 18
   },
   {
     "name": "University of Duisburg Essen",
@@ -17544,7 +17534,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 925,
+    "aggregatedRank": 924,
     "countryRank": 55
   },
   {
@@ -17557,7 +17547,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 926,
+    "aggregatedRank": 925,
     "countryRank": 85
   },
   {
@@ -17570,7 +17560,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 927,
+    "aggregatedRank": 926,
     "countryRank": 1
   },
   {
@@ -17583,7 +17573,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 928,
+    "aggregatedRank": 927,
     "countryRank": 31
   },
   {
@@ -17596,7 +17586,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 929,
+    "aggregatedRank": 928,
     "countryRank": 1
   },
   {
@@ -17609,7 +17599,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 930,
+    "aggregatedRank": 929,
     "countryRank": 56
   },
   {
@@ -17625,7 +17615,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 931,
+    "aggregatedRank": 930,
     "countryRank": 8
   },
   {
@@ -17641,7 +17631,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 932,
+    "aggregatedRank": 931,
     "countryRank": 57
   },
   {
@@ -17657,7 +17647,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 933,
+    "aggregatedRank": 932,
     "countryRank": 20
   },
   {
@@ -17673,7 +17663,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 934,
+    "aggregatedRank": 933,
     "countryRank": 43
   },
   {
@@ -17689,7 +17679,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 935,
+    "aggregatedRank": 934,
     "countryRank": 17
   },
   {
@@ -17705,7 +17695,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 936,
+    "aggregatedRank": 935,
     "countryRank": 96
   },
   {
@@ -17721,7 +17711,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 937,
+    "aggregatedRank": 936,
     "countryRank": 23
   },
   {
@@ -17737,7 +17727,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 938,
+    "aggregatedRank": 937,
     "countryRank": 86
   },
   {
@@ -17753,7 +17743,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 939,
+    "aggregatedRank": 938,
     "countryRank": 44
   },
   {
@@ -17766,7 +17756,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 940,
+    "aggregatedRank": 939,
     "countryRank": 1
   },
   {
@@ -17779,7 +17769,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 941,
+    "aggregatedRank": 940,
     "countryRank": 10
   },
   {
@@ -17792,7 +17782,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 942,
+    "aggregatedRank": 941,
     "countryRank": 32
   },
   {
@@ -17805,7 +17795,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 943,
+    "aggregatedRank": 942,
     "countryRank": 1
   },
   {
@@ -17818,7 +17808,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 944,
+    "aggregatedRank": 943,
     "countryRank": 87
   },
   {
@@ -17831,7 +17821,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 945,
+    "aggregatedRank": 944,
     "countryRank": 1
   },
   {
@@ -17844,7 +17834,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 946,
+    "aggregatedRank": 945,
     "countryRank": 58
   },
   {
@@ -17857,7 +17847,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 947,
+    "aggregatedRank": 946,
     "countryRank": 1
   },
   {
@@ -17870,7 +17860,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 948,
+    "aggregatedRank": 947,
     "countryRank": 29
   },
   {
@@ -17886,7 +17876,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 949,
+    "aggregatedRank": 948,
     "countryRank": 33
   },
   {
@@ -17899,7 +17889,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 950,
+    "aggregatedRank": 949,
     "countryRank": 34
   },
   {
@@ -17912,7 +17902,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 951,
+    "aggregatedRank": 950,
     "countryRank": 1
   },
   {
@@ -17925,7 +17915,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 952,
+    "aggregatedRank": 951,
     "countryRank": 97
   },
   {
@@ -17938,7 +17928,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 953,
+    "aggregatedRank": 952,
     "countryRank": 45
   },
   {
@@ -17951,7 +17941,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 954,
+    "aggregatedRank": 953,
     "countryRank": 1
   },
   {
@@ -17964,7 +17954,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 955,
+    "aggregatedRank": 954,
     "countryRank": 12
   },
   {
@@ -17977,7 +17967,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 956,
+    "aggregatedRank": 955,
     "countryRank": 98
   },
   {
@@ -17990,7 +17980,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 957,
+    "aggregatedRank": 956,
     "countryRank": 59
   },
   {
@@ -18003,7 +17993,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 958,
+    "aggregatedRank": 957,
     "countryRank": 27
   },
   {
@@ -18016,7 +18006,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 959,
+    "aggregatedRank": 958,
     "countryRank": 99
   },
   {
@@ -18029,7 +18019,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 960,
+    "aggregatedRank": 959,
     "countryRank": 60
   },
   {
@@ -18042,7 +18032,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 961,
+    "aggregatedRank": 960,
     "countryRank": 35
   },
   {
@@ -18055,7 +18045,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 962,
+    "aggregatedRank": 961,
     "countryRank": 1
   },
   {
@@ -18068,7 +18058,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 963,
+    "aggregatedRank": 962,
     "countryRank": 1
   },
   {
@@ -18081,7 +18071,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 964,
+    "aggregatedRank": 963,
     "countryRank": 46
   },
   {
@@ -18097,7 +18087,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 965,
+    "aggregatedRank": 964,
     "countryRank": 24
   },
   {
@@ -18110,7 +18100,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 966,
+    "aggregatedRank": 965,
     "countryRank": 39
   },
   {
@@ -18123,7 +18113,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 967,
+    "aggregatedRank": 966,
     "countryRank": 8
   },
   {
@@ -18136,7 +18126,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 968,
+    "aggregatedRank": 967,
     "countryRank": 61
   },
   {
@@ -18149,7 +18139,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 969,
+    "aggregatedRank": 968,
     "countryRank": 3
   },
   {
@@ -18165,7 +18155,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 970,
+    "aggregatedRank": 969,
     "countryRank": 1
   },
   {
@@ -18178,7 +18168,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 971,
+    "aggregatedRank": 970,
     "countryRank": 11
   },
   {
@@ -18191,7 +18181,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 972,
+    "aggregatedRank": 971,
     "countryRank": 36
   },
   {
@@ -18204,7 +18194,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 973,
+    "aggregatedRank": 972,
     "countryRank": 2
   },
   {
@@ -18217,7 +18207,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 974,
+    "aggregatedRank": 973,
     "countryRank": 25
   },
   {
@@ -18230,7 +18220,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 975,
+    "aggregatedRank": 974,
     "countryRank": 1
   },
   {
@@ -18243,7 +18233,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 976,
+    "aggregatedRank": 975,
     "countryRank": 37
   },
   {
@@ -18259,7 +18249,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 977,
+    "aggregatedRank": 976,
     "countryRank": 100
   },
   {
@@ -18275,7 +18265,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 978,
+    "aggregatedRank": 977,
     "countryRank": 101
   },
   {
@@ -18291,7 +18281,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 979,
+    "aggregatedRank": 978,
     "countryRank": 38
   },
   {
@@ -18307,7 +18297,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 980,
+    "aggregatedRank": 979,
     "countryRank": 47
   },
   {
@@ -18323,7 +18313,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 981,
+    "aggregatedRank": 980,
     "countryRank": 157
   },
   {
@@ -18339,7 +18329,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 982,
+    "aggregatedRank": 981,
     "countryRank": 158
   },
   {
@@ -18355,7 +18345,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 983,
+    "aggregatedRank": 982,
     "countryRank": 159
   },
   {
@@ -18371,7 +18361,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 984,
+    "aggregatedRank": 983,
     "countryRank": 26
   },
   {
@@ -18384,7 +18374,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 985,
+    "aggregatedRank": 984,
     "countryRank": 27
   },
   {
@@ -18397,11 +18387,24 @@
       }
     },
     "appearances": 1,
+    "aggregatedRank": 985,
+    "countryRank": 19
+  },
+  {
+    "name": "University of Massachusetts Worcester",
+    "country": "united states",
+    "aggregatedScore": 207.109375,
+    "originalRankings": {
+      "usnews": {
+        "rank": 466
+      }
+    },
+    "appearances": 1,
     "aggregatedRank": 986,
     "countryRank": 20
   },
   {
-    "name": "University of Massachusetts Worcester",
+    "name": "University of Missouri Columbia",
     "country": "united states",
     "aggregatedScore": 207.109375,
     "originalRankings": {
@@ -18414,19 +18417,6 @@
     "countryRank": 21
   },
   {
-    "name": "University of Missouri Columbia",
-    "country": "united states",
-    "aggregatedScore": 207.109375,
-    "originalRankings": {
-      "usnews": {
-        "rank": 466
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 988,
-    "countryRank": 22
-  },
-  {
     "name": "Tampere University",
     "country": "Finland",
     "aggregatedScore": 206.328125,
@@ -18436,7 +18426,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 989,
+    "aggregatedRank": 988,
     "countryRank": 10
   },
   {
@@ -18452,7 +18442,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 990,
+    "aggregatedRank": 989,
     "countryRank": 4
   },
   {
@@ -18468,7 +18458,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 991,
+    "aggregatedRank": 990,
     "countryRank": 102
   },
   {
@@ -18481,8 +18471,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 992,
-    "countryRank": 23
+    "aggregatedRank": 991,
+    "countryRank": 22
   },
   {
     "name": "Universidade de Coimbra",
@@ -18494,7 +18484,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 993,
+    "aggregatedRank": 992,
     "countryRank": 1
   },
   {
@@ -18507,8 +18497,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 994,
-    "countryRank": 24
+    "aggregatedRank": 993,
+    "countryRank": 23
   },
   {
     "name": "Universite de Rennes",
@@ -18520,7 +18510,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 995,
+    "aggregatedRank": 994,
     "countryRank": 39
   },
   {
@@ -18533,7 +18523,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 996,
+    "aggregatedRank": 995,
     "countryRank": 1
   },
   {
@@ -18546,7 +18536,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 997,
+    "aggregatedRank": 996,
     "countryRank": 88
   },
   {
@@ -18559,7 +18549,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 998,
+    "aggregatedRank": 997,
     "countryRank": 1
   },
   {
@@ -18572,7 +18562,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 999,
+    "aggregatedRank": 998,
     "countryRank": 103
   },
   {
@@ -18585,7 +18575,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1000,
+    "aggregatedRank": 999,
     "countryRank": 12
   },
   {
@@ -18598,8 +18588,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1001,
-    "countryRank": 25
+    "aggregatedRank": 1000,
+    "countryRank": 24
   },
   {
     "name": "Moscow Institute of Physics & Technology",
@@ -18611,7 +18601,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1002,
+    "aggregatedRank": 1001,
     "countryRank": 1
   },
   {
@@ -18624,7 +18614,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1003,
+    "aggregatedRank": 1002,
     "countryRank": 104
   },
   {
@@ -18637,7 +18627,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1004,
+    "aggregatedRank": 1003,
     "countryRank": 1
   },
   {
@@ -18653,7 +18643,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1005,
+    "aggregatedRank": 1004,
     "countryRank": 62
   },
   {
@@ -18666,7 +18656,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1006,
+    "aggregatedRank": 1005,
     "countryRank": 63
   },
   {
@@ -18679,7 +18669,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1007,
+    "aggregatedRank": 1006,
     "countryRank": 48
   },
   {
@@ -18692,7 +18682,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1008,
+    "aggregatedRank": 1007,
     "countryRank": 28
   },
   {
@@ -18705,7 +18695,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1009,
+    "aggregatedRank": 1008,
     "countryRank": 10
   },
   {
@@ -18718,7 +18708,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1010,
+    "aggregatedRank": 1009,
     "countryRank": 40
   },
   {
@@ -18731,7 +18721,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1011,
+    "aggregatedRank": 1010,
     "countryRank": 41
   },
   {
@@ -18744,7 +18734,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1012,
+    "aggregatedRank": 1011,
     "countryRank": 49
   },
   {
@@ -18760,7 +18750,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1013,
+    "aggregatedRank": 1012,
     "countryRank": 1
   },
   {
@@ -18773,7 +18763,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1014,
+    "aggregatedRank": 1013,
     "countryRank": 50
   },
   {
@@ -18786,7 +18776,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1015,
+    "aggregatedRank": 1014,
     "countryRank": 1
   },
   {
@@ -18799,7 +18789,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1016,
+    "aggregatedRank": 1015,
     "countryRank": 13
   },
   {
@@ -18815,7 +18805,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1017,
+    "aggregatedRank": 1016,
     "countryRank": 10
   },
   {
@@ -18828,7 +18818,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1018,
+    "aggregatedRank": 1017,
     "countryRank": 2
   },
   {
@@ -18844,7 +18834,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1019,
+    "aggregatedRank": 1018,
     "countryRank": 21
   },
   {
@@ -18857,7 +18847,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1020,
+    "aggregatedRank": 1019,
     "countryRank": 1
   },
   {
@@ -18870,7 +18860,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1021,
+    "aggregatedRank": 1020,
     "countryRank": 1
   },
   {
@@ -18886,7 +18876,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1022,
+    "aggregatedRank": 1021,
     "countryRank": 22
   },
   {
@@ -18899,7 +18889,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1023,
+    "aggregatedRank": 1022,
     "countryRank": 1
   },
   {
@@ -18912,7 +18902,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1024,
+    "aggregatedRank": 1023,
     "countryRank": 1
   },
   {
@@ -18925,7 +18915,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1025,
+    "aggregatedRank": 1024,
     "countryRank": 12
   },
   {
@@ -18938,7 +18928,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1026,
+    "aggregatedRank": 1025,
     "countryRank": 1
   },
   {
@@ -18954,7 +18944,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1027,
+    "aggregatedRank": 1026,
     "countryRank": 23
   },
   {
@@ -18967,7 +18957,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1028,
+    "aggregatedRank": 1027,
     "countryRank": 1
   },
   {
@@ -18980,7 +18970,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1029,
+    "aggregatedRank": 1028,
     "countryRank": 8
   },
   {
@@ -18993,7 +18983,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1030,
+    "aggregatedRank": 1029,
     "countryRank": 64
   },
   {
@@ -19006,7 +18996,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1031,
+    "aggregatedRank": 1030,
     "countryRank": 105
   },
   {
@@ -19022,7 +19012,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1032,
+    "aggregatedRank": 1031,
     "countryRank": 29
   },
   {
@@ -19035,7 +19025,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1033,
+    "aggregatedRank": 1032,
     "countryRank": 42
   },
   {
@@ -19051,7 +19041,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1034,
+    "aggregatedRank": 1033,
     "countryRank": 30
   },
   {
@@ -19067,7 +19057,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1035,
+    "aggregatedRank": 1034,
     "countryRank": 13
   },
   {
@@ -19083,7 +19073,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1036,
+    "aggregatedRank": 1035,
     "countryRank": 9
   },
   {
@@ -19099,7 +19089,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1037,
+    "aggregatedRank": 1036,
     "countryRank": 106
   },
   {
@@ -19115,7 +19105,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1038,
+    "aggregatedRank": 1037,
     "countryRank": 17
   },
   {
@@ -19128,7 +19118,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1039,
+    "aggregatedRank": 1038,
     "countryRank": 1
   },
   {
@@ -19141,7 +19131,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1040,
+    "aggregatedRank": 1039,
     "countryRank": 1
   },
   {
@@ -19154,7 +19144,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1041,
+    "aggregatedRank": 1040,
     "countryRank": 11
   },
   {
@@ -19167,7 +19157,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1042,
+    "aggregatedRank": 1041,
     "countryRank": 24
   },
   {
@@ -19180,7 +19170,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1043,
+    "aggregatedRank": 1042,
     "countryRank": 43
   },
   {
@@ -19193,7 +19183,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1044,
+    "aggregatedRank": 1043,
     "countryRank": 40
   },
   {
@@ -19206,7 +19196,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1045,
+    "aggregatedRank": 1044,
     "countryRank": 65
   },
   {
@@ -19219,7 +19209,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1046,
+    "aggregatedRank": 1045,
     "countryRank": 1
   },
   {
@@ -19232,7 +19222,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1047,
+    "aggregatedRank": 1046,
     "countryRank": 107
   },
   {
@@ -19245,7 +19235,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1048,
+    "aggregatedRank": 1047,
     "countryRank": 1
   },
   {
@@ -19261,7 +19251,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1049,
+    "aggregatedRank": 1048,
     "countryRank": 66
   },
   {
@@ -19277,7 +19267,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1050,
+    "aggregatedRank": 1049,
     "countryRank": 17
   },
   {
@@ -19290,7 +19280,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1051,
+    "aggregatedRank": 1050,
     "countryRank": 1
   },
   {
@@ -19303,7 +19293,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1052,
+    "aggregatedRank": 1051,
     "countryRank": 11
   },
   {
@@ -19316,7 +19306,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1053,
+    "aggregatedRank": 1052,
     "countryRank": 67
   },
   {
@@ -19329,7 +19319,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1054,
+    "aggregatedRank": 1053,
     "countryRank": 68
   },
   {
@@ -19342,7 +19332,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1055,
+    "aggregatedRank": 1054,
     "countryRank": 6
   },
   {
@@ -19355,7 +19345,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1056,
+    "aggregatedRank": 1055,
     "countryRank": 44
   },
   {
@@ -19368,7 +19358,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1057,
+    "aggregatedRank": 1056,
     "countryRank": 14
   },
   {
@@ -19381,7 +19371,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1058,
+    "aggregatedRank": 1057,
     "countryRank": 160
   },
   {
@@ -19394,7 +19384,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1059,
+    "aggregatedRank": 1058,
     "countryRank": 89
   },
   {
@@ -19407,7 +19397,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1060,
+    "aggregatedRank": 1059,
     "countryRank": 69
   },
   {
@@ -19420,7 +19410,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1061,
+    "aggregatedRank": 1060,
     "countryRank": 12
   },
   {
@@ -19433,7 +19423,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1062,
+    "aggregatedRank": 1061,
     "countryRank": 3
   },
   {
@@ -19446,7 +19436,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1063,
+    "aggregatedRank": 1062,
     "countryRank": 3
   },
   {
@@ -19459,7 +19449,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1064,
+    "aggregatedRank": 1063,
     "countryRank": 70
   },
   {
@@ -19472,7 +19462,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1065,
+    "aggregatedRank": 1064,
     "countryRank": 10
   },
   {
@@ -19485,7 +19475,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1066,
+    "aggregatedRank": 1065,
     "countryRank": 45
   },
   {
@@ -19498,7 +19488,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1067,
+    "aggregatedRank": 1066,
     "countryRank": 1
   },
   {
@@ -19514,7 +19504,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1068,
+    "aggregatedRank": 1067,
     "countryRank": 108
   },
   {
@@ -19530,7 +19520,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1069,
+    "aggregatedRank": 1068,
     "countryRank": 161
   },
   {
@@ -19546,7 +19536,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1070,
+    "aggregatedRank": 1069,
     "countryRank": 25
   },
   {
@@ -19562,7 +19552,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1071,
+    "aggregatedRank": 1070,
     "countryRank": 4
   },
   {
@@ -19578,7 +19568,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1072,
+    "aggregatedRank": 1071,
     "countryRank": 4
   },
   {
@@ -19591,7 +19581,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1073,
+    "aggregatedRank": 1072,
     "countryRank": 1
   },
   {
@@ -19604,7 +19594,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1074,
+    "aggregatedRank": 1073,
     "countryRank": 2
   },
   {
@@ -19617,7 +19607,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1075,
+    "aggregatedRank": 1074,
     "countryRank": 1
   },
   {
@@ -19630,7 +19620,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1076,
+    "aggregatedRank": 1075,
     "countryRank": 46
   },
   {
@@ -19643,7 +19633,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1077,
+    "aggregatedRank": 1076,
     "countryRank": 47
   },
   {
@@ -19656,7 +19646,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1078,
+    "aggregatedRank": 1077,
     "countryRank": 5
   },
   {
@@ -19669,7 +19659,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1079,
+    "aggregatedRank": 1078,
     "countryRank": 26
   },
   {
@@ -19682,7 +19672,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1080,
+    "aggregatedRank": 1079,
     "countryRank": 13
   },
   {
@@ -19695,7 +19685,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1081,
+    "aggregatedRank": 1080,
     "countryRank": 14
   },
   {
@@ -19708,7 +19698,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1082,
+    "aggregatedRank": 1081,
     "countryRank": 15
   },
   {
@@ -19721,7 +19711,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1083,
+    "aggregatedRank": 1082,
     "countryRank": 16
   },
   {
@@ -19734,7 +19724,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1084,
+    "aggregatedRank": 1083,
     "countryRank": 17
   },
   {
@@ -19747,7 +19737,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1085,
+    "aggregatedRank": 1084,
     "countryRank": 18
   },
   {
@@ -19760,7 +19750,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1086,
+    "aggregatedRank": 1085,
     "countryRank": 19
   },
   {
@@ -19773,7 +19763,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1087,
+    "aggregatedRank": 1086,
     "countryRank": 51
   },
   {
@@ -19786,7 +19776,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1088,
+    "aggregatedRank": 1087,
     "countryRank": 52
   },
   {
@@ -19799,7 +19789,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1089,
+    "aggregatedRank": 1088,
     "countryRank": 18
   },
   {
@@ -19812,7 +19802,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1090,
+    "aggregatedRank": 1089,
     "countryRank": 10
   },
   {
@@ -19825,7 +19815,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1091,
+    "aggregatedRank": 1090,
     "countryRank": 8
   },
   {
@@ -19838,7 +19828,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1092,
+    "aggregatedRank": 1091,
     "countryRank": 18
   },
   {
@@ -19851,7 +19841,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1093,
+    "aggregatedRank": 1092,
     "countryRank": 13
   },
   {
@@ -19864,7 +19854,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1094,
+    "aggregatedRank": 1093,
     "countryRank": 90
   },
   {
@@ -19877,7 +19867,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1095,
+    "aggregatedRank": 1094,
     "countryRank": 91
   },
   {
@@ -19890,7 +19880,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1096,
+    "aggregatedRank": 1095,
     "countryRank": 162
   },
   {
@@ -19903,7 +19893,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1097,
+    "aggregatedRank": 1096,
     "countryRank": 163
   },
   {
@@ -19916,7 +19906,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1098,
+    "aggregatedRank": 1097,
     "countryRank": 164
   },
   {
@@ -19929,7 +19919,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1099,
+    "aggregatedRank": 1098,
     "countryRank": 165
   },
   {
@@ -19942,7 +19932,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1100,
+    "aggregatedRank": 1099,
     "countryRank": 4
   },
   {
@@ -19955,7 +19945,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1101,
+    "aggregatedRank": 1100,
     "countryRank": 27
   },
   {
@@ -19968,7 +19958,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1102,
+    "aggregatedRank": 1101,
     "countryRank": 92
   },
   {
@@ -19981,7 +19971,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1103,
+    "aggregatedRank": 1102,
     "countryRank": 48
   },
   {
@@ -19994,7 +19984,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1104,
+    "aggregatedRank": 1103,
     "countryRank": 53
   },
   {
@@ -20007,7 +19997,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1105,
+    "aggregatedRank": 1104,
     "countryRank": 31
   },
   {
@@ -20020,7 +20010,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1106,
+    "aggregatedRank": 1105,
     "countryRank": 28
   },
   {
@@ -20033,7 +20023,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1107,
+    "aggregatedRank": 1106,
     "countryRank": 54
   },
   {
@@ -20046,7 +20036,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1108,
+    "aggregatedRank": 1107,
     "countryRank": 93
   },
   {
@@ -20059,7 +20049,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1109,
+    "aggregatedRank": 1108,
     "countryRank": 12
   },
   {
@@ -20072,7 +20062,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1110,
+    "aggregatedRank": 1109,
     "countryRank": 5
   },
   {
@@ -20085,7 +20075,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1111,
+    "aggregatedRank": 1110,
     "countryRank": 20
   },
   {
@@ -20098,7 +20088,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1112,
+    "aggregatedRank": 1111,
     "countryRank": 21
   },
   {
@@ -20111,7 +20101,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1113,
+    "aggregatedRank": 1112,
     "countryRank": 22
   },
   {
@@ -20124,7 +20114,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1114,
+    "aggregatedRank": 1113,
     "countryRank": 19
   },
   {
@@ -20137,7 +20127,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1115,
+    "aggregatedRank": 1114,
     "countryRank": 11
   },
   {
@@ -20150,7 +20140,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1116,
+    "aggregatedRank": 1115,
     "countryRank": 12
   },
   {
@@ -20163,7 +20153,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1117,
+    "aggregatedRank": 1116,
     "countryRank": 29
   },
   {
@@ -20176,7 +20166,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1118,
+    "aggregatedRank": 1117,
     "countryRank": 30
   },
   {
@@ -20189,7 +20179,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1119,
+    "aggregatedRank": 1118,
     "countryRank": 31
   },
   {
@@ -20202,7 +20192,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1120,
+    "aggregatedRank": 1119,
     "countryRank": 18
   },
   {
@@ -20215,7 +20205,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1121,
+    "aggregatedRank": 1120,
     "countryRank": 13
   },
   {
@@ -20228,7 +20218,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1122,
+    "aggregatedRank": 1121,
     "countryRank": 32
   },
   {
@@ -20241,7 +20231,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1123,
+    "aggregatedRank": 1122,
     "countryRank": 33
   },
   {
@@ -20257,7 +20247,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1124,
+    "aggregatedRank": 1123,
     "countryRank": 5
   },
   {
@@ -20273,7 +20263,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1125,
+    "aggregatedRank": 1124,
     "countryRank": 49
   },
   {
@@ -20289,7 +20279,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1126,
+    "aggregatedRank": 1125,
     "countryRank": 71
   },
   {
@@ -20305,7 +20295,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1127,
+    "aggregatedRank": 1126,
     "countryRank": 6
   },
   {
@@ -20321,7 +20311,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1128,
+    "aggregatedRank": 1127,
     "countryRank": 3
   },
   {
@@ -20337,7 +20327,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1129,
+    "aggregatedRank": 1128,
     "countryRank": 19
   },
   {
@@ -20350,7 +20340,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1130,
+    "aggregatedRank": 1129,
     "countryRank": 34
   },
   {
@@ -20366,7 +20356,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1131,
+    "aggregatedRank": 1130,
     "countryRank": 1
   },
   {
@@ -20382,7 +20372,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1132,
+    "aggregatedRank": 1131,
     "countryRank": 20
   },
   {
@@ -20395,7 +20385,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1133,
+    "aggregatedRank": 1132,
     "countryRank": 23
   },
   {
@@ -20408,7 +20398,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1134,
+    "aggregatedRank": 1133,
     "countryRank": 24
   },
   {
@@ -20421,7 +20411,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1135,
+    "aggregatedRank": 1134,
     "countryRank": 14
   },
   {
@@ -20434,7 +20424,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1136,
+    "aggregatedRank": 1135,
     "countryRank": 13
   },
   {
@@ -20447,7 +20437,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1137,
+    "aggregatedRank": 1136,
     "countryRank": 3
   },
   {
@@ -20460,7 +20450,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1138,
+    "aggregatedRank": 1137,
     "countryRank": 4
   },
   {
@@ -20473,7 +20463,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1139,
+    "aggregatedRank": 1138,
     "countryRank": 30
   },
   {
@@ -20486,7 +20476,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1140,
+    "aggregatedRank": 1139,
     "countryRank": 31
   },
   {
@@ -20499,7 +20489,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1141,
+    "aggregatedRank": 1140,
     "countryRank": 109
   },
   {
@@ -20512,7 +20502,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1142,
+    "aggregatedRank": 1141,
     "countryRank": 32
   },
   {
@@ -20525,7 +20515,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1143,
+    "aggregatedRank": 1142,
     "countryRank": 1
   },
   {
@@ -20538,7 +20528,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1144,
+    "aggregatedRank": 1143,
     "countryRank": 50
   },
   {
@@ -20551,7 +20541,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1145,
+    "aggregatedRank": 1144,
     "countryRank": 51
   },
   {
@@ -20564,7 +20554,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1146,
+    "aggregatedRank": 1145,
     "countryRank": 52
   },
   {
@@ -20577,7 +20567,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1147,
+    "aggregatedRank": 1146,
     "countryRank": 1
   },
   {
@@ -20590,7 +20580,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1148,
+    "aggregatedRank": 1147,
     "countryRank": 35
   },
   {
@@ -20603,7 +20593,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1149,
+    "aggregatedRank": 1148,
     "countryRank": 36
   },
   {
@@ -20616,7 +20606,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1150,
+    "aggregatedRank": 1149,
     "countryRank": 37
   },
   {
@@ -20629,7 +20619,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1151,
+    "aggregatedRank": 1150,
     "countryRank": 38
   },
   {
@@ -20642,7 +20632,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1152,
+    "aggregatedRank": 1151,
     "countryRank": 25
   },
   {
@@ -20655,7 +20645,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1153,
+    "aggregatedRank": 1152,
     "countryRank": 26
   },
   {
@@ -20668,7 +20658,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1154,
+    "aggregatedRank": 1153,
     "countryRank": 27
   },
   {
@@ -20681,7 +20671,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1155,
+    "aggregatedRank": 1154,
     "countryRank": 28
   },
   {
@@ -20694,7 +20684,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1156,
+    "aggregatedRank": 1155,
     "countryRank": 29
   },
   {
@@ -20707,7 +20697,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1157,
+    "aggregatedRank": 1156,
     "countryRank": 30
   },
   {
@@ -20720,7 +20710,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1158,
+    "aggregatedRank": 1157,
     "countryRank": 31
   },
   {
@@ -20733,7 +20723,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1159,
+    "aggregatedRank": 1158,
     "countryRank": 32
   },
   {
@@ -20746,7 +20736,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1160,
+    "aggregatedRank": 1159,
     "countryRank": 33
   },
   {
@@ -20759,7 +20749,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1161,
+    "aggregatedRank": 1160,
     "countryRank": 34
   },
   {
@@ -20772,7 +20762,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1162,
+    "aggregatedRank": 1161,
     "countryRank": 2
   },
   {
@@ -20785,7 +20775,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1163,
+    "aggregatedRank": 1162,
     "countryRank": 55
   },
   {
@@ -20798,7 +20788,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1164,
+    "aggregatedRank": 1163,
     "countryRank": 56
   },
   {
@@ -20811,7 +20801,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1165,
+    "aggregatedRank": 1164,
     "countryRank": 57
   },
   {
@@ -20824,7 +20814,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1166,
+    "aggregatedRank": 1165,
     "countryRank": 58
   },
   {
@@ -20837,7 +20827,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1167,
+    "aggregatedRank": 1166,
     "countryRank": 4
   },
   {
@@ -20850,7 +20840,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1168,
+    "aggregatedRank": 1167,
     "countryRank": 21
   },
   {
@@ -20863,7 +20853,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1169,
+    "aggregatedRank": 1168,
     "countryRank": 22
   },
   {
@@ -20876,7 +20866,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1170,
+    "aggregatedRank": 1169,
     "countryRank": 28
   },
   {
@@ -20889,7 +20879,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1171,
+    "aggregatedRank": 1170,
     "countryRank": 1
   },
   {
@@ -20902,7 +20892,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1172,
+    "aggregatedRank": 1171,
     "countryRank": 15
   },
   {
@@ -20915,7 +20905,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1173,
+    "aggregatedRank": 1172,
     "countryRank": 16
   },
   {
@@ -20928,7 +20918,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1174,
+    "aggregatedRank": 1173,
     "countryRank": 17
   },
   {
@@ -20941,7 +20931,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1175,
+    "aggregatedRank": 1174,
     "countryRank": 18
   },
   {
@@ -20954,7 +20944,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1176,
+    "aggregatedRank": 1175,
     "countryRank": 19
   },
   {
@@ -20967,7 +20957,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1177,
+    "aggregatedRank": 1176,
     "countryRank": 20
   },
   {
@@ -20980,7 +20970,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1178,
+    "aggregatedRank": 1177,
     "countryRank": 4
   },
   {
@@ -20993,7 +20983,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1179,
+    "aggregatedRank": 1178,
     "countryRank": 19
   },
   {
@@ -21006,7 +20996,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1180,
+    "aggregatedRank": 1179,
     "countryRank": 11
   },
   {
@@ -21019,7 +21009,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1181,
+    "aggregatedRank": 1180,
     "countryRank": 12
   },
   {
@@ -21032,7 +21022,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1182,
+    "aggregatedRank": 1181,
     "countryRank": 15
   },
   {
@@ -21045,7 +21035,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1183,
+    "aggregatedRank": 1182,
     "countryRank": 1
   },
   {
@@ -21058,7 +21048,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1184,
+    "aggregatedRank": 1183,
     "countryRank": 94
   },
   {
@@ -21071,7 +21061,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1185,
+    "aggregatedRank": 1184,
     "countryRank": 95
   },
   {
@@ -21084,7 +21074,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1186,
+    "aggregatedRank": 1185,
     "countryRank": 96
   },
   {
@@ -21097,7 +21087,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1187,
+    "aggregatedRank": 1186,
     "countryRank": 97
   },
   {
@@ -21110,7 +21100,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1188,
+    "aggregatedRank": 1187,
     "countryRank": 98
   },
   {
@@ -21123,7 +21113,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1189,
+    "aggregatedRank": 1188,
     "countryRank": 4
   },
   {
@@ -21136,7 +21126,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1190,
+    "aggregatedRank": 1189,
     "countryRank": 166
   },
   {
@@ -21149,7 +21139,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1191,
+    "aggregatedRank": 1190,
     "countryRank": 167
   },
   {
@@ -21162,7 +21152,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1192,
+    "aggregatedRank": 1191,
     "countryRank": 168
   },
   {
@@ -21175,7 +21165,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1193,
+    "aggregatedRank": 1192,
     "countryRank": 169
   },
   {
@@ -21188,7 +21178,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1194,
+    "aggregatedRank": 1193,
     "countryRank": 170
   },
   {
@@ -21201,7 +21191,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1195,
+    "aggregatedRank": 1194,
     "countryRank": 171
   },
   {
@@ -21214,7 +21204,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1196,
+    "aggregatedRank": 1195,
     "countryRank": 59
   },
   {
@@ -21227,7 +21217,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1197,
+    "aggregatedRank": 1196,
     "countryRank": 99
   },
   {
@@ -21240,7 +21230,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1198,
+    "aggregatedRank": 1197,
     "countryRank": 39
   },
   {
@@ -21253,7 +21243,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1199,
+    "aggregatedRank": 1198,
     "countryRank": 40
   },
   {
@@ -21266,7 +21256,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1200,
+    "aggregatedRank": 1199,
     "countryRank": 41
   },
   {
@@ -21279,7 +21269,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1201,
+    "aggregatedRank": 1200,
     "countryRank": 42
   },
   {
@@ -21292,7 +21282,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1202,
+    "aggregatedRank": 1201,
     "countryRank": 35
   },
   {
@@ -21305,7 +21295,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1203,
+    "aggregatedRank": 1202,
     "countryRank": 100
   },
   {
@@ -21318,7 +21308,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1204,
+    "aggregatedRank": 1203,
     "countryRank": 1
   },
   {
@@ -21331,7 +21321,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1205,
+    "aggregatedRank": 1204,
     "countryRank": 21
   },
   {
@@ -21344,7 +21334,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1206,
+    "aggregatedRank": 1205,
     "countryRank": 43
   },
   {
@@ -21357,7 +21347,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1207,
+    "aggregatedRank": 1206,
     "countryRank": 44
   },
   {
@@ -21370,7 +21360,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1208,
+    "aggregatedRank": 1207,
     "countryRank": 45
   },
   {
@@ -21383,7 +21373,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1209,
+    "aggregatedRank": 1208,
     "countryRank": 13
   },
   {
@@ -21396,7 +21386,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1210,
+    "aggregatedRank": 1209,
     "countryRank": 33
   },
   {
@@ -21409,7 +21399,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1211,
+    "aggregatedRank": 1210,
     "countryRank": 20
   },
   {
@@ -21422,7 +21412,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1212,
+    "aggregatedRank": 1211,
     "countryRank": 5
   },
   {
@@ -21435,7 +21425,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1213,
+    "aggregatedRank": 1212,
     "countryRank": 5
   },
   {
@@ -21448,7 +21438,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1214,
+    "aggregatedRank": 1213,
     "countryRank": 6
   },
   {
@@ -21461,7 +21451,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1215,
+    "aggregatedRank": 1214,
     "countryRank": 22
   },
   {
@@ -21474,7 +21464,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1216,
+    "aggregatedRank": 1215,
     "countryRank": 2
   },
   {
@@ -21487,7 +21477,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1217,
+    "aggregatedRank": 1216,
     "countryRank": 2
   },
   {
@@ -21500,7 +21490,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1218,
+    "aggregatedRank": 1217,
     "countryRank": 46
   },
   {
@@ -21513,7 +21503,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1219,
+    "aggregatedRank": 1218,
     "countryRank": 47
   },
   {
@@ -21526,7 +21516,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1220,
+    "aggregatedRank": 1219,
     "countryRank": 48
   },
   {
@@ -21539,7 +21529,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1221,
+    "aggregatedRank": 1220,
     "countryRank": 2
   },
   {
@@ -21552,7 +21542,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1222,
+    "aggregatedRank": 1221,
     "countryRank": 21
   },
   {
@@ -21565,7 +21555,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1223,
+    "aggregatedRank": 1222,
     "countryRank": 13
   },
   {
@@ -21578,7 +21568,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1224,
+    "aggregatedRank": 1223,
     "countryRank": 9
   },
   {
@@ -21591,7 +21581,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1225,
+    "aggregatedRank": 1224,
     "countryRank": 36
   },
   {
@@ -21604,7 +21594,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1226,
+    "aggregatedRank": 1225,
     "countryRank": 49
   },
   {
@@ -21617,7 +21607,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1227,
+    "aggregatedRank": 1226,
     "countryRank": 50
   },
   {
@@ -21630,7 +21620,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1228,
+    "aggregatedRank": 1227,
     "countryRank": 2
   },
   {
@@ -21646,7 +21636,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1229,
+    "aggregatedRank": 1228,
     "countryRank": 34
   },
   {
@@ -21662,7 +21652,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1230,
+    "aggregatedRank": 1229,
     "countryRank": 4
   },
   {
@@ -21678,7 +21668,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1231,
+    "aggregatedRank": 1230,
     "countryRank": 35
   },
   {
@@ -21694,7 +21684,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1232,
+    "aggregatedRank": 1231,
     "countryRank": 110
   },
   {
@@ -21710,7 +21700,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1233,
+    "aggregatedRank": 1232,
     "countryRank": 23
   },
   {
@@ -21723,7 +21713,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1234,
+    "aggregatedRank": 1233,
     "countryRank": 2
   },
   {
@@ -21739,7 +21729,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1235,
+    "aggregatedRank": 1234,
     "countryRank": 5
   },
   {
@@ -21755,7 +21745,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1236,
+    "aggregatedRank": 1235,
     "countryRank": 14
   },
   {
@@ -21771,7 +21761,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1237,
+    "aggregatedRank": 1236,
     "countryRank": 32
   },
   {
@@ -21784,7 +21774,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1238,
+    "aggregatedRank": 1237,
     "countryRank": 2
   },
   {
@@ -21800,7 +21790,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1239,
+    "aggregatedRank": 1238,
     "countryRank": 16
   },
   {
@@ -21813,7 +21803,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1240,
+    "aggregatedRank": 1239,
     "countryRank": 3
   },
   {
@@ -21829,7 +21819,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1241,
+    "aggregatedRank": 1240,
     "countryRank": 15
   },
   {
@@ -21842,7 +21832,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1242,
+    "aggregatedRank": 1241,
     "countryRank": 13
   },
   {
@@ -21858,7 +21848,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1243,
+    "aggregatedRank": 1242,
     "countryRank": 29
   },
   {
@@ -21871,7 +21861,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1244,
+    "aggregatedRank": 1243,
     "countryRank": 4
   },
   {
@@ -21887,7 +21877,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1245,
+    "aggregatedRank": 1244,
     "countryRank": 6
   },
   {
@@ -21900,7 +21890,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1246,
+    "aggregatedRank": 1245,
     "countryRank": 3
   },
   {
@@ -21916,7 +21906,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1247,
+    "aggregatedRank": 1246,
     "countryRank": 17
   },
   {
@@ -21932,7 +21922,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1248,
+    "aggregatedRank": 1247,
     "countryRank": 30
   },
   {
@@ -21945,7 +21935,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1249,
+    "aggregatedRank": 1248,
     "countryRank": 1
   },
   {
@@ -21961,7 +21951,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1250,
+    "aggregatedRank": 1249,
     "countryRank": 1
   },
   {
@@ -21974,7 +21964,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1251,
+    "aggregatedRank": 1250,
     "countryRank": 3
   },
   {
@@ -21987,7 +21977,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1252,
+    "aggregatedRank": 1251,
     "countryRank": 72
   },
   {
@@ -22000,7 +21990,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1253,
+    "aggregatedRank": 1252,
     "countryRank": 1
   },
   {
@@ -22013,7 +22003,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1254,
+    "aggregatedRank": 1253,
     "countryRank": 4
   },
   {
@@ -22029,7 +22019,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1255,
+    "aggregatedRank": 1254,
     "countryRank": 2
   },
   {
@@ -22045,7 +22035,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1256,
+    "aggregatedRank": 1255,
     "countryRank": 14
   },
   {
@@ -22061,7 +22051,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1257,
+    "aggregatedRank": 1256,
     "countryRank": 6
   },
   {
@@ -22074,7 +22064,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1258,
+    "aggregatedRank": 1257,
     "countryRank": 18
   },
   {
@@ -22087,7 +22077,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1259,
+    "aggregatedRank": 1258,
     "countryRank": 5
   },
   {
@@ -22100,7 +22090,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1260,
+    "aggregatedRank": 1259,
     "countryRank": 36
   },
   {
@@ -22113,7 +22103,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1261,
+    "aggregatedRank": 1260,
     "countryRank": 4
   },
   {
@@ -22129,7 +22119,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1262,
+    "aggregatedRank": 1261,
     "countryRank": 51
   },
   {
@@ -22145,7 +22135,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1263,
+    "aggregatedRank": 1262,
     "countryRank": 24
   },
   {
@@ -22161,7 +22151,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1264,
+    "aggregatedRank": 1263,
     "countryRank": 172
   },
   {
@@ -22177,7 +22167,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1265,
+    "aggregatedRank": 1264,
     "countryRank": 6
   },
   {
@@ -22193,7 +22183,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1266,
+    "aggregatedRank": 1265,
     "countryRank": 7
   },
   {
@@ -22206,7 +22196,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1267,
+    "aggregatedRank": 1266,
     "countryRank": 2
   },
   {
@@ -22219,7 +22209,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1268,
+    "aggregatedRank": 1267,
     "countryRank": 9
   },
   {
@@ -22232,7 +22222,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1269,
+    "aggregatedRank": 1268,
     "countryRank": 1
   },
   {
@@ -22245,7 +22235,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1270,
+    "aggregatedRank": 1269,
     "countryRank": 2
   },
   {
@@ -22258,7 +22248,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1271,
+    "aggregatedRank": 1270,
     "countryRank": 14
   },
   {
@@ -22271,7 +22261,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1272,
+    "aggregatedRank": 1271,
     "countryRank": 10
   },
   {
@@ -22284,7 +22274,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1273,
+    "aggregatedRank": 1272,
     "countryRank": 3
   },
   {
@@ -22300,7 +22290,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1274,
+    "aggregatedRank": 1273,
     "countryRank": 4
   },
   {
@@ -22316,7 +22306,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1275,
+    "aggregatedRank": 1274,
     "countryRank": 25
   },
   {
@@ -22329,7 +22319,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1276,
+    "aggregatedRank": 1275,
     "countryRank": 52
   },
   {
@@ -22342,7 +22332,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1277,
+    "aggregatedRank": 1276,
     "countryRank": 5
   },
   {
@@ -22355,7 +22345,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1278,
+    "aggregatedRank": 1277,
     "countryRank": 26
   },
   {
@@ -22368,7 +22358,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1279,
+    "aggregatedRank": 1278,
     "countryRank": 2
   },
   {
@@ -22381,7 +22371,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1280,
+    "aggregatedRank": 1279,
     "countryRank": 37
   },
   {
@@ -22394,7 +22384,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1281,
+    "aggregatedRank": 1280,
     "countryRank": 4
   },
   {
@@ -22407,7 +22397,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1282,
+    "aggregatedRank": 1281,
     "countryRank": 20
   },
   {
@@ -22420,7 +22410,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1283,
+    "aggregatedRank": 1282,
     "countryRank": 7
   },
   {
@@ -22433,7 +22423,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1284,
+    "aggregatedRank": 1283,
     "countryRank": 5
   },
   {
@@ -22446,7 +22436,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1285,
+    "aggregatedRank": 1284,
     "countryRank": 6
   },
   {
@@ -22459,7 +22449,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1286,
+    "aggregatedRank": 1285,
     "countryRank": 15
   },
   {
@@ -22475,7 +22465,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1287,
+    "aggregatedRank": 1286,
     "countryRank": 38
   },
   {
@@ -22491,7 +22481,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1288,
+    "aggregatedRank": 1287,
     "countryRank": 2
   },
   {
@@ -22507,7 +22497,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1289,
+    "aggregatedRank": 1288,
     "countryRank": 27
   },
   {
@@ -22523,7 +22513,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1290,
+    "aggregatedRank": 1289,
     "countryRank": 8
   },
   {
@@ -22539,7 +22529,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1291,
+    "aggregatedRank": 1290,
     "countryRank": 9
   },
   {
@@ -22552,7 +22542,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1292,
+    "aggregatedRank": 1291,
     "countryRank": 7
   },
   {
@@ -22565,7 +22555,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1293,
+    "aggregatedRank": 1292,
     "countryRank": 5
   },
   {
@@ -22578,7 +22568,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1294,
+    "aggregatedRank": 1293,
     "countryRank": 19
   },
   {
@@ -22591,7 +22581,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1295,
+    "aggregatedRank": 1294,
     "countryRank": 16
   },
   {
@@ -22604,7 +22594,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1296,
+    "aggregatedRank": 1295,
     "countryRank": 6
   },
   {
@@ -22617,7 +22607,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1297,
+    "aggregatedRank": 1296,
     "countryRank": 11
   },
   {
@@ -22630,7 +22620,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1298,
+    "aggregatedRank": 1297,
     "countryRank": 5
   },
   {
@@ -22643,7 +22633,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1299,
+    "aggregatedRank": 1298,
     "countryRank": 21
   },
   {
@@ -22656,7 +22646,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1300,
+    "aggregatedRank": 1299,
     "countryRank": 173
   },
   {
@@ -22669,7 +22659,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1301,
+    "aggregatedRank": 1300,
     "countryRank": 28
   },
   {
@@ -22682,7 +22672,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1302,
+    "aggregatedRank": 1301,
     "countryRank": 3
   },
   {
@@ -22698,7 +22688,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1303,
+    "aggregatedRank": 1302,
     "countryRank": 29
   },
   {
@@ -22714,7 +22704,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1304,
+    "aggregatedRank": 1303,
     "countryRank": 9
   },
   {
@@ -22727,7 +22717,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1305,
+    "aggregatedRank": 1304,
     "countryRank": 31
   },
   {
@@ -22740,7 +22730,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1306,
+    "aggregatedRank": 1305,
     "countryRank": 174
   },
   {
@@ -22753,7 +22743,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1307,
+    "aggregatedRank": 1306,
     "countryRank": 1
   },
   {
@@ -22766,7 +22756,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1308,
+    "aggregatedRank": 1307,
     "countryRank": 17
   },
   {
@@ -22779,7 +22769,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1309,
+    "aggregatedRank": 1308,
     "countryRank": 1
   },
   {
@@ -22792,7 +22782,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1310,
+    "aggregatedRank": 1309,
     "countryRank": 6
   },
   {
@@ -22805,7 +22795,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1311,
+    "aggregatedRank": 1310,
     "countryRank": 7
   },
   {
@@ -22818,7 +22808,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1312,
+    "aggregatedRank": 1311,
     "countryRank": 23
   },
   {
@@ -22831,7 +22821,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1313,
+    "aggregatedRank": 1312,
     "countryRank": 53
   },
   {
@@ -22844,7 +22834,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1314,
+    "aggregatedRank": 1313,
     "countryRank": 1
   },
   {
@@ -22857,7 +22847,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1315,
+    "aggregatedRank": 1314,
     "countryRank": 5
   },
   {
@@ -22870,7 +22860,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1316,
+    "aggregatedRank": 1315,
     "countryRank": 1
   },
   {
@@ -22883,7 +22873,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1317,
+    "aggregatedRank": 1316,
     "countryRank": 24
   },
   {
@@ -22896,7 +22886,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1318,
+    "aggregatedRank": 1317,
     "countryRank": 54
   },
   {
@@ -22912,7 +22902,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1319,
+    "aggregatedRank": 1318,
     "countryRank": 30
   },
   {
@@ -22928,7 +22918,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1320,
+    "aggregatedRank": 1319,
     "countryRank": 32
   },
   {
@@ -22941,7 +22931,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1321,
+    "aggregatedRank": 1320,
     "countryRank": 3
   },
   {
@@ -22954,7 +22944,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1322,
+    "aggregatedRank": 1321,
     "countryRank": 53
   },
   {
@@ -22967,7 +22957,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1323,
+    "aggregatedRank": 1322,
     "countryRank": 8
   },
   {
@@ -22980,7 +22970,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1324,
+    "aggregatedRank": 1323,
     "countryRank": 55
   },
   {
@@ -22993,7 +22983,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1325,
+    "aggregatedRank": 1324,
     "countryRank": 22
   },
   {
@@ -23006,7 +22996,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1326,
+    "aggregatedRank": 1325,
     "countryRank": 5
   },
   {
@@ -23019,7 +23009,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1327,
+    "aggregatedRank": 1326,
     "countryRank": 8
   },
   {
@@ -23032,7 +23022,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1328,
+    "aggregatedRank": 1327,
     "countryRank": 56
   },
   {
@@ -23045,7 +23035,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1329,
+    "aggregatedRank": 1328,
     "countryRank": 1
   },
   {
@@ -23058,7 +23048,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1330,
+    "aggregatedRank": 1329,
     "countryRank": 22
   },
   {
@@ -23071,7 +23061,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1331,
+    "aggregatedRank": 1330,
     "countryRank": 3
   },
   {
@@ -23084,7 +23074,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1332,
+    "aggregatedRank": 1331,
     "countryRank": 23
   },
   {
@@ -23097,7 +23087,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1333,
+    "aggregatedRank": 1332,
     "countryRank": 2
   },
   {
@@ -23110,7 +23100,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1334,
+    "aggregatedRank": 1333,
     "countryRank": 2
   },
   {
@@ -23123,7 +23113,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1335,
+    "aggregatedRank": 1334,
     "countryRank": 3
   },
   {
@@ -23136,7 +23126,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1336,
+    "aggregatedRank": 1335,
     "countryRank": 4
   },
   {
@@ -23149,7 +23139,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1337,
+    "aggregatedRank": 1336,
     "countryRank": 6
   },
   {
@@ -23162,7 +23152,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1338,
+    "aggregatedRank": 1337,
     "countryRank": 111
   },
   {
@@ -23175,7 +23165,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1339,
+    "aggregatedRank": 1338,
     "countryRank": 175
   },
   {
@@ -23188,7 +23178,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1340,
+    "aggregatedRank": 1339,
     "countryRank": 23
   },
   {
@@ -23201,7 +23191,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1341,
+    "aggregatedRank": 1340,
     "countryRank": 7
   },
   {
@@ -23214,7 +23204,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1342,
+    "aggregatedRank": 1341,
     "countryRank": 4
   },
   {
@@ -23227,7 +23217,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1343,
+    "aggregatedRank": 1342,
     "countryRank": 7
   },
   {
@@ -23240,7 +23230,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1344,
+    "aggregatedRank": 1343,
     "countryRank": 6
   },
   {
@@ -23253,7 +23243,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1345,
+    "aggregatedRank": 1344,
     "countryRank": 7
   },
   {
@@ -23266,7 +23256,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1346,
+    "aggregatedRank": 1345,
     "countryRank": 2
   },
   {
@@ -23279,7 +23269,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1347,
+    "aggregatedRank": 1346,
     "countryRank": 3
   },
   {
@@ -23292,7 +23282,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1348,
+    "aggregatedRank": 1347,
     "countryRank": 6
   },
   {
@@ -23305,7 +23295,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1349,
+    "aggregatedRank": 1348,
     "countryRank": 2
   },
   {
@@ -23318,7 +23308,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1350,
+    "aggregatedRank": 1349,
     "countryRank": 176
   },
   {
@@ -23331,7 +23321,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1351,
+    "aggregatedRank": 1350,
     "countryRank": 12
   },
   {
@@ -23344,7 +23334,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1352,
+    "aggregatedRank": 1351,
     "countryRank": 5
   },
   {
@@ -23357,7 +23347,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1353,
+    "aggregatedRank": 1352,
     "countryRank": 1
   },
   {
@@ -23370,7 +23360,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1354,
+    "aggregatedRank": 1353,
     "countryRank": 6
   },
   {
@@ -23383,7 +23373,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1355,
+    "aggregatedRank": 1354,
     "countryRank": 2
   },
   {
@@ -23396,7 +23386,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1356,
+    "aggregatedRank": 1355,
     "countryRank": 57
   },
   {
@@ -23409,7 +23399,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1357,
+    "aggregatedRank": 1356,
     "countryRank": 2
   },
   {
@@ -23422,7 +23412,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1358,
+    "aggregatedRank": 1357,
     "countryRank": 8
   },
   {
@@ -23435,7 +23425,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1359,
+    "aggregatedRank": 1358,
     "countryRank": 18
   },
   {
@@ -23448,7 +23438,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1360,
+    "aggregatedRank": 1359,
     "countryRank": 4
   },
   {
@@ -23461,7 +23451,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1361,
+    "aggregatedRank": 1360,
     "countryRank": 4
   },
   {
@@ -23474,7 +23464,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1362,
+    "aggregatedRank": 1361,
     "countryRank": 9
   },
   {
@@ -23487,7 +23477,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1363,
+    "aggregatedRank": 1362,
     "countryRank": 9
   },
   {
@@ -23500,7 +23490,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1364,
+    "aggregatedRank": 1363,
     "countryRank": 1
   },
   {
@@ -23513,7 +23503,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1365,
+    "aggregatedRank": 1364,
     "countryRank": 2
   },
   {
@@ -23526,7 +23516,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1366,
+    "aggregatedRank": 1365,
     "countryRank": 24
   },
   {
@@ -23539,7 +23529,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1367,
+    "aggregatedRank": 1366,
     "countryRank": 8
   },
   {
@@ -23552,7 +23542,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1368,
+    "aggregatedRank": 1367,
     "countryRank": 1
   },
   {
@@ -23565,7 +23555,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1369,
+    "aggregatedRank": 1368,
     "countryRank": 12
   },
   {
@@ -23578,7 +23568,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1370,
+    "aggregatedRank": 1369,
     "countryRank": 8
   },
   {
@@ -23591,7 +23581,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1371,
+    "aggregatedRank": 1370,
     "countryRank": 1
   },
   {
@@ -23604,7 +23594,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1372,
+    "aggregatedRank": 1371,
     "countryRank": 3
   },
   {
@@ -23617,7 +23607,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1373,
+    "aggregatedRank": 1372,
     "countryRank": 9
   },
   {
@@ -23630,7 +23620,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1374,
+    "aggregatedRank": 1373,
     "countryRank": 5
   },
   {
@@ -23643,7 +23633,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1375,
+    "aggregatedRank": 1374,
     "countryRank": 4
   },
   {
@@ -23656,7 +23646,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1376,
+    "aggregatedRank": 1375,
     "countryRank": 10
   },
   {
@@ -23669,7 +23659,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1377,
+    "aggregatedRank": 1376,
     "countryRank": 11
   },
   {
@@ -23682,7 +23672,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1378,
+    "aggregatedRank": 1377,
     "countryRank": 2
   },
   {
@@ -23695,7 +23685,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1379,
+    "aggregatedRank": 1378,
     "countryRank": 3
   },
   {
@@ -23708,7 +23698,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1380,
+    "aggregatedRank": 1379,
     "countryRank": 177
   },
   {
@@ -23721,7 +23711,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1381,
+    "aggregatedRank": 1380,
     "countryRank": 178
   },
   {
@@ -23734,7 +23724,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1382,
+    "aggregatedRank": 1381,
     "countryRank": 5
   },
   {
@@ -23747,7 +23737,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1383,
+    "aggregatedRank": 1382,
     "countryRank": 9
   },
   {
@@ -23760,7 +23750,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1384,
+    "aggregatedRank": 1383,
     "countryRank": 12
   },
   {
@@ -23773,7 +23763,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1385,
+    "aggregatedRank": 1384,
     "countryRank": 112
   },
   {
@@ -23786,7 +23776,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1386,
+    "aggregatedRank": 1385,
     "countryRank": 113
   },
   {
@@ -23799,7 +23789,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1387,
+    "aggregatedRank": 1386,
     "countryRank": 114
   },
   {
@@ -23812,7 +23802,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1388,
+    "aggregatedRank": 1387,
     "countryRank": 179
   },
   {
@@ -23825,7 +23815,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1389,
+    "aggregatedRank": 1388,
     "countryRank": 1
   },
   {
@@ -23838,7 +23828,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1390,
+    "aggregatedRank": 1389,
     "countryRank": 6
   },
   {
@@ -23851,7 +23841,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1391,
+    "aggregatedRank": 1390,
     "countryRank": 7
   },
   {
@@ -23864,7 +23854,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1392,
+    "aggregatedRank": 1391,
     "countryRank": 2
   },
   {
@@ -23877,7 +23867,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1393,
+    "aggregatedRank": 1392,
     "countryRank": 54
   },
   {
@@ -23890,7 +23880,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1394,
+    "aggregatedRank": 1393,
     "countryRank": 2
   },
   {
@@ -23903,7 +23893,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1395,
+    "aggregatedRank": 1394,
     "countryRank": 5
   },
   {
@@ -23916,7 +23906,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1396,
+    "aggregatedRank": 1395,
     "countryRank": 6
   },
   {
@@ -23929,7 +23919,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1397,
+    "aggregatedRank": 1396,
     "countryRank": 31
   },
   {
@@ -23942,7 +23932,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1398,
+    "aggregatedRank": 1397,
     "countryRank": 1
   },
   {
@@ -23955,7 +23945,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1399,
+    "aggregatedRank": 1398,
     "countryRank": 2
   },
   {
@@ -23968,7 +23958,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1400,
+    "aggregatedRank": 1399,
     "countryRank": 10
   },
   {
@@ -23981,7 +23971,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1401,
+    "aggregatedRank": 1400,
     "countryRank": 2
   },
   {
@@ -23994,7 +23984,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1402,
+    "aggregatedRank": 1401,
     "countryRank": 25
   },
   {
@@ -24007,7 +23997,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1403,
+    "aggregatedRank": 1402,
     "countryRank": 13
   },
   {
@@ -24020,7 +24010,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1404,
+    "aggregatedRank": 1403,
     "countryRank": 25
   },
   {
@@ -24033,7 +24023,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1405,
+    "aggregatedRank": 1404,
     "countryRank": 3
   },
   {
@@ -24046,7 +24036,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1406,
+    "aggregatedRank": 1405,
     "countryRank": 15
   },
   {
@@ -24059,7 +24049,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1407,
+    "aggregatedRank": 1406,
     "countryRank": 1
   },
   {
@@ -24072,7 +24062,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1408,
+    "aggregatedRank": 1407,
     "countryRank": 101
   },
   {
@@ -24085,7 +24075,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1409,
+    "aggregatedRank": 1408,
     "countryRank": 4
   },
   {
@@ -24098,7 +24088,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1410,
+    "aggregatedRank": 1409,
     "countryRank": 180
   },
   {
@@ -24111,7 +24101,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1411,
+    "aggregatedRank": 1410,
     "countryRank": 14
   },
   {
@@ -24124,7 +24114,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1412,
+    "aggregatedRank": 1411,
     "countryRank": 6
   },
   {
@@ -24137,7 +24127,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1413,
+    "aggregatedRank": 1412,
     "countryRank": 8
   },
   {
@@ -24150,7 +24140,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1414,
+    "aggregatedRank": 1413,
     "countryRank": 11
   },
   {
@@ -24163,7 +24153,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1415,
+    "aggregatedRank": 1414,
     "countryRank": 26
   },
   {
@@ -24176,7 +24166,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1416,
+    "aggregatedRank": 1415,
     "countryRank": 7
   },
   {
@@ -24189,7 +24179,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1417,
+    "aggregatedRank": 1416,
     "countryRank": 8
   },
   {
@@ -24202,7 +24192,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1418,
+    "aggregatedRank": 1417,
     "countryRank": 9
   },
   {
@@ -24215,7 +24205,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1419,
+    "aggregatedRank": 1418,
     "countryRank": 10
   },
   {
@@ -24228,7 +24218,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1420,
+    "aggregatedRank": 1419,
     "countryRank": 1
   },
   {
@@ -24241,7 +24231,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1421,
+    "aggregatedRank": 1420,
     "countryRank": 4
   },
   {
@@ -24254,7 +24244,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1422,
+    "aggregatedRank": 1421,
     "countryRank": 7
   },
   {
@@ -24267,7 +24257,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1423,
+    "aggregatedRank": 1422,
     "countryRank": 8
   },
   {
@@ -24280,7 +24270,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1424,
+    "aggregatedRank": 1423,
     "countryRank": 9
   },
   {
@@ -24293,7 +24283,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1425,
+    "aggregatedRank": 1424,
     "countryRank": 9
   },
   {
@@ -24306,7 +24296,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1426,
+    "aggregatedRank": 1425,
     "countryRank": 3
   },
   {
@@ -24319,7 +24309,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1427,
+    "aggregatedRank": 1426,
     "countryRank": 39
   },
   {
@@ -24332,7 +24322,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1428,
+    "aggregatedRank": 1427,
     "countryRank": 55
   },
   {
@@ -24345,7 +24335,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1429,
+    "aggregatedRank": 1428,
     "countryRank": 7
   },
   {
@@ -24358,7 +24348,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1430,
+    "aggregatedRank": 1429,
     "countryRank": 10
   },
   {
@@ -24371,7 +24361,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1431,
+    "aggregatedRank": 1430,
     "countryRank": 7
   },
   {
@@ -24384,7 +24374,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1432,
+    "aggregatedRank": 1431,
     "countryRank": 32
   },
   {
@@ -24397,7 +24387,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1433,
+    "aggregatedRank": 1432,
     "countryRank": 33
   },
   {
@@ -24410,7 +24400,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1434,
+    "aggregatedRank": 1433,
     "countryRank": 1
   },
   {
@@ -24423,7 +24413,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1435,
+    "aggregatedRank": 1434,
     "countryRank": 10
   },
   {
@@ -24436,7 +24426,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1436,
+    "aggregatedRank": 1435,
     "countryRank": 7
   },
   {
@@ -24449,7 +24439,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1437,
+    "aggregatedRank": 1436,
     "countryRank": 8
   },
   {
@@ -24462,7 +24452,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1438,
+    "aggregatedRank": 1437,
     "countryRank": 10
   },
   {
@@ -24475,7 +24465,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1439,
+    "aggregatedRank": 1438,
     "countryRank": 27
   },
   {
@@ -24488,7 +24478,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1440,
+    "aggregatedRank": 1439,
     "countryRank": 3
   },
   {
@@ -24501,7 +24491,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1441,
+    "aggregatedRank": 1440,
     "countryRank": 58
   },
   {
@@ -24514,7 +24504,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1442,
+    "aggregatedRank": 1441,
     "countryRank": 12
   },
   {
@@ -24527,7 +24517,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1443,
+    "aggregatedRank": 1442,
     "countryRank": 115
   },
   {
@@ -24540,7 +24530,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1444,
+    "aggregatedRank": 1443,
     "countryRank": 116
   },
   {
@@ -24553,7 +24543,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1445,
+    "aggregatedRank": 1444,
     "countryRank": 117
   },
   {
@@ -24566,7 +24556,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1446,
+    "aggregatedRank": 1445,
     "countryRank": 118
   },
   {
@@ -24579,7 +24569,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1447,
+    "aggregatedRank": 1446,
     "countryRank": 119
   },
   {
@@ -24592,7 +24582,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1448,
+    "aggregatedRank": 1447,
     "countryRank": 120
   },
   {
@@ -24605,7 +24595,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1449,
+    "aggregatedRank": 1448,
     "countryRank": 121
   },
   {
@@ -24618,7 +24608,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1450,
+    "aggregatedRank": 1449,
     "countryRank": 181
   },
   {
@@ -24631,7 +24621,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1451,
+    "aggregatedRank": 1450,
     "countryRank": 182
   },
   {
@@ -24644,7 +24634,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1452,
+    "aggregatedRank": 1451,
     "countryRank": 183
   },
   {
@@ -24657,7 +24647,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1453,
+    "aggregatedRank": 1452,
     "countryRank": 122
   },
   {
@@ -24670,7 +24660,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1454,
+    "aggregatedRank": 1453,
     "countryRank": 34
   },
   {
@@ -24683,7 +24673,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1455,
+    "aggregatedRank": 1454,
     "countryRank": 123
   },
   {
@@ -24696,7 +24686,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1456,
+    "aggregatedRank": 1455,
     "countryRank": 124
   },
   {
@@ -24709,7 +24699,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1457,
+    "aggregatedRank": 1456,
     "countryRank": 125
   },
   {
@@ -24722,7 +24712,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1458,
+    "aggregatedRank": 1457,
     "countryRank": 126
   },
   {
@@ -24735,7 +24725,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1459,
+    "aggregatedRank": 1458,
     "countryRank": 127
   },
   {
@@ -24748,7 +24738,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1460,
+    "aggregatedRank": 1459,
     "countryRank": 128
   },
   {
@@ -24761,7 +24751,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1461,
+    "aggregatedRank": 1460,
     "countryRank": 129
   },
   {
@@ -24774,7 +24764,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1462,
+    "aggregatedRank": 1461,
     "countryRank": 130
   },
   {
@@ -24787,7 +24777,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1463,
+    "aggregatedRank": 1462,
     "countryRank": 131
   },
   {
@@ -24800,7 +24790,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1464,
+    "aggregatedRank": 1463,
     "countryRank": 40
   },
   {
@@ -24813,7 +24803,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1465,
+    "aggregatedRank": 1464,
     "countryRank": 7
   },
   {
@@ -24826,7 +24816,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1466,
+    "aggregatedRank": 1465,
     "countryRank": 184
   },
   {
@@ -24839,7 +24829,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1467,
+    "aggregatedRank": 1466,
     "countryRank": 185
   },
   {
@@ -24852,7 +24842,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1468,
+    "aggregatedRank": 1467,
     "countryRank": 186
   },
   {
@@ -24865,7 +24855,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1469,
+    "aggregatedRank": 1468,
     "countryRank": 187
   },
   {
@@ -24878,7 +24868,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1470,
+    "aggregatedRank": 1469,
     "countryRank": 132
   },
   {
@@ -24891,7 +24881,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1471,
+    "aggregatedRank": 1470,
     "countryRank": 133
   },
   {
@@ -24904,7 +24894,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1472,
+    "aggregatedRank": 1471,
     "countryRank": 134
   },
   {
@@ -24917,7 +24907,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1473,
+    "aggregatedRank": 1472,
     "countryRank": 135
   },
   {
@@ -24930,7 +24920,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1474,
+    "aggregatedRank": 1473,
     "countryRank": 136
   },
   {
@@ -24943,7 +24933,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1475,
+    "aggregatedRank": 1474,
     "countryRank": 137
   },
   {
@@ -24956,7 +24946,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1476,
+    "aggregatedRank": 1475,
     "countryRank": 138
   },
   {
@@ -24969,7 +24959,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1477,
+    "aggregatedRank": 1476,
     "countryRank": 139
   },
   {
@@ -24982,7 +24972,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1478,
+    "aggregatedRank": 1477,
     "countryRank": 140
   },
   {
@@ -24995,7 +24985,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1479,
+    "aggregatedRank": 1478,
     "countryRank": 141
   },
   {
@@ -25008,7 +24998,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1480,
+    "aggregatedRank": 1479,
     "countryRank": 142
   },
   {
@@ -25021,7 +25011,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1481,
+    "aggregatedRank": 1480,
     "countryRank": 143
   },
   {
@@ -25034,7 +25024,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1482,
+    "aggregatedRank": 1481,
     "countryRank": 144
   },
   {
@@ -25047,7 +25037,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1483,
+    "aggregatedRank": 1482,
     "countryRank": 73
   },
   {
@@ -25060,7 +25050,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1484,
+    "aggregatedRank": 1483,
     "countryRank": 74
   },
   {
@@ -25073,7 +25063,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1485,
+    "aggregatedRank": 1484,
     "countryRank": 37
   },
   {
@@ -25086,7 +25076,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1486,
+    "aggregatedRank": 1485,
     "countryRank": 35
   },
   {
@@ -25099,7 +25089,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1487,
+    "aggregatedRank": 1486,
     "countryRank": 188
   },
   {
@@ -25112,7 +25102,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1488,
+    "aggregatedRank": 1487,
     "countryRank": 189
   },
   {
@@ -25125,7 +25115,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1489,
+    "aggregatedRank": 1488,
     "countryRank": 190
   },
   {
@@ -25138,7 +25128,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1490,
+    "aggregatedRank": 1489,
     "countryRank": 191
   },
   {
@@ -25151,7 +25141,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1491,
+    "aggregatedRank": 1490,
     "countryRank": 192
   },
   {
@@ -25164,7 +25154,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1492,
+    "aggregatedRank": 1491,
     "countryRank": 193
   },
   {
@@ -25177,7 +25167,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1493,
+    "aggregatedRank": 1492,
     "countryRank": 14
   },
   {
@@ -25190,7 +25180,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1494,
+    "aggregatedRank": 1493,
     "countryRank": 145
   },
   {
@@ -25203,7 +25193,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1495,
+    "aggregatedRank": 1494,
     "countryRank": 146
   },
   {
@@ -25216,7 +25206,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1496,
+    "aggregatedRank": 1495,
     "countryRank": 147
   },
   {
@@ -25229,7 +25219,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1497,
+    "aggregatedRank": 1496,
     "countryRank": 5
   },
   {
@@ -25242,7 +25232,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1498,
+    "aggregatedRank": 1497,
     "countryRank": 148
   },
   {
@@ -25255,7 +25245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1499,
+    "aggregatedRank": 1498,
     "countryRank": 149
   },
   {
@@ -25268,7 +25258,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1500,
+    "aggregatedRank": 1499,
     "countryRank": 150
   },
   {
@@ -25281,7 +25271,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1501,
+    "aggregatedRank": 1500,
     "countryRank": 16
   },
   {
@@ -25294,7 +25284,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1502,
+    "aggregatedRank": 1501,
     "countryRank": 16
   },
   {
@@ -25307,7 +25297,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1503,
+    "aggregatedRank": 1502,
     "countryRank": 17
   },
   {
@@ -25320,7 +25310,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1504,
+    "aggregatedRank": 1503,
     "countryRank": 151
   },
   {
@@ -25333,7 +25323,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1505,
+    "aggregatedRank": 1504,
     "countryRank": 152
   },
   {
@@ -25346,7 +25336,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1506,
+    "aggregatedRank": 1505,
     "countryRank": 153
   },
   {
@@ -25359,7 +25349,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1507,
+    "aggregatedRank": 1506,
     "countryRank": 154
   },
   {
@@ -25372,7 +25362,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1508,
+    "aggregatedRank": 1507,
     "countryRank": 155
   },
   {
@@ -25385,7 +25375,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1509,
+    "aggregatedRank": 1508,
     "countryRank": 156
   },
   {
@@ -25398,7 +25388,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1510,
+    "aggregatedRank": 1509,
     "countryRank": 157
   },
   {
@@ -25411,7 +25401,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1511,
+    "aggregatedRank": 1510,
     "countryRank": 75
   },
   {
@@ -25424,7 +25414,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1512,
+    "aggregatedRank": 1511,
     "countryRank": 76
   },
   {
@@ -25437,7 +25427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1513,
+    "aggregatedRank": 1512,
     "countryRank": 77
   },
   {
@@ -25450,7 +25440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1514,
+    "aggregatedRank": 1513,
     "countryRank": 7
   },
   {
@@ -25463,7 +25453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1515,
+    "aggregatedRank": 1514,
     "countryRank": 41
   },
   {
@@ -25476,7 +25466,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1516,
+    "aggregatedRank": 1515,
     "countryRank": 42
   },
   {
@@ -25489,7 +25479,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1517,
+    "aggregatedRank": 1516,
     "countryRank": 36
   },
   {
@@ -25502,7 +25492,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1518,
+    "aggregatedRank": 1517,
     "countryRank": 37
   },
   {
@@ -25515,7 +25505,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1519,
+    "aggregatedRank": 1518,
     "countryRank": 33
   },
   {
@@ -25528,7 +25518,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1520,
+    "aggregatedRank": 1519,
     "countryRank": 14
   },
   {
@@ -25541,7 +25531,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1521,
+    "aggregatedRank": 1520,
     "countryRank": 194
   },
   {
@@ -25554,7 +25544,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1522,
+    "aggregatedRank": 1521,
     "countryRank": 195
   },
   {
@@ -25567,7 +25557,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1523,
+    "aggregatedRank": 1522,
     "countryRank": 196
   },
   {
@@ -25580,7 +25570,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1524,
+    "aggregatedRank": 1523,
     "countryRank": 197
   },
   {
@@ -25593,7 +25583,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1525,
+    "aggregatedRank": 1524,
     "countryRank": 56
   },
   {
@@ -25606,7 +25596,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1526,
+    "aggregatedRank": 1525,
     "countryRank": 158
   },
   {
@@ -25619,7 +25609,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1527,
+    "aggregatedRank": 1526,
     "countryRank": 159
   },
   {
@@ -25632,7 +25622,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1528,
+    "aggregatedRank": 1527,
     "countryRank": 160
   },
   {
@@ -25645,7 +25635,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1529,
+    "aggregatedRank": 1528,
     "countryRank": 161
   },
   {
@@ -25658,7 +25648,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1530,
+    "aggregatedRank": 1529,
     "countryRank": 162
   },
   {
@@ -25671,7 +25661,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1531,
+    "aggregatedRank": 1530,
     "countryRank": 59
   },
   {
@@ -25684,7 +25674,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1532,
+    "aggregatedRank": 1531,
     "countryRank": 163
   },
   {
@@ -25697,7 +25687,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1533,
+    "aggregatedRank": 1532,
     "countryRank": 18
   },
   {
@@ -25710,7 +25700,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1534,
+    "aggregatedRank": 1533,
     "countryRank": 19
   },
   {
@@ -25723,7 +25713,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1535,
+    "aggregatedRank": 1534,
     "countryRank": 33
   },
   {
@@ -25736,7 +25726,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1536,
+    "aggregatedRank": 1535,
     "countryRank": 164
   },
   {
@@ -25749,7 +25739,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1537,
+    "aggregatedRank": 1536,
     "countryRank": 165
   },
   {
@@ -25762,7 +25752,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1538,
+    "aggregatedRank": 1537,
     "countryRank": 166
   },
   {
@@ -25775,7 +25765,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1539,
+    "aggregatedRank": 1538,
     "countryRank": 167
   },
   {
@@ -25788,7 +25778,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1540,
+    "aggregatedRank": 1539,
     "countryRank": 168
   },
   {
@@ -25801,7 +25791,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1541,
+    "aggregatedRank": 1540,
     "countryRank": 169
   },
   {
@@ -25814,7 +25804,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1542,
+    "aggregatedRank": 1541,
     "countryRank": 170
   },
   {
@@ -25827,7 +25817,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1543,
+    "aggregatedRank": 1542,
     "countryRank": 171
   },
   {
@@ -25840,7 +25830,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1544,
+    "aggregatedRank": 1543,
     "countryRank": 172
   },
   {
@@ -25853,7 +25843,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1545,
+    "aggregatedRank": 1544,
     "countryRank": 173
   },
   {
@@ -25866,7 +25856,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1546,
+    "aggregatedRank": 1545,
     "countryRank": 174
   },
   {
@@ -25879,7 +25869,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1547,
+    "aggregatedRank": 1546,
     "countryRank": 175
   },
   {
@@ -25892,7 +25882,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1548,
+    "aggregatedRank": 1547,
     "countryRank": 78
   },
   {
@@ -25905,7 +25895,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1549,
+    "aggregatedRank": 1548,
     "countryRank": 43
   },
   {
@@ -25918,7 +25908,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1550,
+    "aggregatedRank": 1549,
     "countryRank": 57
   },
   {
@@ -25931,7 +25921,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1551,
+    "aggregatedRank": 1550,
     "countryRank": 8
   },
   {
@@ -25944,7 +25934,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1552,
+    "aggregatedRank": 1551,
     "countryRank": 9
   },
   {
@@ -25957,7 +25947,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1553,
+    "aggregatedRank": 1552,
     "countryRank": 38
   },
   {
@@ -25970,7 +25960,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1554,
+    "aggregatedRank": 1553,
     "countryRank": 34
   },
   {
@@ -25983,7 +25973,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1555,
+    "aggregatedRank": 1554,
     "countryRank": 102
   },
   {
@@ -25996,7 +25986,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1556,
+    "aggregatedRank": 1555,
     "countryRank": 198
   },
   {
@@ -26009,7 +25999,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1557,
+    "aggregatedRank": 1556,
     "countryRank": 199
   },
   {
@@ -26022,7 +26012,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1558,
+    "aggregatedRank": 1557,
     "countryRank": 176
   },
   {
@@ -26035,7 +26025,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1559,
+    "aggregatedRank": 1558,
     "countryRank": 177
   },
   {
@@ -26048,7 +26038,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1560,
+    "aggregatedRank": 1559,
     "countryRank": 178
   },
   {
@@ -26061,7 +26051,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1561,
+    "aggregatedRank": 1560,
     "countryRank": 179
   },
   {
@@ -26074,7 +26064,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1562,
+    "aggregatedRank": 1561,
     "countryRank": 180
   },
   {
@@ -26087,7 +26077,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1563,
+    "aggregatedRank": 1562,
     "countryRank": 181
   },
   {
@@ -26100,7 +26090,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1564,
+    "aggregatedRank": 1563,
     "countryRank": 182
   },
   {
@@ -26113,7 +26103,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1565,
+    "aggregatedRank": 1564,
     "countryRank": 28
   },
   {
@@ -26126,7 +26116,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1566,
+    "aggregatedRank": 1565,
     "countryRank": 17
   },
   {
@@ -26139,7 +26129,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1567,
+    "aggregatedRank": 1566,
     "countryRank": 200
   },
   {
@@ -26152,7 +26142,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1568,
+    "aggregatedRank": 1567,
     "countryRank": 201
   },
   {
@@ -26165,7 +26155,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1569,
+    "aggregatedRank": 1568,
     "countryRank": 20
   },
   {
@@ -26178,7 +26168,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1570,
+    "aggregatedRank": 1569,
     "countryRank": 21
   },
   {
@@ -26191,7 +26181,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1571,
+    "aggregatedRank": 1570,
     "countryRank": 22
   },
   {
@@ -26204,7 +26194,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1572,
+    "aggregatedRank": 1571,
     "countryRank": 23
   },
   {
@@ -26217,7 +26207,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1573,
+    "aggregatedRank": 1572,
     "countryRank": 24
   },
   {
@@ -26230,7 +26220,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1574,
+    "aggregatedRank": 1573,
     "countryRank": 34
   },
   {
@@ -26243,7 +26233,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1575,
+    "aggregatedRank": 1574,
     "countryRank": 9
   },
   {
@@ -26256,7 +26246,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1576,
+    "aggregatedRank": 1575,
     "countryRank": 183
   },
   {
@@ -26269,7 +26259,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1577,
+    "aggregatedRank": 1576,
     "countryRank": 184
   },
   {
@@ -26282,7 +26272,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1578,
+    "aggregatedRank": 1577,
     "countryRank": 185
   },
   {
@@ -26295,7 +26285,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1579,
+    "aggregatedRank": 1578,
     "countryRank": 186
   },
   {
@@ -26308,7 +26298,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1580,
+    "aggregatedRank": 1579,
     "countryRank": 187
   },
   {
@@ -26321,7 +26311,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1581,
+    "aggregatedRank": 1580,
     "countryRank": 188
   },
   {
@@ -26334,7 +26324,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1582,
+    "aggregatedRank": 1581,
     "countryRank": 189
   },
   {
@@ -26347,7 +26337,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1583,
+    "aggregatedRank": 1582,
     "countryRank": 190
   },
   {
@@ -26360,7 +26350,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1584,
+    "aggregatedRank": 1583,
     "countryRank": 191
   },
   {
@@ -26373,7 +26363,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1585,
+    "aggregatedRank": 1584,
     "countryRank": 192
   },
   {
@@ -26386,7 +26376,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1586,
+    "aggregatedRank": 1585,
     "countryRank": 11
   },
   {
@@ -26399,7 +26389,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1587,
+    "aggregatedRank": 1586,
     "countryRank": 12
   },
   {
@@ -26412,7 +26402,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1588,
+    "aggregatedRank": 1587,
     "countryRank": 44
   },
   {
@@ -26425,7 +26415,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1589,
+    "aggregatedRank": 1588,
     "countryRank": 58
   },
   {
@@ -26438,7 +26428,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1590,
+    "aggregatedRank": 1589,
     "countryRank": 39
   },
   {
@@ -26451,7 +26441,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1591,
+    "aggregatedRank": 1590,
     "countryRank": 35
   },
   {
@@ -26464,7 +26454,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1592,
+    "aggregatedRank": 1591,
     "countryRank": 18
   },
   {
@@ -26477,7 +26467,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1593,
+    "aggregatedRank": 1592,
     "countryRank": 19
   },
   {
@@ -26490,7 +26480,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1594,
+    "aggregatedRank": 1593,
     "countryRank": 202
   },
   {
@@ -26503,7 +26493,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1595,
+    "aggregatedRank": 1594,
     "countryRank": 203
   },
   {
@@ -26516,7 +26506,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1596,
+    "aggregatedRank": 1595,
     "countryRank": 204
   },
   {
@@ -26529,7 +26519,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1597,
+    "aggregatedRank": 1596,
     "countryRank": 205
   },
   {
@@ -26542,7 +26532,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1598,
+    "aggregatedRank": 1597,
     "countryRank": 193
   },
   {
@@ -26555,7 +26545,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1599,
+    "aggregatedRank": 1598,
     "countryRank": 2
   },
   {
@@ -26568,7 +26558,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1600,
+    "aggregatedRank": 1599,
     "countryRank": 206
   },
   {
@@ -26581,7 +26571,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1601,
+    "aggregatedRank": 1600,
     "countryRank": 194
   },
   {
@@ -26594,7 +26584,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1602,
+    "aggregatedRank": 1601,
     "countryRank": 15
   },
   {
@@ -26607,7 +26597,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1603,
+    "aggregatedRank": 1602,
     "countryRank": 195
   },
   {
@@ -26620,7 +26610,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1604,
+    "aggregatedRank": 1603,
     "countryRank": 196
   },
   {
@@ -26633,7 +26623,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1605,
+    "aggregatedRank": 1604,
     "countryRank": 197
   },
   {
@@ -26646,7 +26636,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1606,
+    "aggregatedRank": 1605,
     "countryRank": 8
   },
   {
@@ -26659,7 +26649,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1607,
+    "aggregatedRank": 1606,
     "countryRank": 198
   },
   {
@@ -26672,7 +26662,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1608,
+    "aggregatedRank": 1607,
     "countryRank": 199
   },
   {
@@ -26685,7 +26675,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1609,
+    "aggregatedRank": 1608,
     "countryRank": 200
   },
   {
@@ -26698,7 +26688,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1610,
+    "aggregatedRank": 1609,
     "countryRank": 201
   },
   {
@@ -26711,7 +26701,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1611,
+    "aggregatedRank": 1610,
     "countryRank": 2
   }
 ]

--- a/scripts/scrape-rankings.js
+++ b/scripts/scrape-rankings.js
@@ -56,7 +56,11 @@ const aliasMap = new Map([
     ['university of michigan ann arbor', 'University of Michigan'],
     ['university of michigan - ann arbor', 'University of Michigan'],
     ['newcastle university newcastle upon tyne', 'Newcastle University'],
-    ['swiss federal institute of technology zurich', 'ETH Zurich']
+    ['swiss federal institute of technology zurich', 'ETH Zurich'],
+    // Resolve discrepancies around Washington University in St. Louis
+    ['washington university in st louis', 'Washington University (WUSTL)'],
+    ['washington university st louis', 'Washington University (WUSTL)'],
+    ['washington university', 'Washington University (WUSTL)']
 ]);
 
 function canonicalizeName(name) {


### PR DESCRIPTION
## Summary
- extend alias map in `scrape-rankings.js` so that "Washington University in St. Louis" from other datasets maps to the USNews form "Washington University (WUSTL)"
- regenerate aggregated rankings to reflect the merge

## Testing
- `npm install`
- `node scripts/scrape-rankings.js 50`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684386d1bfc88320bb8bd047d5c629f5