### PR TITLE
Improve manual name mapping

### DIFF
--- a/frontend/public/data/aggregated-rankings.json
+++ b/frontend/public/data/aggregated-rankings.json
@@ -110,6 +110,28 @@
     "countryRank": 2
   },
   {
+    "name": "University of California Berkeley",
+    "country": "United States",
+    "aggregatedScore": 1704.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 12
+      },
+      "the": {
+        "rank": 8
+      },
+      "arwu": {
+        "rank": 5
+      },
+      "usnews": {
+        "rank": 5
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 6,
+    "countryRank": 4
+  },
+  {
     "name": "Imperial College London",
     "country": "United Kingdom",
     "aggregatedScore": 1700.25,
@@ -128,7 +150,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 6,
+    "aggregatedRank": 7,
     "countryRank": 3
   },
   {
@@ -150,8 +172,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 7,
-    "countryRank": 4
+    "aggregatedRank": 8,
+    "countryRank": 5
   },
   {
     "name": "Princeton University",
@@ -172,8 +194,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 8,
-    "countryRank": 5
+    "aggregatedRank": 9,
+    "countryRank": 6
   },
   {
     "name": "University of Pennsylvania",
@@ -194,8 +216,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 9,
-    "countryRank": 6
+    "aggregatedRank": 10,
+    "countryRank": 7
   },
   {
     "name": "University College London",
@@ -216,7 +238,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 10,
+    "aggregatedRank": 11,
     "countryRank": 4
   },
   {
@@ -238,8 +260,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 11,
-    "countryRank": 7
+    "aggregatedRank": 12,
+    "countryRank": 8
   },
   {
     "name": "Cornell University",
@@ -260,8 +282,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 12,
-    "countryRank": 8
+    "aggregatedRank": 13,
+    "countryRank": 9
   },
   {
     "name": "Columbia University",
@@ -282,8 +304,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 13,
-    "countryRank": 9
+    "aggregatedRank": 14,
+    "countryRank": 10
   },
   {
     "name": "Tsinghua University",
@@ -304,7 +326,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 14,
+    "aggregatedRank": 15,
     "countryRank": 1
   },
   {
@@ -326,8 +348,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 15,
-    "countryRank": 10
+    "aggregatedRank": 16,
+    "countryRank": 11
   },
   {
     "name": "ETH Zurich",
@@ -348,7 +370,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 16,
+    "aggregatedRank": 17,
     "countryRank": 1
   },
   {
@@ -370,8 +392,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 17,
-    "countryRank": 11
+    "aggregatedRank": 18,
+    "countryRank": 12
   },
   {
     "name": "Peking University",
@@ -392,7 +414,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 18,
+    "aggregatedRank": 19,
     "countryRank": 2
   },
   {
@@ -414,8 +436,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 19,
-    "countryRank": 12
+    "aggregatedRank": 20,
+    "countryRank": 13
   },
   {
     "name": "University of Toronto",
@@ -436,7 +458,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 20,
+    "aggregatedRank": 21,
     "countryRank": 1
   },
   {
@@ -458,7 +480,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 21,
+    "aggregatedRank": 22,
     "countryRank": 1
   },
   {
@@ -480,8 +502,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 22,
-    "countryRank": 13
+    "aggregatedRank": 23,
+    "countryRank": 14
   },
   {
     "name": "University of Melbourne",
@@ -502,7 +524,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 23,
+    "aggregatedRank": 24,
     "countryRank": 1
   },
   {
@@ -524,8 +546,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 24,
-    "countryRank": 14
+    "aggregatedRank": 25,
+    "countryRank": 15
   },
   {
     "name": "University of Edinburgh",
@@ -546,7 +568,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 25,
+    "aggregatedRank": 26,
     "countryRank": 5
   },
   {
@@ -568,8 +590,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 26,
-    "countryRank": 15
+    "aggregatedRank": 27,
+    "countryRank": 16
   },
   {
     "name": "New York University",
@@ -590,8 +612,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 27,
-    "countryRank": 16
+    "aggregatedRank": 28,
+    "countryRank": 17
   },
   {
     "name": "University of California San Diego",
@@ -612,8 +634,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 28,
-    "countryRank": 17
+    "aggregatedRank": 29,
+    "countryRank": 18
   },
   {
     "name": "Duke University",
@@ -634,8 +656,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 29,
-    "countryRank": 18
+    "aggregatedRank": 30,
+    "countryRank": 19
   },
   {
     "name": "Nanyang Technological University",
@@ -656,7 +678,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 30,
+    "aggregatedRank": 31,
     "countryRank": 2
   },
   {
@@ -678,7 +700,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 31,
+    "aggregatedRank": 32,
     "countryRank": 1
   },
   {
@@ -700,7 +722,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 32,
+    "aggregatedRank": 33,
     "countryRank": 2
   },
   {
@@ -722,8 +744,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 33,
+    "aggregatedRank": 34,
     "countryRank": 6
+  },
+  {
+    "name": "University of Tokyo",
+    "country": "Japan",
+    "aggregatedScore": 1669.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 32
+      },
+      "the": {
+        "rank": 28
+      },
+      "arwu": {
+        "rank": 28
+      },
+      "usnews": {
+        "rank": 84
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 35,
+    "countryRank": 1
   },
   {
     "name": "Zhejiang University",
@@ -744,7 +788,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 34,
+    "aggregatedRank": 36,
     "countryRank": 3
   },
   {
@@ -766,7 +810,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 35,
+    "aggregatedRank": 37,
     "countryRank": 2
   },
   {
@@ -788,7 +832,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 36,
+    "aggregatedRank": 38,
     "countryRank": 1
   },
   {
@@ -810,7 +854,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 37,
+    "aggregatedRank": 39,
     "countryRank": 4
   },
   {
@@ -832,7 +876,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 38,
+    "aggregatedRank": 40,
     "countryRank": 2
   },
   {
@@ -854,7 +898,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 39,
+    "aggregatedRank": 41,
     "countryRank": 3
   },
   {
@@ -876,7 +920,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 40,
+    "aggregatedRank": 42,
     "countryRank": 7
   },
   {
@@ -898,8 +942,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 41,
+    "aggregatedRank": 43,
     "countryRank": 5
+  },
+  {
+    "name": "Universite PSL",
+    "country": "France",
+    "aggregatedScore": 1659.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 24
+      },
+      "the": {
+        "rank": 42
+      },
+      "arwu": {
+        "rank": 33
+      },
+      "usnews": {
+        "rank": 112
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 44,
+    "countryRank": 1
   },
   {
     "name": "Monash University",
@@ -920,7 +986,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 42,
+    "aggregatedRank": 45,
     "countryRank": 3
   },
   {
@@ -942,8 +1008,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 43,
+    "aggregatedRank": 46,
     "countryRank": 4
+  },
+  {
+    "name": "University of Texas Austin",
+    "country": "United States",
+    "aggregatedScore": 1658,
+    "originalRankings": {
+      "qs": {
+        "rank": 66
+      },
+      "the": {
+        "rank": 50
+      },
+      "arwu": {
+        "rank": 45
+      },
+      "usnews": {
+        "rank": 56
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 47,
+    "countryRank": 20
   },
   {
     "name": "University of Queensland",
@@ -964,8 +1052,52 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 44,
+    "aggregatedRank": 48,
     "countryRank": 5
+  },
+  {
+    "name": "Chinese University of Hong Kong",
+    "country": "Hong Kong",
+    "aggregatedScore": 1656.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 36
+      },
+      "the": {
+        "rank": 44
+      },
+      "arwu": {
+        "rank": 101
+      },
+      "usnews": {
+        "rank": 42
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 49,
+    "countryRank": 2
+  },
+  {
+    "name": "KU Leuven",
+    "country": "Belgium",
+    "aggregatedScore": 1654.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 63
+      },
+      "the": {
+        "rank": 43
+      },
+      "arwu": {
+        "rank": 78
+      },
+      "usnews": {
+        "rank": 48
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 50,
+    "countryRank": 1
   },
   {
     "name": "Sorbonne Universite",
@@ -986,8 +1118,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 45,
-    "countryRank": 1
+    "aggregatedRank": 51,
+    "countryRank": 2
+  },
+  {
+    "name": "Ruprecht Karls University Heidelberg",
+    "country": "Germany",
+    "aggregatedScore": 1653.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 84
+      },
+      "the": {
+        "rank": 47
+      },
+      "arwu": {
+        "rank": 50
+      },
+      "usnews": {
+        "rank": 55
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 52,
+    "countryRank": 3
   },
   {
     "name": "University of Amsterdam",
@@ -1008,8 +1162,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 46,
+    "aggregatedRank": 53,
     "countryRank": 1
+  },
+  {
+    "name": "University of Illinois Urbana-Champaign",
+    "country": "United States",
+    "aggregatedScore": 1644.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 69
+      },
+      "the": {
+        "rank": 46
+      },
+      "arwu": {
+        "rank": 55
+      },
+      "usnews": {
+        "rank": 100
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 54,
+    "countryRank": 21
   },
   {
     "name": "University of Copenhagen",
@@ -1030,8 +1206,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 47,
+    "aggregatedRank": 55,
     "countryRank": 1
+  },
+  {
+    "name": "University of Wisconsin Madison",
+    "country": "United States",
+    "aggregatedScore": 1641.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 116
+      },
+      "the": {
+        "rank": 56
+      },
+      "arwu": {
+        "rank": 36
+      },
+      "usnews": {
+        "rank": 74
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 56,
+    "countryRank": 22
   },
   {
     "name": "Australian National University",
@@ -1052,7 +1250,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 48,
+    "aggregatedRank": 57,
     "countryRank": 6
   },
   {
@@ -1074,8 +1272,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 49,
-    "countryRank": 19
+    "aggregatedRank": 58,
+    "countryRank": 23
   },
   {
     "name": "University of North Carolina Chapel Hill",
@@ -1096,8 +1294,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 50,
-    "countryRank": 20
+    "aggregatedRank": 59,
+    "countryRank": 24
   },
   {
     "name": "Seoul National University (SNU)",
@@ -1118,7 +1316,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 51,
+    "aggregatedRank": 60,
     "countryRank": 1
   },
   {
@@ -1140,8 +1338,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 52,
-    "countryRank": 21
+    "aggregatedRank": 61,
+    "countryRank": 25
   },
   {
     "name": "Kyoto University",
@@ -1162,8 +1360,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 53,
-    "countryRank": 1
+    "aggregatedRank": 62,
+    "countryRank": 2
   },
   {
     "name": "City University of Hong Kong",
@@ -1184,8 +1382,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 54,
-    "countryRank": 2
+    "aggregatedRank": 63,
+    "countryRank": 3
   },
   {
     "name": "University of Bristol",
@@ -1206,7 +1404,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 55,
+    "aggregatedRank": 64,
     "countryRank": 8
   },
   {
@@ -1228,7 +1426,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 56,
+    "aggregatedRank": 65,
     "countryRank": 9
   },
   {
@@ -1250,8 +1448,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 57,
-    "countryRank": 22
+    "aggregatedRank": 66,
+    "countryRank": 26
   },
   {
     "name": "Boston University",
@@ -1272,8 +1470,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 58,
-    "countryRank": 23
+    "aggregatedRank": 67,
+    "countryRank": 27
   },
   {
     "name": "Hong Kong Polytechnic University",
@@ -1294,8 +1492,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 59,
-    "countryRank": 3
+    "aggregatedRank": 68,
+    "countryRank": 4
   },
   {
     "name": "Georgia Institute of Technology",
@@ -1316,8 +1514,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 60,
-    "countryRank": 24
+    "aggregatedRank": 69,
+    "countryRank": 28
   },
   {
     "name": "University of Groningen",
@@ -1338,7 +1536,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 61,
+    "aggregatedRank": 70,
     "countryRank": 2
   },
   {
@@ -1360,8 +1558,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 62,
-    "countryRank": 25
+    "aggregatedRank": 71,
+    "countryRank": 29
   },
   {
     "name": "Nanjing University",
@@ -1382,7 +1580,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 63,
+    "aggregatedRank": 72,
     "countryRank": 6
   },
   {
@@ -1404,8 +1602,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 64,
-    "countryRank": 26
+    "aggregatedRank": 73,
+    "countryRank": 30
   },
   {
     "name": "Lund University",
@@ -1426,7 +1624,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 65,
+    "aggregatedRank": 74,
     "countryRank": 1
   },
   {
@@ -1448,8 +1646,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 66,
-    "countryRank": 27
+    "aggregatedRank": 75,
+    "countryRank": 31
   },
   {
     "name": "University of Minnesota Twin Cities",
@@ -1470,8 +1668,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 67,
-    "countryRank": 28
+    "aggregatedRank": 76,
+    "countryRank": 32
   },
   {
     "name": "University of Oslo",
@@ -1492,7 +1690,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 68,
+    "aggregatedRank": 77,
     "countryRank": 1
   },
   {
@@ -1514,7 +1712,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 69,
+    "aggregatedRank": 78,
     "countryRank": 7
   },
   {
@@ -1536,8 +1734,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 70,
+    "aggregatedRank": 79,
     "countryRank": 10
+  },
+  {
+    "name": "Hong Kong University of Science & Technology",
+    "country": "Hong Kong",
+    "aggregatedScore": 1607.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 47
+      },
+      "the": {
+        "rank": 66
+      },
+      "arwu": {
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 105
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 80,
+    "countryRank": 5
   },
   {
     "name": "Purdue University West Lafayette Campus",
@@ -1558,8 +1778,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 71,
-    "countryRank": 29
+    "aggregatedRank": 81,
+    "countryRank": 33
   },
   {
     "name": "University of Helsinki",
@@ -1580,7 +1800,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 72,
+    "aggregatedRank": 82,
     "countryRank": 1
   },
   {
@@ -1602,7 +1822,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 73,
+    "aggregatedRank": 83,
     "countryRank": 3
   },
   {
@@ -1624,7 +1844,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 74,
+    "aggregatedRank": 84,
     "countryRank": 4
   },
   {
@@ -1646,7 +1866,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 75,
+    "aggregatedRank": 85,
     "countryRank": 11
   },
   {
@@ -1668,7 +1888,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 76,
+    "aggregatedRank": 86,
     "countryRank": 2
   },
   {
@@ -1690,7 +1910,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 77,
+    "aggregatedRank": 87,
     "countryRank": 8
   },
   {
@@ -1712,8 +1932,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 78,
-    "countryRank": 30
+    "aggregatedRank": 88,
+    "countryRank": 34
   },
   {
     "name": "University of Maryland College Park",
@@ -1734,8 +1954,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 79,
-    "countryRank": 31
+    "aggregatedRank": 89,
+    "countryRank": 35
   },
   {
     "name": "University of Alberta",
@@ -1756,7 +1976,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 80,
+    "aggregatedRank": 90,
     "countryRank": 4
   },
   {
@@ -1778,8 +1998,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 81,
-    "countryRank": 32
+    "aggregatedRank": 91,
+    "countryRank": 36
   },
   {
     "name": "Vanderbilt University",
@@ -1800,8 +2020,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 82,
-    "countryRank": 33
+    "aggregatedRank": 92,
+    "countryRank": 37
   },
   {
     "name": "University of Southampton",
@@ -1822,7 +2042,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 83,
+    "aggregatedRank": 93,
     "countryRank": 12
   },
   {
@@ -1844,7 +2064,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 84,
+    "aggregatedRank": 94,
     "countryRank": 2
   },
   {
@@ -1866,7 +2086,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 85,
+    "aggregatedRank": 95,
     "countryRank": 2
   },
   {
@@ -1888,8 +2108,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 86,
+    "aggregatedRank": 96,
     "countryRank": 13
+  },
+  {
+    "name": "London School Economics & Political Science",
+    "country": "United Kingdom",
+    "aggregatedScore": 1589.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 50
+      },
+      "the": {
+        "rank": 50
+      },
+      "arwu": {
+        "rank": 151
+      },
+      "usnews": {
+        "rank": 239
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 97,
+    "countryRank": 14
   },
   {
     "name": "University of Leeds",
@@ -1910,8 +2152,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 87,
-    "countryRank": 14
+    "aggregatedRank": 98,
+    "countryRank": 15
   },
   {
     "name": "University of Sheffield",
@@ -1932,8 +2174,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 88,
-    "countryRank": 15
+    "aggregatedRank": 99,
+    "countryRank": 16
+  },
+  {
+    "name": "Universidade de Sao Paulo",
+    "country": "Brazil",
+    "aggregatedScore": 1582.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 92
+      },
+      "the": {
+        "rank": 199
+      },
+      "arwu": {
+        "rank": 101
+      },
+      "usnews": {
+        "rank": 127
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 100,
+    "countryRank": 1
   },
   {
     "name": "University of Basel",
@@ -1954,7 +2218,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 89,
+    "aggregatedRank": 101,
     "countryRank": 3
   },
   {
@@ -1976,7 +2240,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 90,
+    "aggregatedRank": 102,
     "countryRank": 5
   },
   {
@@ -1998,7 +2262,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 91,
+    "aggregatedRank": 103,
     "countryRank": 7
   },
   {
@@ -2020,7 +2284,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 92,
+    "aggregatedRank": 104,
     "countryRank": 9
   },
   {
@@ -2042,8 +2306,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 93,
-    "countryRank": 3
+    "aggregatedRank": 105,
+    "countryRank": 4
   },
   {
     "name": "University of Barcelona",
@@ -2064,7 +2328,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 94,
+    "aggregatedRank": 106,
     "countryRank": 1
   },
   {
@@ -2086,8 +2350,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 95,
-    "countryRank": 34
+    "aggregatedRank": 107,
+    "countryRank": 38
   },
   {
     "name": "University of Geneva",
@@ -2108,7 +2372,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 96,
+    "aggregatedRank": 108,
     "countryRank": 4
   },
   {
@@ -2130,7 +2394,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 97,
+    "aggregatedRank": 109,
     "countryRank": 1
   },
   {
@@ -2152,8 +2416,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 98,
-    "countryRank": 35
+    "aggregatedRank": 110,
+    "countryRank": 39
   },
   {
     "name": "University of Pittsburgh",
@@ -2174,8 +2438,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 99,
-    "countryRank": 36
+    "aggregatedRank": 111,
+    "countryRank": 40
   },
   {
     "name": "University of Vienna",
@@ -2196,7 +2460,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 100,
+    "aggregatedRank": 112,
     "countryRank": 1
   },
   {
@@ -2218,8 +2482,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 101,
-    "countryRank": 16
+    "aggregatedRank": 113,
+    "countryRank": 17
   },
   {
     "name": "Yonsei University",
@@ -2240,7 +2504,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 102,
+    "aggregatedRank": 114,
     "countryRank": 2
   },
   {
@@ -2262,7 +2526,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 103,
+    "aggregatedRank": 115,
     "countryRank": 3
   },
   {
@@ -2284,8 +2548,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 104,
+    "aggregatedRank": 116,
     "countryRank": 3
+  },
+  {
+    "name": "University of California Irvine",
+    "country": "United States",
+    "aggregatedScore": 1569,
+    "originalRankings": {
+      "qs": {
+        "rank": 307
+      },
+      "the": {
+        "rank": 90
+      },
+      "arwu": {
+        "rank": 76
+      },
+      "usnews": {
+        "rank": 100
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 117,
+    "countryRank": 41
   },
   {
     "name": "Rice University",
@@ -2306,8 +2592,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 105,
-    "countryRank": 37
+    "aggregatedRank": 118,
+    "countryRank": 42
   },
   {
     "name": "RWTH Aachen University",
@@ -2328,8 +2614,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 106,
-    "countryRank": 4
+    "aggregatedRank": 119,
+    "countryRank": 5
   },
   {
     "name": "University of Bologna",
@@ -2350,7 +2636,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 107,
+    "aggregatedRank": 120,
     "countryRank": 1
   },
   {
@@ -2372,8 +2658,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 108,
-    "countryRank": 17
+    "aggregatedRank": 121,
+    "countryRank": 18
   },
   {
     "name": "Royal Institute of Technology",
@@ -2394,7 +2680,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 109,
+    "aggregatedRank": 122,
     "countryRank": 4
   },
   {
@@ -2416,30 +2702,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 110,
+    "aggregatedRank": 123,
     "countryRank": 6
-  },
-  {
-    "name": "Chinese University of Hong Kong",
-    "country": "Hong Kong",
-    "aggregatedScore": 1556.5,
-    "originalRankings": {
-      "qs": {
-        "rank": 36
-      },
-      "the": {
-        "rank": 44
-      },
-      "arwu": {
-        "rank": 501
-      },
-      "usnews": {
-        "rank": 42
-      }
-    },
-    "appearances": 4,
-    "aggregatedRank": 111,
-    "countryRank": 4
   },
   {
     "name": "Korea Advanced Institute of Science & Technology (KAIST)",
@@ -2460,7 +2724,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 112,
+    "aggregatedRank": 124,
     "countryRank": 3
   },
   {
@@ -2482,7 +2746,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 113,
+    "aggregatedRank": 125,
     "countryRank": 1
   },
   {
@@ -2504,7 +2768,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 114,
+    "aggregatedRank": 126,
     "countryRank": 5
   },
   {
@@ -2526,7 +2790,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 115,
+    "aggregatedRank": 127,
     "countryRank": 8
   },
   {
@@ -2548,7 +2812,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 116,
+    "aggregatedRank": 128,
     "countryRank": 4
   },
   {
@@ -2570,8 +2834,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 117,
-    "countryRank": 5
+    "aggregatedRank": 129,
+    "countryRank": 6
   },
   {
     "name": "Harbin Institute of Technology",
@@ -2592,7 +2856,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 118,
+    "aggregatedRank": 130,
     "countryRank": 9
   },
   {
@@ -2614,7 +2878,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 119,
+    "aggregatedRank": 131,
     "countryRank": 1
   },
   {
@@ -2636,8 +2900,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 120,
-    "countryRank": 6
+    "aggregatedRank": 132,
+    "countryRank": 7
   },
   {
     "name": "National Taiwan University",
@@ -2658,7 +2922,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 121,
+    "aggregatedRank": 133,
     "countryRank": 1
   },
   {
@@ -2680,7 +2944,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 122,
+    "aggregatedRank": 134,
     "countryRank": 1
   },
   {
@@ -2702,8 +2966,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 123,
-    "countryRank": 38
+    "aggregatedRank": 135,
+    "countryRank": 43
   },
   {
     "name": "Macquarie University",
@@ -2724,7 +2988,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 124,
+    "aggregatedRank": 136,
     "countryRank": 10
   },
   {
@@ -2746,7 +3010,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 125,
+    "aggregatedRank": 137,
     "countryRank": 10
   },
   {
@@ -2768,8 +3032,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 126,
-    "countryRank": 39
+    "aggregatedRank": 138,
+    "countryRank": 44
   },
   {
     "name": "Cardiff University",
@@ -2790,8 +3054,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 127,
-    "countryRank": 18
+    "aggregatedRank": 139,
+    "countryRank": 19
   },
   {
     "name": "Case Western Reserve University",
@@ -2812,8 +3076,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 128,
-    "countryRank": 40
+    "aggregatedRank": 140,
+    "countryRank": 45
   },
   {
     "name": "Arizona State University-Tempe",
@@ -2834,8 +3098,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 129,
-    "countryRank": 41
+    "aggregatedRank": 141,
+    "countryRank": 46
   },
   {
     "name": "Tohoku University",
@@ -2856,8 +3120,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 130,
-    "countryRank": 2
+    "aggregatedRank": 142,
+    "countryRank": 3
   },
   {
     "name": "University of Calgary",
@@ -2878,7 +3142,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 131,
+    "aggregatedRank": 143,
     "countryRank": 7
   },
   {
@@ -2900,7 +3164,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 132,
+    "aggregatedRank": 144,
     "countryRank": 5
   },
   {
@@ -2922,8 +3186,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 133,
-    "countryRank": 7
+    "aggregatedRank": 145,
+    "countryRank": 8
   },
   {
     "name": "Osaka University",
@@ -2944,8 +3208,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 134,
-    "countryRank": 3
+    "aggregatedRank": 146,
+    "countryRank": 4
   },
   {
     "name": "Tianjin University",
@@ -2966,7 +3230,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 135,
+    "aggregatedRank": 147,
     "countryRank": 11
   },
   {
@@ -2988,7 +3252,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 136,
+    "aggregatedRank": 148,
     "countryRank": 2
   },
   {
@@ -3010,7 +3274,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 137,
+    "aggregatedRank": 149,
     "countryRank": 12
   },
   {
@@ -3032,7 +3296,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 138,
+    "aggregatedRank": 150,
     "countryRank": 13
   },
   {
@@ -3054,7 +3318,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 139,
+    "aggregatedRank": 151,
     "countryRank": 2
   },
   {
@@ -3076,7 +3340,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 140,
+    "aggregatedRank": 152,
     "countryRank": 11
   },
   {
@@ -3098,8 +3362,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 141,
-    "countryRank": 8
+    "aggregatedRank": 153,
+    "countryRank": 9
   },
   {
     "name": "Beijing Institute of Technology",
@@ -3120,7 +3384,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 142,
+    "aggregatedRank": 154,
     "countryRank": 14
   },
   {
@@ -3142,8 +3406,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 143,
-    "countryRank": 42
+    "aggregatedRank": 155,
+    "countryRank": 47
   },
   {
     "name": "Tel Aviv University",
@@ -3164,7 +3428,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 144,
+    "aggregatedRank": 156,
     "countryRank": 1
   },
   {
@@ -3186,7 +3450,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 145,
+    "aggregatedRank": 157,
     "countryRank": 12
   },
   {
@@ -3208,8 +3472,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 146,
-    "countryRank": 1
+    "aggregatedRank": 158,
+    "countryRank": 2
   },
   {
     "name": "University of Ottawa",
@@ -3230,7 +3494,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 147,
+    "aggregatedRank": 159,
     "countryRank": 8
   },
   {
@@ -3252,7 +3516,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 148,
+    "aggregatedRank": 160,
     "countryRank": 13
   },
   {
@@ -3274,7 +3538,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 149,
+    "aggregatedRank": 161,
     "countryRank": 2
   },
   {
@@ -3296,8 +3560,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 150,
-    "countryRank": 4
+    "aggregatedRank": 162,
+    "countryRank": 5
   },
   {
     "name": "Polytechnic University of Milan",
@@ -3318,7 +3582,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 151,
+    "aggregatedRank": 163,
     "countryRank": 3
   },
   {
@@ -3340,7 +3604,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 152,
+    "aggregatedRank": 164,
     "countryRank": 9
   },
   {
@@ -3362,8 +3626,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 153,
-    "countryRank": 9
+    "aggregatedRank": 165,
+    "countryRank": 10
   },
   {
     "name": "Lancaster University",
@@ -3384,8 +3648,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 154,
-    "countryRank": 19
+    "aggregatedRank": 166,
+    "countryRank": 20
   },
   {
     "name": "Sichuan University",
@@ -3406,7 +3670,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 155,
+    "aggregatedRank": 167,
     "countryRank": 15
   },
   {
@@ -3428,8 +3692,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 156,
-    "countryRank": 43
+    "aggregatedRank": 168,
+    "countryRank": 48
+  },
+  {
+    "name": "Durham University",
+    "country": "United Kingdom",
+    "aggregatedScore": 1494.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 89
+      },
+      "the": {
+        "rank": 172
+      },
+      "arwu": {
+        "rank": 301
+      },
+      "usnews": {
+        "rank": 309
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 169,
+    "countryRank": 21
   },
   {
     "name": "University of Wollongong",
@@ -3450,7 +3736,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 157,
+    "aggregatedRank": 170,
     "countryRank": 14
   },
   {
@@ -3472,8 +3758,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 158,
-    "countryRank": 5
+    "aggregatedRank": 171,
+    "countryRank": 6
   },
   {
     "name": "University of York - UK",
@@ -3494,8 +3780,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 159,
-    "countryRank": 20
+    "aggregatedRank": 172,
+    "countryRank": 22
   },
   {
     "name": "University College Dublin",
@@ -3516,8 +3802,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 160,
+    "aggregatedRank": 173,
     "countryRank": 2
+  },
+  {
+    "name": "University of Milan",
+    "country": "Italy",
+    "aggregatedScore": 1491.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 285
+      },
+      "the": {
+        "rank": 301
+      },
+      "arwu": {
+        "rank": 151
+      },
+      "usnews": {
+        "rank": 146
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 174,
+    "countryRank": 4
   },
   {
     "name": "Swinburne University of Technology",
@@ -3538,7 +3846,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 161,
+    "aggregatedRank": 175,
     "countryRank": 15
   },
   {
@@ -3560,8 +3868,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 162,
-    "countryRank": 21
+    "aggregatedRank": 176,
+    "countryRank": 23
   },
   {
     "name": "Nankai University",
@@ -3582,7 +3890,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 163,
+    "aggregatedRank": 177,
     "countryRank": 16
   },
   {
@@ -3604,7 +3912,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 164,
+    "aggregatedRank": 178,
     "countryRank": 17
   },
   {
@@ -3626,7 +3934,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 165,
+    "aggregatedRank": 179,
     "countryRank": 2
   },
   {
@@ -3648,8 +3956,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 166,
-    "countryRank": 44
+    "aggregatedRank": 180,
+    "countryRank": 49
   },
   {
     "name": "University of Antwerp",
@@ -3670,8 +3978,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 167,
-    "countryRank": 2
+    "aggregatedRank": 181,
+    "countryRank": 3
   },
   {
     "name": "University of Leicester",
@@ -3692,8 +4000,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 168,
-    "countryRank": 22
+    "aggregatedRank": 182,
+    "countryRank": 24
   },
   {
     "name": "Queens University Belfast",
@@ -3714,8 +4022,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 169,
-    "countryRank": 23
+    "aggregatedRank": 183,
+    "countryRank": 25
   },
   {
     "name": "Norwegian University of Science & Technology (NTNU)",
@@ -3736,7 +4044,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 170,
+    "aggregatedRank": 184,
     "countryRank": 2
   },
   {
@@ -3758,8 +4066,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 171,
-    "countryRank": 45
+    "aggregatedRank": 185,
+    "countryRank": 50
   },
   {
     "name": "University of St Andrews",
@@ -3780,8 +4088,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 172,
-    "countryRank": 24
+    "aggregatedRank": 186,
+    "countryRank": 26
   },
   {
     "name": "University of Macau",
@@ -3802,7 +4110,29 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 173,
+    "aggregatedRank": 187,
+    "countryRank": 1
+  },
+  {
+    "name": "Universiti Malaya",
+    "country": "Malaysia",
+    "aggregatedScore": 1464,
+    "originalRankings": {
+      "qs": {
+        "rank": 60
+      },
+      "the": {
+        "rank": 251
+      },
+      "arwu": {
+        "rank": 401
+      },
+      "usnews": {
+        "rank": 281
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 188,
     "countryRank": 1
   },
   {
@@ -3824,7 +4154,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 174,
+    "aggregatedRank": 189,
     "countryRank": 16
   },
   {
@@ -3846,7 +4176,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 175,
+    "aggregatedRank": 190,
     "countryRank": 3
   },
   {
@@ -3868,8 +4198,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 176,
-    "countryRank": 25
+    "aggregatedRank": 191,
+    "countryRank": 27
   },
   {
     "name": "Aalto University",
@@ -3890,7 +4220,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 177,
+    "aggregatedRank": 192,
     "countryRank": 2
   },
   {
@@ -3912,7 +4242,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 178,
+    "aggregatedRank": 193,
     "countryRank": 3
   },
   {
@@ -3934,7 +4264,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 179,
+    "aggregatedRank": 194,
     "countryRank": 18
   },
   {
@@ -3956,7 +4286,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 180,
+    "aggregatedRank": 195,
     "countryRank": 19
   },
   {
@@ -3978,7 +4308,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 181,
+    "aggregatedRank": 196,
     "countryRank": 20
   },
   {
@@ -4000,8 +4330,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 182,
-    "countryRank": 46
+    "aggregatedRank": 197,
+    "countryRank": 51
   },
   {
     "name": "Kyushu University",
@@ -4022,8 +4352,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 183,
-    "countryRank": 6
+    "aggregatedRank": 198,
+    "countryRank": 7
   },
   {
     "name": "Dartmouth College",
@@ -4044,8 +4374,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 184,
-    "countryRank": 47
+    "aggregatedRank": 199,
+    "countryRank": 52
   },
   {
     "name": "La Trobe University",
@@ -4066,7 +4396,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 185,
+    "aggregatedRank": 200,
     "countryRank": 17
   },
   {
@@ -4088,30 +4418,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 186,
+    "aggregatedRank": 201,
     "countryRank": 21
-  },
-  {
-    "name": "University of Newcastle",
-    "country": "Australia",
-    "aggregatedScore": 1445.75,
-    "originalRankings": {
-      "qs": {
-        "rank": 179
-      },
-      "the": {
-        "rank": 251
-      },
-      "arwu": {
-        "rank": 401
-      },
-      "usnews": {
-        "rank": 235
-      }
-    },
-    "appearances": 4,
-    "aggregatedRank": 187,
-    "countryRank": 18
   },
   {
     "name": "University of Miami",
@@ -4132,8 +4440,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 188,
-    "countryRank": 48
+    "aggregatedRank": 202,
+    "countryRank": 53
   },
   {
     "name": "Ulsan National Institute of Science & Technology (UNIST)",
@@ -4154,7 +4462,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 189,
+    "aggregatedRank": 203,
     "countryRank": 6
   },
   {
@@ -4176,7 +4484,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 190,
+    "aggregatedRank": 204,
     "countryRank": 22
   },
   {
@@ -4198,7 +4506,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 191,
+    "aggregatedRank": 205,
     "countryRank": 5
   },
   {
@@ -4220,8 +4528,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 192,
-    "countryRank": 3
+    "aggregatedRank": 206,
+    "countryRank": 4
   },
   {
     "name": "University of Naples Federico II",
@@ -4242,8 +4550,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 193,
-    "countryRank": 4
+    "aggregatedRank": 207,
+    "countryRank": 5
   },
   {
     "name": "Eindhoven University of Technology",
@@ -4264,7 +4572,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 194,
+    "aggregatedRank": 208,
     "countryRank": 5
   },
   {
@@ -4286,7 +4594,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 195,
+    "aggregatedRank": 209,
     "countryRank": 4
   },
   {
@@ -4308,7 +4616,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 196,
+    "aggregatedRank": 210,
     "countryRank": 6
   },
   {
@@ -4330,8 +4638,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 197,
-    "countryRank": 49
+    "aggregatedRank": 211,
+    "countryRank": 54
   },
   {
     "name": "Autonomous University of Madrid",
@@ -4352,7 +4660,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 198,
+    "aggregatedRank": 212,
     "countryRank": 4
   },
   {
@@ -4374,8 +4682,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 199,
-    "countryRank": 5
+    "aggregatedRank": 213,
+    "countryRank": 6
   },
   {
     "name": "University of Tasmania",
@@ -4396,8 +4704,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 200,
-    "countryRank": 19
+    "aggregatedRank": 214,
+    "countryRank": 18
   },
   {
     "name": "University of Witwatersrand",
@@ -4418,7 +4726,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 201,
+    "aggregatedRank": 215,
     "countryRank": 2
   },
   {
@@ -4440,8 +4748,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 202,
-    "countryRank": 50
+    "aggregatedRank": 216,
+    "countryRank": 55
   },
   {
     "name": "University of Reading",
@@ -4462,8 +4770,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 203,
-    "countryRank": 26
+    "aggregatedRank": 217,
+    "countryRank": 28
   },
   {
     "name": "Northwestern Polytechnical University",
@@ -4484,7 +4792,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 204,
+    "aggregatedRank": 218,
     "countryRank": 23
   },
   {
@@ -4506,7 +4814,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 205,
+    "aggregatedRank": 219,
     "countryRank": 7
   },
   {
@@ -4528,8 +4836,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 206,
-    "countryRank": 7
+    "aggregatedRank": 220,
+    "countryRank": 8
+  },
+  {
+    "name": "University of California Riverside",
+    "country": "United States",
+    "aggregatedScore": 1419.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 497
+      },
+      "the": {
+        "rank": 251
+      },
+      "arwu": {
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 223
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 221,
+    "countryRank": 56
   },
   {
     "name": "University of East Anglia",
@@ -4550,8 +4880,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 207,
-    "countryRank": 27
+    "aggregatedRank": 222,
+    "countryRank": 29
   },
   {
     "name": "Aix-Marseille Universite",
@@ -4572,8 +4902,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 208,
-    "countryRank": 2
+    "aggregatedRank": 223,
+    "countryRank": 3
   },
   {
     "name": "University of Notre Dame",
@@ -4594,8 +4924,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 209,
-    "countryRank": 51
+    "aggregatedRank": 224,
+    "countryRank": 57
   },
   {
     "name": "University of Turin",
@@ -4616,8 +4946,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 210,
-    "countryRank": 6
+    "aggregatedRank": 225,
+    "countryRank": 7
   },
   {
     "name": "Shenzhen University",
@@ -4638,7 +4968,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 211,
+    "aggregatedRank": 226,
     "countryRank": 24
   },
   {
@@ -4660,8 +4990,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 212,
-    "countryRank": 7
+    "aggregatedRank": 227,
+    "countryRank": 8
   },
   {
     "name": "Charles University Prague",
@@ -4682,7 +5012,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 213,
+    "aggregatedRank": 228,
     "countryRank": 1
   },
   {
@@ -4704,7 +5034,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 214,
+    "aggregatedRank": 229,
     "countryRank": 25
   },
   {
@@ -4726,8 +5056,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 215,
-    "countryRank": 28
+    "aggregatedRank": 230,
+    "countryRank": 30
   },
   {
     "name": "University of Twente",
@@ -4748,8 +5078,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 216,
+    "aggregatedRank": 231,
     "countryRank": 6
+  },
+  {
+    "name": "University of Tennessee Knoxville",
+    "country": "United States",
+    "aggregatedScore": 1405.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 481
+      },
+      "the": {
+        "rank": 301
+      },
+      "arwu": {
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 245
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 232,
+    "countryRank": 58
   },
   {
     "name": "Dalhousie University",
@@ -4770,7 +5122,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 217,
+    "aggregatedRank": 233,
     "countryRank": 10
   },
   {
@@ -4792,7 +5144,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 218,
+    "aggregatedRank": 234,
     "countryRank": 5
   },
   {
@@ -4814,8 +5166,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 219,
-    "countryRank": 52
+    "aggregatedRank": 235,
+    "countryRank": 59
   },
   {
     "name": "Technion Israel Institute of Technology",
@@ -4836,7 +5188,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 220,
+    "aggregatedRank": 236,
     "countryRank": 3
   },
   {
@@ -4858,7 +5210,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 221,
+    "aggregatedRank": 237,
     "countryRank": 2
   },
   {
@@ -4880,8 +5232,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 222,
-    "countryRank": 8
+    "aggregatedRank": 238,
+    "countryRank": 9
   },
   {
     "name": "University of Innsbruck",
@@ -4902,7 +5254,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 223,
+    "aggregatedRank": 239,
     "countryRank": 2
   },
   {
@@ -4924,7 +5276,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 224,
+    "aggregatedRank": 240,
     "countryRank": 26
   },
   {
@@ -4946,7 +5298,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 225,
+    "aggregatedRank": 241,
     "countryRank": 5
   },
   {
@@ -4968,8 +5320,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 226,
-    "countryRank": 53
+    "aggregatedRank": 242,
+    "countryRank": 60
   },
   {
     "name": "King Fahd University of Petroleum & Minerals",
@@ -4990,30 +5342,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 227,
+    "aggregatedRank": 243,
     "countryRank": 3
-  },
-  {
-    "name": "University of Milan",
-    "country": "Italy",
-    "aggregatedScore": 1384.5,
-    "originalRankings": {
-      "qs": {
-        "rank": 513
-      },
-      "the": {
-        "rank": 351
-      },
-      "arwu": {
-        "rank": 301
-      },
-      "usnews": {
-        "rank": 146
-      }
-    },
-    "appearances": 4,
-    "aggregatedRank": 228,
-    "countryRank": 9
   },
   {
     "name": "Georgetown University",
@@ -5034,8 +5364,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 229,
-    "countryRank": 54
+    "aggregatedRank": 244,
+    "countryRank": 61
   },
   {
     "name": "Simon Fraser University",
@@ -5056,7 +5386,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 230,
+    "aggregatedRank": 245,
     "countryRank": 11
   },
   {
@@ -5078,8 +5408,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 231,
-    "countryRank": 29
+    "aggregatedRank": 246,
+    "countryRank": 31
   },
   {
     "name": "University of Victoria",
@@ -5100,7 +5430,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 232,
+    "aggregatedRank": 247,
     "countryRank": 12
   },
   {
@@ -5122,7 +5452,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 233,
+    "aggregatedRank": 248,
     "countryRank": 3
   },
   {
@@ -5144,7 +5474,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 234,
+    "aggregatedRank": 249,
     "countryRank": 8
   },
   {
@@ -5166,7 +5496,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 235,
+    "aggregatedRank": 250,
     "countryRank": 27
   },
   {
@@ -5188,8 +5518,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 236,
-    "countryRank": 10
+    "aggregatedRank": 251,
+    "countryRank": 11
   },
   {
     "name": "Colorado State University",
@@ -5210,8 +5540,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 237,
-    "countryRank": 55
+    "aggregatedRank": 252,
+    "countryRank": 62
   },
   {
     "name": "University of Iowa",
@@ -5232,8 +5562,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 238,
-    "countryRank": 56
+    "aggregatedRank": 253,
+    "countryRank": 63
   },
   {
     "name": "University of Navarra",
@@ -5254,7 +5584,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 239,
+    "aggregatedRank": 254,
     "countryRank": 6
   },
   {
@@ -5276,7 +5606,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 240,
+    "aggregatedRank": 255,
     "countryRank": 7
   },
   {
@@ -5298,7 +5628,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 241,
+    "aggregatedRank": 256,
     "countryRank": 13
   },
   {
@@ -5320,7 +5650,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 242,
+    "aggregatedRank": 257,
     "countryRank": 3
   },
   {
@@ -5342,8 +5672,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 243,
+    "aggregatedRank": 258,
     "countryRank": 28
+  },
+  {
+    "name": "University of Milano-Bicocca",
+    "country": "Italy",
+    "aggregatedScore": 1357.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 513
+      },
+      "the": {
+        "rank": 351
+      },
+      "arwu": {
+        "rank": 301
+      },
+      "usnews": {
+        "rank": 253
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 259,
+    "countryRank": 10
   },
   {
     "name": "University of South Australia",
@@ -5364,8 +5716,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 244,
-    "countryRank": 20
+    "aggregatedRank": 260,
+    "countryRank": 19
   },
   {
     "name": "University of Trento",
@@ -5386,8 +5738,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 245,
-    "countryRank": 10
+    "aggregatedRank": 261,
+    "countryRank": 11
   },
   {
     "name": "University of Turku",
@@ -5408,7 +5760,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 246,
+    "aggregatedRank": 262,
     "countryRank": 4
   },
   {
@@ -5430,8 +5782,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 247,
-    "countryRank": 57
+    "aggregatedRank": 263,
+    "countryRank": 64
   },
   {
     "name": "University of Kiel",
@@ -5452,8 +5804,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 248,
-    "countryRank": 11
+    "aggregatedRank": 264,
+    "countryRank": 12
   },
   {
     "name": "University of Tehran",
@@ -5474,7 +5826,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 249,
+    "aggregatedRank": 265,
     "countryRank": 1
   },
   {
@@ -5496,8 +5848,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 250,
-    "countryRank": 58
+    "aggregatedRank": 266,
+    "countryRank": 65
   },
   {
     "name": "University of Pavia",
@@ -5518,8 +5870,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 251,
-    "countryRank": 11
+    "aggregatedRank": 267,
+    "countryRank": 12
   },
   {
     "name": "University of Rome Tor Vergata",
@@ -5540,8 +5892,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 252,
-    "countryRank": 12
+    "aggregatedRank": 268,
+    "countryRank": 13
   },
   {
     "name": "University of Johannesburg",
@@ -5562,7 +5914,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 253,
+    "aggregatedRank": 269,
     "countryRank": 3
   },
   {
@@ -5584,8 +5936,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 254,
-    "countryRank": 59
+    "aggregatedRank": 270,
+    "countryRank": 66
   },
   {
     "name": "University of Dundee",
@@ -5606,8 +5958,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 255,
-    "countryRank": 30
+    "aggregatedRank": 271,
+    "countryRank": 32
   },
   {
     "name": "University of Connecticut",
@@ -5628,8 +5980,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 256,
-    "countryRank": 60
+    "aggregatedRank": 272,
+    "countryRank": 67
   },
   {
     "name": "Catholic University of the Sacred Heart",
@@ -5650,8 +6002,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 257,
-    "countryRank": 13
+    "aggregatedRank": 273,
+    "countryRank": 14
   },
   {
     "name": "University of Delaware",
@@ -5672,8 +6024,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 258,
-    "countryRank": 61
+    "aggregatedRank": 274,
+    "countryRank": 68
   },
   {
     "name": "Kyung Hee University",
@@ -5694,7 +6046,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 259,
+    "aggregatedRank": 275,
     "countryRank": 9
   },
   {
@@ -5716,7 +6068,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 260,
+    "aggregatedRank": 276,
     "countryRank": 1
   },
   {
@@ -5738,7 +6090,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 261,
+    "aggregatedRank": 277,
     "countryRank": 2
   },
   {
@@ -5760,8 +6112,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 262,
-    "countryRank": 31
+    "aggregatedRank": 278,
+    "countryRank": 33
+  },
+  {
+    "name": "Pontificia Universidad Catolica de Chile",
+    "country": "Chile",
+    "aggregatedScore": 1323.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 93
+      },
+      "the": {
+        "rank": 501
+      },
+      "arwu": {
+        "rank": 601
+      },
+      "usnews": {
+        "rank": 359
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 279,
+    "countryRank": 1
   },
   {
     "name": "James Cook University",
@@ -5782,8 +6156,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 263,
-    "countryRank": 21
+    "aggregatedRank": 280,
+    "countryRank": 20
   },
   {
     "name": "University of Strathclyde",
@@ -5804,8 +6178,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 264,
-    "countryRank": 32
+    "aggregatedRank": 281,
+    "countryRank": 34
   },
   {
     "name": "Hong Kong Baptist University",
@@ -5826,8 +6200,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 265,
-    "countryRank": 5
+    "aggregatedRank": 282,
+    "countryRank": 6
   },
   {
     "name": "University of Genoa",
@@ -5848,8 +6222,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 266,
-    "countryRank": 14
+    "aggregatedRank": 283,
+    "countryRank": 15
   },
   {
     "name": "University of South Florida",
@@ -5870,8 +6244,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 267,
-    "countryRank": 62
+    "aggregatedRank": 284,
+    "countryRank": 69
   },
   {
     "name": "Soochow University - China",
@@ -5892,7 +6266,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 268,
+    "aggregatedRank": 285,
     "countryRank": 29
   },
   {
@@ -5914,30 +6288,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 269,
-    "countryRank": 8
-  },
-  {
-    "name": "York University - Canada",
-    "country": "Canada",
-    "aggregatedScore": 1304.75,
-    "originalRankings": {
-      "qs": {
-        "rank": 362
-      },
-      "the": {
-        "rank": 401
-      },
-      "arwu": {
-        "rank": 401
-      },
-      "usnews": {
-        "rank": 466
-      }
-    },
-    "appearances": 4,
-    "aggregatedRank": 270,
-    "countryRank": 14
+    "aggregatedRank": 286,
+    "countryRank": 9
   },
   {
     "name": "University of Saskatchewan",
@@ -5958,8 +6310,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 271,
-    "countryRank": 15
+    "aggregatedRank": 287,
+    "countryRank": 14
   },
   {
     "name": "Beijing University of Chemical Technology",
@@ -5980,7 +6332,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 272,
+    "aggregatedRank": 288,
     "countryRank": 30
   },
   {
@@ -6002,8 +6354,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 273,
-    "countryRank": 22
+    "aggregatedRank": 289,
+    "countryRank": 21
   },
   {
     "name": "Washington State University",
@@ -6024,8 +6376,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 274,
-    "countryRank": 63
+    "aggregatedRank": 290,
+    "countryRank": 70
   },
   {
     "name": "University of Luxembourg",
@@ -6046,7 +6398,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 275,
+    "aggregatedRank": 291,
     "countryRank": 1
   },
   {
@@ -6068,8 +6420,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 276,
-    "countryRank": 64
+    "aggregatedRank": 292,
+    "countryRank": 71
   },
   {
     "name": "University of Manitoba",
@@ -6090,8 +6442,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 277,
-    "countryRank": 16
+    "aggregatedRank": 293,
+    "countryRank": 15
   },
   {
     "name": "University of Granada",
@@ -6112,7 +6464,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 278,
+    "aggregatedRank": 294,
     "countryRank": 8
   },
   {
@@ -6134,30 +6486,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 279,
-    "countryRank": 65
-  },
-  {
-    "name": "Jinan University",
-    "country": "China",
-    "aggregatedScore": 1289.75,
-    "originalRankings": {
-      "qs": {
-        "rank": 580
-      },
-      "the": {
-        "rank": 501
-      },
-      "arwu": {
-        "rank": 201
-      },
-      "usnews": {
-        "rank": 408
-      }
-    },
-    "appearances": 4,
-    "aggregatedRank": 280,
-    "countryRank": 31
+    "aggregatedRank": 295,
+    "countryRank": 72
   },
   {
     "name": "University of Sharjah",
@@ -6178,7 +6508,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 281,
+    "aggregatedRank": 296,
     "countryRank": 1
   },
   {
@@ -6200,7 +6530,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 282,
+    "aggregatedRank": 297,
     "countryRank": 1
   },
   {
@@ -6222,7 +6552,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 283,
+    "aggregatedRank": 298,
     "countryRank": 3
   },
   {
@@ -6244,7 +6574,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 284,
+    "aggregatedRank": 299,
     "countryRank": 7
   },
   {
@@ -6266,7 +6596,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 285,
+    "aggregatedRank": 300,
     "countryRank": 2
   },
   {
@@ -6288,8 +6618,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 286,
-    "countryRank": 66
+    "aggregatedRank": 301,
+    "countryRank": 73
   },
   {
     "name": "Cairo University",
@@ -6310,7 +6640,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 287,
+    "aggregatedRank": 302,
     "countryRank": 1
   },
   {
@@ -6332,7 +6662,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 288,
+    "aggregatedRank": 303,
     "countryRank": 2
   },
   {
@@ -6354,8 +6684,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 289,
-    "countryRank": 15
+    "aggregatedRank": 304,
+    "countryRank": 16
   },
   {
     "name": "Loughborough University",
@@ -6376,8 +6706,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 290,
-    "countryRank": 33
+    "aggregatedRank": 305,
+    "countryRank": 35
   },
   {
     "name": "King Khalid University",
@@ -6398,7 +6728,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 291,
+    "aggregatedRank": 306,
     "countryRank": 4
   },
   {
@@ -6420,8 +6750,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 292,
-    "countryRank": 67
+    "aggregatedRank": 307,
+    "countryRank": 74
+  },
+  {
+    "name": "University of Missouri Columbia",
+    "country": "United States",
+    "aggregatedScore": 1260,
+    "originalRankings": {
+      "qs": {
+        "rank": 641
+      },
+      "the": {
+        "rank": 501
+      },
+      "arwu": {
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 466
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 308,
+    "countryRank": 75
   },
   {
     "name": "Virginia Commonwealth University",
@@ -6442,8 +6794,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 293,
-    "countryRank": 68
+    "aggregatedRank": 309,
+    "countryRank": 76
   },
   {
     "name": "Sharif University of Technology",
@@ -6464,7 +6816,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 294,
+    "aggregatedRank": 310,
     "countryRank": 2
   },
   {
@@ -6486,8 +6838,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 295,
-    "countryRank": 69
+    "aggregatedRank": 311,
+    "countryRank": 77
   },
   {
     "name": "Murdoch University",
@@ -6508,8 +6860,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 296,
-    "countryRank": 23
+    "aggregatedRank": 312,
+    "countryRank": 22
   },
   {
     "name": "Brunel University",
@@ -6530,8 +6882,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 297,
-    "countryRank": 34
+    "aggregatedRank": 313,
+    "countryRank": 36
   },
   {
     "name": "University of Pretoria",
@@ -6552,7 +6904,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 298,
+    "aggregatedRank": 314,
     "countryRank": 4
   },
   {
@@ -6574,8 +6926,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 299,
-    "countryRank": 17
+    "aggregatedRank": 315,
+    "countryRank": 16
+  },
+  {
+    "name": "University of Nebraska Lincoln",
+    "country": "United States",
+    "aggregatedScore": 1237.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 701
+      },
+      "the": {
+        "rank": 401
+      },
+      "arwu": {
+        "rank": 301
+      },
+      "usnews": {
+        "rank": 497
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 316,
+    "countryRank": 78
   },
   {
     "name": "Drexel University",
@@ -6596,8 +6970,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 300,
-    "countryRank": 70
+    "aggregatedRank": 317,
+    "countryRank": 79
   },
   {
     "name": "Boston College",
@@ -6618,8 +6992,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 301,
-    "countryRank": 71
+    "aggregatedRank": 318,
+    "countryRank": 80
   },
   {
     "name": "Edith Cowan University",
@@ -6640,8 +7014,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 302,
-    "countryRank": 24
+    "aggregatedRank": 319,
+    "countryRank": 23
   },
   {
     "name": "American University of Beirut",
@@ -6662,7 +7036,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 303,
+    "aggregatedRank": 320,
     "countryRank": 1
   },
   {
@@ -6684,8 +7058,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 304,
-    "countryRank": 72
+    "aggregatedRank": 321,
+    "countryRank": 81
   },
   {
     "name": "Chulalongkorn University",
@@ -6706,7 +7080,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 305,
+    "aggregatedRank": 322,
     "countryRank": 1
   },
   {
@@ -6728,8 +7102,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 306,
-    "countryRank": 73
+    "aggregatedRank": 323,
+    "countryRank": 82
   },
   {
     "name": "University of Central Florida",
@@ -6750,8 +7124,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 307,
-    "countryRank": 74
+    "aggregatedRank": 324,
+    "countryRank": 83
   },
   {
     "name": "Koc University",
@@ -6772,7 +7146,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 308,
+    "aggregatedRank": 325,
     "countryRank": 1
   },
   {
@@ -6794,8 +7168,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 309,
-    "countryRank": 75
+    "aggregatedRank": 326,
+    "countryRank": 84
   },
   {
     "name": "Humboldt University of Berlin",
@@ -6813,8 +7187,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 310,
-    "countryRank": 12
+    "aggregatedRank": 327,
+    "countryRank": 13
   },
   {
     "name": "Free University of Berlin",
@@ -6832,8 +7206,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 311,
-    "countryRank": 13
+    "aggregatedRank": 328,
+    "countryRank": 14
   },
   {
     "name": "University of Brescia",
@@ -6854,8 +7228,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 312,
-    "countryRank": 16
+    "aggregatedRank": 329,
+    "countryRank": 17
   },
   {
     "name": "Mahidol University",
@@ -6876,7 +7250,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 313,
+    "aggregatedRank": 330,
     "countryRank": 2
   },
   {
@@ -6898,8 +7272,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 314,
-    "countryRank": 17
+    "aggregatedRank": 331,
+    "countryRank": 18
   },
   {
     "name": "Wake Forest University",
@@ -6920,8 +7294,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 315,
-    "countryRank": 76
+    "aggregatedRank": 332,
+    "countryRank": 85
   },
   {
     "name": "Nanjing University of Aeronautics & Astronautics",
@@ -6942,8 +7316,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 316,
-    "countryRank": 32
+    "aggregatedRank": 333,
+    "countryRank": 31
   },
   {
     "name": "Auckland University of Technology",
@@ -6964,7 +7338,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 317,
+    "aggregatedRank": 334,
     "countryRank": 4
   },
   {
@@ -6986,7 +7360,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 318,
+    "aggregatedRank": 335,
     "countryRank": 1
   },
   {
@@ -7008,7 +7382,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 319,
+    "aggregatedRank": 336,
     "countryRank": 9
   },
   {
@@ -7030,7 +7404,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 320,
+    "aggregatedRank": 337,
     "countryRank": 1
   },
   {
@@ -7052,7 +7426,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 321,
+    "aggregatedRank": 338,
     "countryRank": 1
   },
   {
@@ -7074,8 +7448,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 322,
-    "countryRank": 33
+    "aggregatedRank": 339,
+    "countryRank": 32
   },
   {
     "name": "Australian Catholic University",
@@ -7096,8 +7470,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 323,
-    "countryRank": 25
+    "aggregatedRank": 340,
+    "countryRank": 24
   },
   {
     "name": "University of Trieste",
@@ -7118,8 +7492,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 324,
-    "countryRank": 18
+    "aggregatedRank": 341,
+    "countryRank": 19
   },
   {
     "name": "University of Eastern Finland",
@@ -7140,7 +7514,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 325,
+    "aggregatedRank": 342,
     "countryRank": 5
   },
   {
@@ -7162,8 +7536,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 326,
-    "countryRank": 77
+    "aggregatedRank": 343,
+    "countryRank": 86
   },
   {
     "name": "Wayne State University",
@@ -7184,30 +7558,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 327,
-    "countryRank": 78
-  },
-  {
-    "name": "Donghua University",
-    "country": "China",
-    "aggregatedScore": 1121.75,
-    "originalRankings": {
-      "qs": {
-        "rank": 851
-      },
-      "the": {
-        "rank": 501
-      },
-      "arwu": {
-        "rank": 501
-      },
-      "usnews": {
-        "rank": 509
-      }
-    },
-    "appearances": 4,
-    "aggregatedRank": 328,
-    "countryRank": 34
+    "aggregatedRank": 344,
+    "countryRank": 87
   },
   {
     "name": "Syracuse University",
@@ -7228,8 +7580,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 329,
-    "countryRank": 79
+    "aggregatedRank": 345,
+    "countryRank": 88
   },
   {
     "name": "University of Ljubljana",
@@ -7250,7 +7602,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 330,
+    "aggregatedRank": 346,
     "countryRank": 1
   },
   {
@@ -7272,8 +7624,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 331,
-    "countryRank": 80
+    "aggregatedRank": 347,
+    "countryRank": 89
   },
   {
     "name": "Karolinska Institutet",
@@ -7291,7 +7643,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 332,
+    "aggregatedRank": 348,
     "countryRank": 8
   },
   {
@@ -7313,7 +7665,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 333,
+    "aggregatedRank": 349,
     "countryRank": 2
   },
   {
@@ -7335,7 +7687,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 334,
+    "aggregatedRank": 350,
     "countryRank": 2
   },
   {
@@ -7357,7 +7709,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 335,
+    "aggregatedRank": 351,
     "countryRank": 3
   },
   {
@@ -7379,8 +7731,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 336,
-    "countryRank": 35
+    "aggregatedRank": 352,
+    "countryRank": 37
   },
   {
     "name": "University of Ferrara",
@@ -7401,8 +7753,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 337,
-    "countryRank": 19
+    "aggregatedRank": 353,
+    "countryRank": 20
   },
   {
     "name": "University of Messina",
@@ -7423,8 +7775,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 338,
-    "countryRank": 20
+    "aggregatedRank": 354,
+    "countryRank": 21
   },
   {
     "name": "University of Salerno",
@@ -7445,8 +7797,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 339,
-    "countryRank": 21
+    "aggregatedRank": 355,
+    "countryRank": 22
   },
   {
     "name": "University of Palermo",
@@ -7467,8 +7819,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 340,
-    "countryRank": 22
+    "aggregatedRank": 356,
+    "countryRank": 23
   },
   {
     "name": "Medical University of Vienna",
@@ -7486,7 +7838,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 341,
+    "aggregatedRank": 357,
     "countryRank": 3
   },
   {
@@ -7505,7 +7857,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 342,
+    "aggregatedRank": 358,
     "countryRank": 2
   },
   {
@@ -7524,27 +7876,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 343,
+    "aggregatedRank": 359,
     "countryRank": 1
-  },
-  {
-    "name": "University of California - Berkeley",
-    "country": "United States",
-    "aggregatedScore": 951.125,
-    "originalRankings": {
-      "qs": {
-        "rank": 12
-      },
-      "the": {
-        "rank": 8
-      },
-      "arwu": {
-        "rank": 5
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 344,
-    "countryRank": 81
   },
   {
     "name": "Utrecht University",
@@ -7562,7 +7895,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 345,
+    "aggregatedRank": 360,
     "countryRank": 7
   },
   {
@@ -7581,46 +7914,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 346,
+    "aggregatedRank": 361,
     "countryRank": 6
-  },
-  {
-    "name": "The University of Tokyo",
-    "country": "Japan",
-    "aggregatedScore": 937.34375,
-    "originalRankings": {
-      "qs": {
-        "rank": 32
-      },
-      "the": {
-        "rank": 28
-      },
-      "arwu": {
-        "rank": 28
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 347,
-    "countryRank": 9
-  },
-  {
-    "name": "PSL Research University Paris",
-    "country": "France",
-    "aggregatedScore": 934.9375,
-    "originalRankings": {
-      "qs": {
-        "rank": 24
-      },
-      "the": {
-        "rank": 42
-      },
-      "arwu": {
-        "rank": 33
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 348,
-    "countryRank": 3
   },
   {
     "name": "Swiss Federal Institute of Technology Lausanne - EPFL",
@@ -7638,7 +7933,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 349,
+    "aggregatedRank": 362,
     "countryRank": 7
   },
   {
@@ -7657,7 +7952,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 350,
+    "aggregatedRank": 363,
     "countryRank": 3
   },
   {
@@ -7676,7 +7971,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 351,
+    "aggregatedRank": 364,
     "countryRank": 5
   },
   {
@@ -7695,84 +7990,27 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 352,
+    "aggregatedRank": 365,
     "countryRank": 4
   },
   {
-    "name": "University of Texas at Austin",
-    "country": "United States",
-    "aggregatedScore": 921.375,
+    "name": "China Medical University Taiwan",
+    "country": "Taiwan",
+    "aggregatedScore": 920.4343749999999,
     "originalRankings": {
-      "qs": {
-        "rank": 66
-      },
       "the": {
-        "rank": 50
+        "rank": 301
       },
       "arwu": {
-        "rank": 45
+        "rank": 401
+      },
+      "usnews": {
+        "rank": 285
       }
     },
     "appearances": 3,
-    "aggregatedRank": 353,
-    "countryRank": 82
-  },
-  {
-    "name": "University of Illinois at Urbana-Champaign",
-    "country": "United States",
-    "aggregatedScore": 919.40625,
-    "originalRankings": {
-      "qs": {
-        "rank": 69
-      },
-      "the": {
-        "rank": 46
-      },
-      "arwu": {
-        "rank": 55
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 354,
-    "countryRank": 83
-  },
-  {
-    "name": "University of Heidelberg",
-    "country": "Germany",
-    "aggregatedScore": 917,
-    "originalRankings": {
-      "qs": {
-        "rank": 84
-      },
-      "the": {
-        "rank": 47
-      },
-      "arwu": {
-        "rank": 50
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 355,
-    "countryRank": 14
-  },
-  {
-    "name": "Catholic University of Leuven",
-    "country": "Belgium",
-    "aggregatedScore": 916.34375,
-    "originalRankings": {
-      "qs": {
-        "rank": 63
-      },
-      "the": {
-        "rank": 43
-      },
-      "arwu": {
-        "rank": 78
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 356,
-    "countryRank": 4
+    "aggregatedRank": 366,
+    "countryRank": 3
   },
   {
     "name": "Ton Duc Thang University",
@@ -7790,27 +8028,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 357,
+    "aggregatedRank": 367,
     "countryRank": 2
-  },
-  {
-    "name": "University of Wisconsin-Madison",
-    "country": "United States",
-    "aggregatedScore": 911.09375,
-    "originalRankings": {
-      "qs": {
-        "rank": 116
-      },
-      "the": {
-        "rank": 56
-      },
-      "arwu": {
-        "rank": 36
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 358,
-    "countryRank": 84
   },
   {
     "name": "University of Electronic Science and Technology of China",
@@ -7828,27 +8047,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 359,
-    "countryRank": 35
-  },
-  {
-    "name": "London School of Economics",
-    "country": "United Kingdom",
-    "aggregatedScore": 901.6875,
-    "originalRankings": {
-      "qs": {
-        "rank": 50
-      },
-      "the": {
-        "rank": 50
-      },
-      "arwu": {
-        "rank": 151
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 360,
-    "countryRank": 36
+    "aggregatedRank": 368,
+    "countryRank": 33
   },
   {
     "name": "Medical University of Graz",
@@ -7866,7 +8066,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 361,
+    "aggregatedRank": 369,
     "countryRank": 4
   },
   {
@@ -7885,7 +8085,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 362,
+    "aggregatedRank": 370,
     "countryRank": 9
   },
   {
@@ -7904,8 +8104,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 363,
-    "countryRank": 85
+    "aggregatedRank": 371,
+    "countryRank": 90
   },
   {
     "name": "University of California - Davis",
@@ -7923,8 +8123,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 364,
-    "countryRank": 86
+    "aggregatedRank": 372,
+    "countryRank": 91
   },
   {
     "name": "Moscow State University",
@@ -7942,27 +8142,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 365,
+    "aggregatedRank": 373,
     "countryRank": 1
-  },
-  {
-    "name": "Hong Kong University of Science and Technology",
-    "country": "Hong Kong",
-    "aggregatedScore": 887.90625,
-    "originalRankings": {
-      "qs": {
-        "rank": 47
-      },
-      "the": {
-        "rank": 66
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 366,
-    "countryRank": 6
   },
   {
     "name": "Wageningen University & Research Center",
@@ -7980,7 +8161,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 367,
+    "aggregatedRank": 374,
     "countryRank": 8
   },
   {
@@ -7999,27 +8180,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 368,
+    "aggregatedRank": 375,
     "countryRank": 5
-  },
-  {
-    "name": "University of Sao Paulo",
-    "country": "Brazil",
-    "aggregatedScore": 870.84375,
-    "originalRankings": {
-      "qs": {
-        "rank": 92
-      },
-      "the": {
-        "rank": 199
-      },
-      "arwu": {
-        "rank": 101
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 369,
-    "countryRank": 1
   },
   {
     "name": "Fuzhou University",
@@ -8037,8 +8199,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 370,
-    "countryRank": 36
+    "aggregatedRank": 376,
+    "countryRank": 34
   },
   {
     "name": "Institut Polytechnique de Paris",
@@ -8056,7 +8218,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 371,
+    "aggregatedRank": 377,
     "countryRank": 5
   },
   {
@@ -8075,8 +8237,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 372,
-    "countryRank": 23
+    "aggregatedRank": 378,
+    "countryRank": 24
   },
   {
     "name": "University of Montreal",
@@ -8094,8 +8256,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 373,
-    "countryRank": 18
+    "aggregatedRank": 379,
+    "countryRank": 17
   },
   {
     "name": "Humanitas University",
@@ -8113,8 +8275,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 374,
-    "countryRank": 24
+    "aggregatedRank": 380,
+    "countryRank": 25
   },
   {
     "name": "Queen Mary - University of London",
@@ -8132,8 +8294,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 375,
-    "countryRank": 37
+    "aggregatedRank": 381,
+    "countryRank": 38
   },
   {
     "name": "University of T�bingen",
@@ -8151,27 +8313,27 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 376,
+    "aggregatedRank": 382,
     "countryRank": 15
   },
   {
-    "name": "University of California - Irvine",
+    "name": "University of Massachusetts Amherst",
     "country": "United States",
-    "aggregatedScore": 853.125,
+    "aggregatedScore": 852.2062500000001,
     "originalRankings": {
       "qs": {
-        "rank": 307
-      },
-      "the": {
-        "rank": 90
+        "rank": 275
       },
       "arwu": {
-        "rank": 76
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 175
       }
     },
     "appearances": 3,
-    "aggregatedRank": 377,
-    "countryRank": 87
+    "aggregatedRank": 383,
+    "countryRank": 92
   },
   {
     "name": "Newcastle University - Newcastle-upon-Tyne",
@@ -8189,8 +8351,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 378,
-    "countryRank": 38
+    "aggregatedRank": 384,
+    "countryRank": 39
   },
   {
     "name": "G�teborg University",
@@ -8208,7 +8370,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 379,
+    "aggregatedRank": 385,
     "countryRank": 10
   },
   {
@@ -8227,8 +8389,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 380,
-    "countryRank": 37
+    "aggregatedRank": 386,
+    "countryRank": 35
   },
   {
     "name": "Texas A&M University",
@@ -8246,8 +8408,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 381,
-    "countryRank": 88
+    "aggregatedRank": 387,
+    "countryRank": 93
   },
   {
     "name": "VU University Amsterdam",
@@ -8265,7 +8427,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 382,
+    "aggregatedRank": 388,
     "countryRank": 9
   },
   {
@@ -8284,7 +8446,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 383,
+    "aggregatedRank": 389,
     "countryRank": 10
   },
   {
@@ -8303,8 +8465,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 384,
-    "countryRank": 38
+    "aggregatedRank": 390,
+    "countryRank": 36
   },
   {
     "name": "University of G�ttingen",
@@ -8322,7 +8484,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 385,
+    "aggregatedRank": 391,
     "countryRank": 16
   },
   {
@@ -8341,8 +8503,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 386,
-    "countryRank": 89
+    "aggregatedRank": 392,
+    "countryRank": 94
   },
   {
     "name": "Shandong University",
@@ -8360,8 +8522,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 387,
-    "countryRank": 39
+    "aggregatedRank": 393,
+    "countryRank": 37
   },
   {
     "name": "Taif University",
@@ -8379,7 +8541,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 388,
+    "aggregatedRank": 394,
     "countryRank": 6
   },
   {
@@ -8398,8 +8560,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 389,
-    "countryRank": 40
+    "aggregatedRank": 395,
+    "countryRank": 38
   },
   {
     "name": "Paris Cit� University",
@@ -8417,7 +8579,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 390,
+    "aggregatedRank": 396,
     "countryRank": 6
   },
   {
@@ -8436,46 +8598,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 391,
+    "aggregatedRank": 397,
     "countryRank": 1
-  },
-  {
-    "name": "University of Massachusetts - Amherst",
-    "country": "United States",
-    "aggregatedScore": 834.09375,
-    "originalRankings": {
-      "qs": {
-        "rank": 275
-      },
-      "the": {
-        "rank": 84
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 392,
-    "countryRank": 90
-  },
-  {
-    "name": "University of Durham",
-    "country": "United Kingdom",
-    "aggregatedScore": 833.65625,
-    "originalRankings": {
-      "qs": {
-        "rank": 89
-      },
-      "the": {
-        "rank": 172
-      },
-      "arwu": {
-        "rank": 301
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 393,
-    "countryRank": 39
   },
   {
     "name": "University of Maastricht",
@@ -8493,7 +8617,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 394,
+    "aggregatedRank": 398,
     "countryRank": 11
   },
   {
@@ -8512,8 +8636,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 395,
-    "countryRank": 41
+    "aggregatedRank": 399,
+    "countryRank": 39
   },
   {
     "name": "Jiangnan University",
@@ -8531,8 +8655,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 396,
-    "countryRank": 42
+    "aggregatedRank": 400,
+    "countryRank": 40
   },
   {
     "name": "Catholic University of Louvain",
@@ -8550,7 +8674,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 397,
+    "aggregatedRank": 401,
     "countryRank": 5
   },
   {
@@ -8569,8 +8693,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 398,
-    "countryRank": 25
+    "aggregatedRank": 402,
+    "countryRank": 26
   },
   {
     "name": "Technical University of Dresden",
@@ -8588,7 +8712,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 399,
+    "aggregatedRank": 403,
     "countryRank": 17
   },
   {
@@ -8607,7 +8731,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 400,
+    "aggregatedRank": 404,
     "countryRank": 18
   },
   {
@@ -8626,8 +8750,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 401,
-    "countryRank": 43
+    "aggregatedRank": 405,
+    "countryRank": 41
   },
   {
     "name": "Guangzhou University",
@@ -8645,8 +8769,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 402,
-    "countryRank": 44
+    "aggregatedRank": 406,
+    "countryRank": 42
   },
   {
     "name": "Nanjing Forestry University",
@@ -8664,8 +8788,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 403,
-    "countryRank": 45
+    "aggregatedRank": 407,
+    "countryRank": 43
   },
   {
     "name": "Rush University",
@@ -8683,8 +8807,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 404,
-    "countryRank": 91
+    "aggregatedRank": 408,
+    "countryRank": 95
   },
   {
     "name": "University of Frankfurt am Main",
@@ -8702,7 +8826,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 405,
+    "aggregatedRank": 409,
     "countryRank": 19
   },
   {
@@ -8721,8 +8845,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 406,
-    "countryRank": 46
+    "aggregatedRank": 410,
+    "countryRank": 44
   },
   {
     "name": "RMIT University",
@@ -8740,8 +8864,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 407,
-    "countryRank": 26
+    "aggregatedRank": 411,
+    "countryRank": 25
   },
   {
     "name": "Nanjing University of Information Science & Technology",
@@ -8759,8 +8883,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 408,
-    "countryRank": 47
+    "aggregatedRank": 412,
+    "countryRank": 45
   },
   {
     "name": "Queen's University",
@@ -8778,8 +8902,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 409,
-    "countryRank": 19
+    "aggregatedRank": 413,
+    "countryRank": 18
   },
   {
     "name": "Indiana University at Bloomington",
@@ -8797,8 +8921,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 410,
-    "countryRank": 92
+    "aggregatedRank": 414,
+    "countryRank": 96
   },
   {
     "name": "Zhengzhou University",
@@ -8816,8 +8940,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 411,
-    "countryRank": 48
+    "aggregatedRank": 415,
+    "countryRank": 46
   },
   {
     "name": "Baylor University",
@@ -8835,8 +8959,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 412,
-    "countryRank": 93
+    "aggregatedRank": 416,
+    "countryRank": 97
   },
   {
     "name": "University of M�nster",
@@ -8854,27 +8978,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 413,
+    "aggregatedRank": 417,
     "countryRank": 20
-  },
-  {
-    "name": "University of Malaya",
-    "country": "Malaysia",
-    "aggregatedScore": 800.84375,
-    "originalRankings": {
-      "qs": {
-        "rank": 60
-      },
-      "the": {
-        "rank": 251
-      },
-      "arwu": {
-        "rank": 401
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 414,
-    "countryRank": 1
   },
   {
     "name": "Ecole Normale Sup�rieure de Lyon",
@@ -8892,7 +8997,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 415,
+    "aggregatedRank": 418,
     "countryRank": 7
   },
   {
@@ -8911,8 +9016,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 416,
-    "countryRank": 49
+    "aggregatedRank": 419,
+    "countryRank": 47
   },
   {
     "name": "Jilin University",
@@ -8930,8 +9035,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 417,
-    "countryRank": 50
+    "aggregatedRank": 420,
+    "countryRank": 48
   },
   {
     "name": "Grenoble Alpes University",
@@ -8949,7 +9054,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 418,
+    "aggregatedRank": 421,
     "countryRank": 8
   },
   {
@@ -8968,7 +9073,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 419,
+    "aggregatedRank": 422,
     "countryRank": 6
   },
   {
@@ -8987,7 +9092,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 420,
+    "aggregatedRank": 423,
     "countryRank": 21
   },
   {
@@ -9006,8 +9111,27 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 421,
+    "aggregatedRank": 424,
     "countryRank": 1
+  },
+  {
+    "name": "University of Newcastle - Australia",
+    "country": "Australia",
+    "aggregatedScore": 774.8125,
+    "originalRankings": {
+      "qs": {
+        "rank": 179
+      },
+      "the": {
+        "rank": 251
+      },
+      "arwu": {
+        "rank": 401
+      }
+    },
+    "appearances": 3,
+    "aggregatedRank": 425,
+    "countryRank": 26
   },
   {
     "name": "Indian Institute of Science",
@@ -9025,7 +9149,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 422,
+    "aggregatedRank": 426,
     "countryRank": 1
   },
   {
@@ -9044,7 +9168,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 423,
+    "aggregatedRank": 427,
     "countryRank": 22
   },
   {
@@ -9063,8 +9187,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 424,
-    "countryRank": 94
+    "aggregatedRank": 428,
+    "countryRank": 98
   },
   {
     "name": "Prince Sattam Bin Abdulaziz University",
@@ -9082,7 +9206,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 425,
+    "aggregatedRank": 429,
     "countryRank": 7
   },
   {
@@ -9101,7 +9225,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 426,
+    "aggregatedRank": 430,
     "countryRank": 1
   },
   {
@@ -9120,7 +9244,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 427,
+    "aggregatedRank": 431,
     "countryRank": 23
   },
   {
@@ -9139,7 +9263,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 428,
+    "aggregatedRank": 432,
     "countryRank": 24
   },
   {
@@ -9158,7 +9282,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 429,
+    "aggregatedRank": 433,
     "countryRank": 25
   },
   {
@@ -9177,8 +9301,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 430,
-    "countryRank": 51
+    "aggregatedRank": 434,
+    "countryRank": 49
   },
   {
     "name": "Tsukuba University",
@@ -9196,7 +9320,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 431,
+    "aggregatedRank": 435,
     "countryRank": 10
   },
   {
@@ -9215,8 +9339,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 432,
-    "countryRank": 52
+    "aggregatedRank": 436,
+    "countryRank": 50
   },
   {
     "name": "University of Li�ge",
@@ -9234,27 +9358,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 433,
+    "aggregatedRank": 437,
     "countryRank": 6
-  },
-  {
-    "name": "University of California - Riverside",
-    "country": "United States",
-    "aggregatedScore": 749,
-    "originalRankings": {
-      "qs": {
-        "rank": 497
-      },
-      "the": {
-        "rank": 251
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 434,
-    "countryRank": 95
   },
   {
     "name": "Nanjing Normal University",
@@ -9272,8 +9377,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 435,
-    "countryRank": 53
+    "aggregatedRank": 438,
+    "countryRank": 51
   },
   {
     "name": "University of Montpellier",
@@ -9291,7 +9396,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 436,
+    "aggregatedRank": 439,
     "countryRank": 9
   },
   {
@@ -9310,27 +9415,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 437,
-    "countryRank": 54
-  },
-  {
-    "name": "University of Tennessee - Knoxville",
-    "country": "United States",
-    "aggregatedScore": 741.5625,
-    "originalRankings": {
-      "qs": {
-        "rank": 481
-      },
-      "the": {
-        "rank": 301
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 438,
-    "countryRank": 96
+    "aggregatedRank": 440,
+    "countryRank": 52
   },
   {
     "name": "State University of Campinas",
@@ -9348,7 +9434,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 439,
+    "aggregatedRank": 441,
     "countryRank": 2
   },
   {
@@ -9367,7 +9453,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 440,
+    "aggregatedRank": 442,
     "countryRank": 27
   },
   {
@@ -9386,7 +9472,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 441,
+    "aggregatedRank": 443,
     "countryRank": 4
   },
   {
@@ -9405,7 +9491,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 442,
+    "aggregatedRank": 444,
     "countryRank": 5
   },
   {
@@ -9424,7 +9510,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 443,
+    "aggregatedRank": 445,
     "countryRank": 3
   },
   {
@@ -9443,7 +9529,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 444,
+    "aggregatedRank": 446,
     "countryRank": 3
   },
   {
@@ -9462,8 +9548,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 445,
-    "countryRank": 3
+    "aggregatedRank": 447,
+    "countryRank": 4
   },
   {
     "name": "University of Jena",
@@ -9481,7 +9567,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 446,
+    "aggregatedRank": 448,
     "countryRank": 26
   },
   {
@@ -9500,8 +9586,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 447,
-    "countryRank": 97
+    "aggregatedRank": 449,
+    "countryRank": 99
   },
   {
     "name": "Flinders University",
@@ -9519,7 +9605,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 448,
+    "aggregatedRank": 450,
     "countryRank": 28
   },
   {
@@ -9538,8 +9624,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 449,
-    "countryRank": 98
+    "aggregatedRank": 451,
+    "countryRank": 100
   },
   {
     "name": "Victoria University of Wellington",
@@ -9557,7 +9643,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 450,
+    "aggregatedRank": 452,
     "countryRank": 5
   },
   {
@@ -9576,7 +9662,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 451,
+    "aggregatedRank": 453,
     "countryRank": 27
   },
   {
@@ -9595,7 +9681,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 452,
+    "aggregatedRank": 454,
     "countryRank": 1
   },
   {
@@ -9614,8 +9700,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 453,
-    "countryRank": 99
+    "aggregatedRank": 455,
+    "countryRank": 101
   },
   {
     "name": "Macau University of Science and Technology",
@@ -9633,7 +9719,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 454,
+    "aggregatedRank": 456,
     "countryRank": 2
   },
   {
@@ -9652,8 +9738,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 455,
-    "countryRank": 4
+    "aggregatedRank": 457,
+    "countryRank": 5
   },
   {
     "name": "University of Kent at Canterbury",
@@ -9671,7 +9757,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 456,
+    "aggregatedRank": 458,
     "countryRank": 40
   },
   {
@@ -9690,7 +9776,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 457,
+    "aggregatedRank": 459,
     "countryRank": 10
   },
   {
@@ -9709,7 +9795,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 458,
+    "aggregatedRank": 460,
     "countryRank": 2
   },
   {
@@ -9728,8 +9814,27 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 459,
+    "aggregatedRank": 461,
     "countryRank": 3
+  },
+  {
+    "name": "York University",
+    "country": "Canada",
+    "aggregatedScore": 701.96875,
+    "originalRankings": {
+      "qs": {
+        "rank": 362
+      },
+      "the": {
+        "rank": 401
+      },
+      "arwu": {
+        "rank": 401
+      }
+    },
+    "appearances": 3,
+    "aggregatedRank": 462,
+    "countryRank": 19
   },
   {
     "name": "University Claude Bernard - Lyon I",
@@ -9747,7 +9852,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 460,
+    "aggregatedRank": 463,
     "countryRank": 11
   },
   {
@@ -9766,8 +9871,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 461,
-    "countryRank": 55
+    "aggregatedRank": 464,
+    "countryRank": 53
   },
   {
     "name": "University of Hannover",
@@ -9785,27 +9890,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 462,
+    "aggregatedRank": 465,
     "countryRank": 28
-  },
-  {
-    "name": "Pontifical Catholic University of Chile",
-    "country": "Chile",
-    "aggregatedScore": 695.1875,
-    "originalRankings": {
-      "qs": {
-        "rank": 93
-      },
-      "the": {
-        "rank": 501
-      },
-      "arwu": {
-        "rank": 601
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 463,
-    "countryRank": 1
   },
   {
     "name": "University of Athens",
@@ -9823,7 +9909,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 464,
+    "aggregatedRank": 466,
     "countryRank": 3
   },
   {
@@ -9842,8 +9928,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 465,
-    "countryRank": 56
+    "aggregatedRank": 467,
+    "countryRank": 54
   },
   {
     "name": "Moscow Institute of Physics and Technology",
@@ -9861,7 +9947,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 466,
+    "aggregatedRank": 468,
     "countryRank": 2
   },
   {
@@ -9880,7 +9966,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 467,
+    "aggregatedRank": 469,
     "countryRank": 29
   },
   {
@@ -9899,7 +9985,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 468,
+    "aggregatedRank": 470,
     "countryRank": 4
   },
   {
@@ -9918,7 +10004,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 469,
+    "aggregatedRank": 471,
     "countryRank": 30
   },
   {
@@ -9937,8 +10023,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 470,
-    "countryRank": 57
+    "aggregatedRank": 472,
+    "countryRank": 55
   },
   {
     "name": "University of Coimbra",
@@ -9956,7 +10042,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 471,
+    "aggregatedRank": 473,
     "countryRank": 2
   },
   {
@@ -9975,8 +10061,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 472,
-    "countryRank": 100
+    "aggregatedRank": 474,
+    "countryRank": 102
   },
   {
     "name": "University of Tampere",
@@ -9994,7 +10080,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 473,
+    "aggregatedRank": 475,
     "countryRank": 6
   },
   {
@@ -10013,8 +10099,27 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 474,
+    "aggregatedRank": 476,
     "countryRank": 4
+  },
+  {
+    "name": "Jinan University - Guangdong",
+    "country": "China",
+    "aggregatedScore": 676.15625,
+    "originalRankings": {
+      "qs": {
+        "rank": 580
+      },
+      "the": {
+        "rank": 501
+      },
+      "arwu": {
+        "rank": 201
+      }
+    },
+    "appearances": 3,
+    "aggregatedRank": 477,
+    "countryRank": 56
   },
   {
     "name": "University of Alabama Birmingham",
@@ -10032,8 +10137,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 475,
-    "countryRank": 101
+    "aggregatedRank": 478,
+    "countryRank": 103
   },
   {
     "name": "University of Giessen",
@@ -10051,7 +10156,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 476,
+    "aggregatedRank": 479,
     "countryRank": 31
   },
   {
@@ -10070,8 +10175,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 477,
-    "countryRank": 58
+    "aggregatedRank": 480,
+    "countryRank": 57
   },
   {
     "name": "Tilburg University",
@@ -10089,7 +10194,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 478,
+    "aggregatedRank": 481,
     "countryRank": 12
   },
   {
@@ -10108,7 +10213,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 479,
+    "aggregatedRank": 482,
     "countryRank": 32
   },
   {
@@ -10127,7 +10232,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 480,
+    "aggregatedRank": 483,
     "countryRank": 8
   },
   {
@@ -10146,27 +10251,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 481,
+    "aggregatedRank": 484,
     "countryRank": 41
-  },
-  {
-    "name": "University of Missouri - Columbia",
-    "country": "United States",
-    "aggregatedScore": 662.8125,
-    "originalRankings": {
-      "qs": {
-        "rank": 641
-      },
-      "the": {
-        "rank": 501
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 482,
-    "countryRank": 102
   },
   {
     "name": "University of Duisburg-Essen",
@@ -10184,7 +10270,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 483,
+    "aggregatedRank": 485,
     "countryRank": 33
   },
   {
@@ -10203,7 +10289,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 484,
+    "aggregatedRank": 486,
     "countryRank": 3
   },
   {
@@ -10222,7 +10308,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 485,
+    "aggregatedRank": 487,
     "countryRank": 1
   },
   {
@@ -10241,7 +10327,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 486,
+    "aggregatedRank": 488,
     "countryRank": 34
   },
   {
@@ -10260,26 +10346,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 487,
-    "countryRank": 103
-  },
-  {
-    "name": "University of Nebraska - Lincoln",
-    "country": "United States",
-    "aggregatedScore": 649.6875,
-    "originalRankings": {
-      "qs": {
-        "rank": 701
-      },
-      "the": {
-        "rank": 401
-      },
-      "arwu": {
-        "rank": 301
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 488,
+    "aggregatedRank": 489,
     "countryRank": 104
   },
   {
@@ -10298,7 +10365,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 489,
+    "aggregatedRank": 490,
     "countryRank": 3
   },
   {
@@ -10317,7 +10384,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 490,
+    "aggregatedRank": 491,
     "countryRank": 2
   },
   {
@@ -10336,7 +10403,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 491,
+    "aggregatedRank": 492,
     "countryRank": 10
   },
   {
@@ -10355,7 +10422,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 492,
+    "aggregatedRank": 493,
     "countryRank": 4
   },
   {
@@ -10374,7 +10441,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 493,
+    "aggregatedRank": 494,
     "countryRank": 105
   },
   {
@@ -10393,7 +10460,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 494,
+    "aggregatedRank": 495,
     "countryRank": 11
   },
   {
@@ -10412,8 +10479,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 495,
-    "countryRank": 59
+    "aggregatedRank": 496,
+    "countryRank": 58
   },
   {
     "name": "University of Waikato",
@@ -10431,7 +10498,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 496,
+    "aggregatedRank": 497,
     "countryRank": 6
   },
   {
@@ -10450,7 +10517,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 497,
+    "aggregatedRank": 498,
     "countryRank": 35
   },
   {
@@ -10469,7 +10536,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 498,
+    "aggregatedRank": 499,
     "countryRank": 10
   },
   {
@@ -10488,7 +10555,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 499,
+    "aggregatedRank": 500,
     "countryRank": 9
   },
   {
@@ -10507,7 +10574,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 500,
+    "aggregatedRank": 501,
     "countryRank": 1
   },
   {
@@ -10526,7 +10593,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 501,
+    "aggregatedRank": 502,
     "countryRank": 2
   },
   {
@@ -10545,7 +10612,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 502,
+    "aggregatedRank": 503,
     "countryRank": 42
   },
   {
@@ -10564,8 +10631,27 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 503,
+    "aggregatedRank": 504,
     "countryRank": 4
+  },
+  {
+    "name": "China University of Mining & Technology",
+    "country": "China",
+    "aggregatedScore": 635.4250000000001,
+    "originalRankings": {
+      "qs": {
+        "rank": 681
+      },
+      "arwu": {
+        "rank": 401
+      },
+      "usnews": {
+        "rank": 560
+      }
+    },
+    "appearances": 3,
+    "aggregatedRank": 505,
+    "countryRank": 59
   },
   {
     "name": "Bangor University",
@@ -10583,7 +10669,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 504,
+    "aggregatedRank": 506,
     "countryRank": 43
   },
   {
@@ -10602,7 +10688,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 505,
+    "aggregatedRank": 507,
     "countryRank": 60
   },
   {
@@ -10621,7 +10707,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 506,
+    "aggregatedRank": 508,
     "countryRank": 8
   },
   {
@@ -10640,7 +10726,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 507,
+    "aggregatedRank": 509,
     "countryRank": 1
   },
   {
@@ -10659,8 +10745,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 508,
-    "countryRank": 5
+    "aggregatedRank": 510,
+    "countryRank": 6
   },
   {
     "name": "University of Texas at Dallas",
@@ -10678,7 +10764,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 509,
+    "aggregatedRank": 511,
     "countryRank": 106
   },
   {
@@ -10697,7 +10783,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 510,
+    "aggregatedRank": 512,
     "countryRank": 107
   },
   {
@@ -10716,7 +10802,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 511,
+    "aggregatedRank": 513,
     "countryRank": 108
   },
   {
@@ -10735,7 +10821,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 512,
+    "aggregatedRank": 514,
     "countryRank": 36
   },
   {
@@ -10754,7 +10840,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 513,
+    "aggregatedRank": 515,
     "countryRank": 109
   },
   {
@@ -10773,7 +10859,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 514,
+    "aggregatedRank": 516,
     "countryRank": 44
   },
   {
@@ -10792,7 +10878,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 515,
+    "aggregatedRank": 517,
     "countryRank": 3
   },
   {
@@ -10811,7 +10897,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 516,
+    "aggregatedRank": 518,
     "countryRank": 20
   },
   {
@@ -10830,7 +10916,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 517,
+    "aggregatedRank": 519,
     "countryRank": 3
   },
   {
@@ -10849,7 +10935,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 518,
+    "aggregatedRank": 520,
     "countryRank": 4
   },
   {
@@ -10868,7 +10954,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 519,
+    "aggregatedRank": 521,
     "countryRank": 110
   },
   {
@@ -10887,7 +10973,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 520,
+    "aggregatedRank": 522,
     "countryRank": 7
   },
   {
@@ -10906,7 +10992,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 521,
+    "aggregatedRank": 523,
     "countryRank": 61
   },
   {
@@ -10925,7 +11011,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 522,
+    "aggregatedRank": 524,
     "countryRank": 11
   },
   {
@@ -10944,7 +11030,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 523,
+    "aggregatedRank": 525,
     "countryRank": 7
   },
   {
@@ -10963,7 +11049,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 524,
+    "aggregatedRank": 526,
     "countryRank": 11
   },
   {
@@ -10982,7 +11068,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 525,
+    "aggregatedRank": 527,
     "countryRank": 12
   },
   {
@@ -11001,7 +11087,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 526,
+    "aggregatedRank": 528,
     "countryRank": 13
   },
   {
@@ -11020,7 +11106,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 527,
+    "aggregatedRank": 529,
     "countryRank": 14
   },
   {
@@ -11039,8 +11125,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 528,
-    "countryRank": 26
+    "aggregatedRank": 530,
+    "countryRank": 27
   },
   {
     "name": "University of KwaZulu-Natal",
@@ -11058,7 +11144,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 529,
+    "aggregatedRank": 531,
     "countryRank": 6
   },
   {
@@ -11077,7 +11163,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 530,
+    "aggregatedRank": 532,
     "countryRank": 5
   },
   {
@@ -11096,7 +11182,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 531,
+    "aggregatedRank": 533,
     "countryRank": 12
   },
   {
@@ -11115,7 +11201,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 532,
+    "aggregatedRank": 534,
     "countryRank": 7
   },
   {
@@ -11134,7 +11220,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 533,
+    "aggregatedRank": 535,
     "countryRank": 12
   },
   {
@@ -11153,7 +11239,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 534,
+    "aggregatedRank": 536,
     "countryRank": 29
   },
   {
@@ -11172,7 +11258,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 535,
+    "aggregatedRank": 537,
     "countryRank": 13
   },
   {
@@ -11191,7 +11277,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 536,
+    "aggregatedRank": 538,
     "countryRank": 45
   },
   {
@@ -11210,7 +11296,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 537,
+    "aggregatedRank": 539,
     "countryRank": 13
   },
   {
@@ -11229,7 +11315,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 538,
+    "aggregatedRank": 540,
     "countryRank": 5
   },
   {
@@ -11248,7 +11334,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 539,
+    "aggregatedRank": 541,
     "countryRank": 46
   },
   {
@@ -11267,7 +11353,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 540,
+    "aggregatedRank": 542,
     "countryRank": 13
   },
   {
@@ -11286,7 +11372,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 541,
+    "aggregatedRank": 543,
     "countryRank": 47
   },
   {
@@ -11305,7 +11391,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 542,
+    "aggregatedRank": 544,
     "countryRank": 5
   },
   {
@@ -11324,8 +11410,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 543,
-    "countryRank": 27
+    "aggregatedRank": 545,
+    "countryRank": 28
   },
   {
     "name": "Umm Al-Qura University",
@@ -11343,27 +11429,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 544,
+    "aggregatedRank": 546,
     "countryRank": 9
-  },
-  {
-    "name": "China University of Mining & Technology",
-    "country": "China",
-    "aggregatedScore": 591.6750000000001,
-    "originalRankings": {
-      "qs": {
-        "rank": 681
-      },
-      "arwu": {
-        "rank": 601
-      },
-      "usnews": {
-        "rank": 560
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 545,
-    "countryRank": 62
   },
   {
     "name": "Dublin City University",
@@ -11381,7 +11448,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 546,
+    "aggregatedRank": 547,
     "countryRank": 5
   },
   {
@@ -11400,7 +11467,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 547,
+    "aggregatedRank": 548,
     "countryRank": 5
   },
   {
@@ -11419,7 +11486,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 548,
+    "aggregatedRank": 549,
     "countryRank": 7
   },
   {
@@ -11438,7 +11505,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 549,
+    "aggregatedRank": 550,
     "countryRank": 48
   },
   {
@@ -11457,8 +11524,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 550,
-    "countryRank": 6
+    "aggregatedRank": 551,
+    "countryRank": 7
   },
   {
     "name": "Iran University of Science and Technology Tehran",
@@ -11476,7 +11543,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 551,
+    "aggregatedRank": 552,
     "countryRank": 6
   },
   {
@@ -11495,7 +11562,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 552,
+    "aggregatedRank": 553,
     "countryRank": 4
   },
   {
@@ -11511,7 +11578,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 553,
+    "aggregatedRank": 554,
     "countryRank": 5
   },
   {
@@ -11530,7 +11597,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 554,
+    "aggregatedRank": 555,
     "countryRank": 5
   },
   {
@@ -11549,7 +11616,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 555,
+    "aggregatedRank": 556,
     "countryRank": 14
   },
   {
@@ -11568,7 +11635,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 556,
+    "aggregatedRank": 557,
     "countryRank": 15
   },
   {
@@ -11587,7 +11654,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 557,
+    "aggregatedRank": 558,
     "countryRank": 6
   },
   {
@@ -11606,8 +11673,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 558,
-    "countryRank": 7
+    "aggregatedRank": 559,
+    "countryRank": 8
   },
   {
     "name": "University of Limerick",
@@ -11625,7 +11692,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 559,
+    "aggregatedRank": 560,
     "countryRank": 6
   },
   {
@@ -11644,7 +11711,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 560,
+    "aggregatedRank": 561,
     "countryRank": 14
   },
   {
@@ -11663,7 +11730,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 561,
+    "aggregatedRank": 562,
     "countryRank": 2
   },
   {
@@ -11682,7 +11749,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 562,
+    "aggregatedRank": 563,
     "countryRank": 15
   },
   {
@@ -11701,7 +11768,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 563,
+    "aggregatedRank": 564,
     "countryRank": 21
   },
   {
@@ -11720,7 +11787,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 564,
+    "aggregatedRank": 565,
     "countryRank": 12
   },
   {
@@ -11739,7 +11806,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 565,
+    "aggregatedRank": 566,
     "countryRank": 4
   },
   {
@@ -11758,7 +11825,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 566,
+    "aggregatedRank": 567,
     "countryRank": 1
   },
   {
@@ -11777,7 +11844,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 567,
+    "aggregatedRank": 568,
     "countryRank": 13
   },
   {
@@ -11796,7 +11863,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 568,
+    "aggregatedRank": 569,
     "countryRank": 8
   },
   {
@@ -11812,7 +11879,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 569,
+    "aggregatedRank": 570,
     "countryRank": 6
   },
   {
@@ -11831,8 +11898,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 570,
-    "countryRank": 63
+    "aggregatedRank": 571,
+    "countryRank": 62
   },
   {
     "name": "Texas Technical University",
@@ -11850,7 +11917,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 571,
+    "aggregatedRank": 572,
     "countryRank": 111
   },
   {
@@ -11869,8 +11936,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 572,
-    "countryRank": 28
+    "aggregatedRank": 573,
+    "countryRank": 29
   },
   {
     "name": "Rutgers - The State University of New Jersey",
@@ -11888,7 +11955,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 573,
+    "aggregatedRank": 574,
     "countryRank": 112
   },
   {
@@ -11907,7 +11974,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 574,
+    "aggregatedRank": 575,
     "countryRank": 37
   },
   {
@@ -11926,7 +11993,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 575,
+    "aggregatedRank": 576,
     "countryRank": 49
   },
   {
@@ -11945,8 +12012,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 576,
-    "countryRank": 29
+    "aggregatedRank": 577,
+    "countryRank": 30
   },
   {
     "name": "Institut National des Sciences Appliqu�es de Toulouse",
@@ -11964,7 +12031,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 577,
+    "aggregatedRank": 578,
     "countryRank": 16
   },
   {
@@ -11983,8 +12050,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 578,
-    "countryRank": 30
+    "aggregatedRank": 579,
+    "countryRank": 31
   },
   {
     "name": "Graz University of Technology",
@@ -12002,7 +12069,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 579,
+    "aggregatedRank": 580,
     "countryRank": 9
   },
   {
@@ -12021,7 +12088,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 580,
+    "aggregatedRank": 581,
     "countryRank": 16
   },
   {
@@ -12040,8 +12107,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 581,
-    "countryRank": 64
+    "aggregatedRank": 582,
+    "countryRank": 63
   },
   {
     "name": "Chang Gung University",
@@ -12059,8 +12126,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 582,
-    "countryRank": 8
+    "aggregatedRank": 583,
+    "countryRank": 9
   },
   {
     "name": "University of Salamanca",
@@ -12078,7 +12145,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 583,
+    "aggregatedRank": 584,
     "countryRank": 14
   },
   {
@@ -12097,7 +12164,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 584,
+    "aggregatedRank": 585,
     "countryRank": 5
   },
   {
@@ -12116,8 +12183,27 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 585,
+    "aggregatedRank": 586,
     "countryRank": 38
+  },
+  {
+    "name": "Donghua University - Shanghai",
+    "country": "China",
+    "aggregatedScore": 551.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 851
+      },
+      "the": {
+        "rank": 501
+      },
+      "arwu": {
+        "rank": 501
+      }
+    },
+    "appearances": 3,
+    "aggregatedRank": 587,
+    "countryRank": 64
   },
   {
     "name": "St. Louis University",
@@ -12135,7 +12221,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 586,
+    "aggregatedRank": 588,
     "countryRank": 113
   },
   {
@@ -12154,7 +12240,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 587,
+    "aggregatedRank": 589,
     "countryRank": 2
   },
   {
@@ -12173,7 +12259,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 588,
+    "aggregatedRank": 590,
     "countryRank": 50
   },
   {
@@ -12192,7 +12278,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 589,
+    "aggregatedRank": 591,
     "countryRank": 51
   },
   {
@@ -12211,7 +12297,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 590,
+    "aggregatedRank": 592,
     "countryRank": 1
   },
   {
@@ -12230,8 +12316,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 591,
-    "countryRank": 31
+    "aggregatedRank": 593,
+    "countryRank": 32
   },
   {
     "name": "University of Greenwich",
@@ -12249,7 +12335,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 592,
+    "aggregatedRank": 594,
     "countryRank": 52
   },
   {
@@ -12268,7 +12354,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 593,
+    "aggregatedRank": 595,
     "countryRank": 3
   },
   {
@@ -12287,7 +12373,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 594,
+    "aggregatedRank": 596,
     "countryRank": 39
   },
   {
@@ -12306,8 +12392,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 595,
-    "countryRank": 9
+    "aggregatedRank": 597,
+    "countryRank": 10
   },
   {
     "name": "University of California San Francisco",
@@ -12322,7 +12408,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 596,
+    "aggregatedRank": 598,
     "countryRank": 114
   },
   {
@@ -12341,7 +12427,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 597,
+    "aggregatedRank": 599,
     "countryRank": 53
   },
   {
@@ -12360,7 +12446,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 598,
+    "aggregatedRank": 600,
     "countryRank": 54
   },
   {
@@ -12379,8 +12465,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 599,
-    "countryRank": 32
+    "aggregatedRank": 601,
+    "countryRank": 33
   },
   {
     "name": "University of Nantes",
@@ -12398,7 +12484,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 600,
+    "aggregatedRank": 602,
     "countryRank": 17
   },
   {
@@ -12417,7 +12503,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 601,
+    "aggregatedRank": 603,
     "countryRank": 115
   },
   {
@@ -12436,7 +12522,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 602,
+    "aggregatedRank": 604,
     "countryRank": 116
   },
   {
@@ -12455,7 +12541,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 603,
+    "aggregatedRank": 605,
     "countryRank": 22
   },
   {
@@ -12471,7 +12557,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 604,
+    "aggregatedRank": 606,
     "countryRank": 6
   },
   {
@@ -12490,7 +12576,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 605,
+    "aggregatedRank": 607,
     "countryRank": 6
   },
   {
@@ -12509,7 +12595,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 606,
+    "aggregatedRank": 608,
     "countryRank": 117
   },
   {
@@ -12528,7 +12614,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 607,
+    "aggregatedRank": 609,
     "countryRank": 15
   },
   {
@@ -12547,7 +12633,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 608,
+    "aggregatedRank": 610,
     "countryRank": 118
   },
   {
@@ -12566,7 +12652,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 609,
+    "aggregatedRank": 611,
     "countryRank": 55
   },
   {
@@ -12582,7 +12668,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 610,
+    "aggregatedRank": 612,
     "countryRank": 119
   },
   {
@@ -12601,7 +12687,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 611,
+    "aggregatedRank": 613,
     "countryRank": 10
   },
   {
@@ -12620,7 +12706,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 612,
+    "aggregatedRank": 614,
     "countryRank": 4
   },
   {
@@ -12636,7 +12722,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 613,
+    "aggregatedRank": 615,
     "countryRank": 120
   },
   {
@@ -12652,7 +12738,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 614,
+    "aggregatedRank": 616,
     "countryRank": 121
   },
   {
@@ -12668,7 +12754,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 615,
+    "aggregatedRank": 617,
     "countryRank": 2
   },
   {
@@ -12687,8 +12773,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 616,
-    "countryRank": 33
+    "aggregatedRank": 618,
+    "countryRank": 34
   },
   {
     "name": "Ajou University",
@@ -12706,7 +12792,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 617,
+    "aggregatedRank": 619,
     "countryRank": 17
   },
   {
@@ -12725,7 +12811,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 618,
+    "aggregatedRank": 620,
     "countryRank": 18
   },
   {
@@ -12744,7 +12830,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 619,
+    "aggregatedRank": 621,
     "countryRank": 16
   },
   {
@@ -12760,7 +12846,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 620,
+    "aggregatedRank": 622,
     "countryRank": 122
   },
   {
@@ -12779,7 +12865,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 621,
+    "aggregatedRank": 623,
     "countryRank": 4
   },
   {
@@ -12798,7 +12884,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 622,
+    "aggregatedRank": 624,
     "countryRank": 123
   },
   {
@@ -12817,8 +12903,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 623,
-    "countryRank": 34
+    "aggregatedRank": 625,
+    "countryRank": 35
   },
   {
     "name": "Yeungnam University",
@@ -12836,7 +12922,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 624,
+    "aggregatedRank": 626,
     "countryRank": 19
   },
   {
@@ -12855,7 +12941,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 625,
+    "aggregatedRank": 627,
     "countryRank": 124
   },
   {
@@ -12871,7 +12957,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 626,
+    "aggregatedRank": 628,
     "countryRank": 7
   },
   {
@@ -12887,7 +12973,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 627,
+    "aggregatedRank": 629,
     "countryRank": 6
   },
   {
@@ -12903,7 +12989,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 628,
+    "aggregatedRank": 630,
     "countryRank": 8
   },
   {
@@ -12922,7 +13008,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 629,
+    "aggregatedRank": 631,
     "countryRank": 3
   },
   {
@@ -12941,7 +13027,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 630,
+    "aggregatedRank": 632,
     "countryRank": 10
   },
   {
@@ -12960,7 +13046,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 631,
+    "aggregatedRank": 633,
     "countryRank": 7
   },
   {
@@ -12979,7 +13065,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 632,
+    "aggregatedRank": 634,
     "countryRank": 7
   },
   {
@@ -12995,7 +13081,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 633,
+    "aggregatedRank": 635,
     "countryRank": 8
   },
   {
@@ -13011,7 +13097,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 634,
+    "aggregatedRank": 636,
     "countryRank": 1
   },
   {
@@ -13030,7 +13116,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 635,
+    "aggregatedRank": 637,
     "countryRank": 17
   },
   {
@@ -13046,7 +13132,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 636,
+    "aggregatedRank": 638,
     "countryRank": 5
   },
   {
@@ -13062,7 +13148,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 637,
+    "aggregatedRank": 639,
     "countryRank": 56
   },
   {
@@ -13081,7 +13167,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 638,
+    "aggregatedRank": 640,
     "countryRank": 6
   },
   {
@@ -13100,7 +13186,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 639,
+    "aggregatedRank": 641,
     "countryRank": 125
   },
   {
@@ -13116,7 +13202,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 640,
+    "aggregatedRank": 642,
     "countryRank": 20
   },
   {
@@ -13135,7 +13221,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 641,
+    "aggregatedRank": 643,
     "countryRank": 15
   },
   {
@@ -13154,7 +13240,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 642,
+    "aggregatedRank": 644,
     "countryRank": 21
   },
   {
@@ -13173,7 +13259,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 643,
+    "aggregatedRank": 645,
     "countryRank": 4
   },
   {
@@ -13189,7 +13275,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 644,
+    "aggregatedRank": 646,
     "countryRank": 40
   },
   {
@@ -13205,7 +13291,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 645,
+    "aggregatedRank": 647,
     "countryRank": 5
   },
   {
@@ -13224,7 +13310,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 646,
+    "aggregatedRank": 648,
     "countryRank": 11
   },
   {
@@ -13240,7 +13326,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 647,
+    "aggregatedRank": 649,
     "countryRank": 57
   },
   {
@@ -13256,7 +13342,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 648,
+    "aggregatedRank": 650,
     "countryRank": 18
   },
   {
@@ -13272,7 +13358,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 649,
+    "aggregatedRank": 651,
     "countryRank": 4
   },
   {
@@ -13291,7 +13377,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 650,
+    "aggregatedRank": 652,
     "countryRank": 23
   },
   {
@@ -13310,7 +13396,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 651,
+    "aggregatedRank": 653,
     "countryRank": 22
   },
   {
@@ -13326,7 +13412,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 652,
+    "aggregatedRank": 654,
     "countryRank": 126
   },
   {
@@ -13345,7 +13431,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 653,
+    "aggregatedRank": 655,
     "countryRank": 7
   },
   {
@@ -13364,7 +13450,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 654,
+    "aggregatedRank": 656,
     "countryRank": 4
   },
   {
@@ -13383,7 +13469,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 655,
+    "aggregatedRank": 657,
     "countryRank": 23
   },
   {
@@ -13402,7 +13488,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 656,
+    "aggregatedRank": 658,
     "countryRank": 127
   },
   {
@@ -13418,7 +13504,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 657,
+    "aggregatedRank": 659,
     "countryRank": 24
   },
   {
@@ -13434,7 +13520,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 658,
+    "aggregatedRank": 660,
     "countryRank": 12
   },
   {
@@ -13450,7 +13536,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 659,
+    "aggregatedRank": 661,
     "countryRank": 58
   },
   {
@@ -13466,7 +13552,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 660,
+    "aggregatedRank": 662,
     "countryRank": 4
   },
   {
@@ -13482,7 +13568,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 661,
+    "aggregatedRank": 663,
     "countryRank": 2
   },
   {
@@ -13501,7 +13587,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 662,
+    "aggregatedRank": 664,
     "countryRank": 7
   },
   {
@@ -13517,7 +13603,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 663,
+    "aggregatedRank": 665,
     "countryRank": 7
   },
   {
@@ -13536,7 +13622,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 664,
+    "aggregatedRank": 666,
     "countryRank": 3
   },
   {
@@ -13552,7 +13638,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 665,
+    "aggregatedRank": 667,
     "countryRank": 8
   },
   {
@@ -13568,24 +13654,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 666,
+    "aggregatedRank": 668,
     "countryRank": 1
-  },
-  {
-    "name": "China University of Geosciences",
-    "country": "China",
-    "aggregatedScore": 444.46875,
-    "originalRankings": {
-      "arwu": {
-        "rank": 301
-      },
-      "usnews": {
-        "rank": 221
-      }
-    },
-    "appearances": 2,
-    "aggregatedRank": 667,
-    "countryRank": 65
   },
   {
     "name": "School of Oriental and African Studies - University of London",
@@ -13600,7 +13670,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 668,
+    "aggregatedRank": 669,
     "countryRank": 59
   },
   {
@@ -13619,7 +13689,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 669,
+    "aggregatedRank": 670,
     "countryRank": 60
   },
   {
@@ -13638,7 +13708,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 670,
+    "aggregatedRank": 671,
     "countryRank": 128
   },
   {
@@ -13654,7 +13724,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 671,
+    "aggregatedRank": 672,
     "countryRank": 6
   },
   {
@@ -13670,7 +13740,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 672,
+    "aggregatedRank": 673,
     "countryRank": 129
   },
   {
@@ -13686,7 +13756,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 673,
+    "aggregatedRank": 674,
     "countryRank": 7
   },
   {
@@ -13702,7 +13772,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 674,
+    "aggregatedRank": 675,
     "countryRank": 6
   },
   {
@@ -13718,7 +13788,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 675,
+    "aggregatedRank": 676,
     "countryRank": 1
   },
   {
@@ -13734,7 +13804,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 676,
+    "aggregatedRank": 677,
     "countryRank": 19
   },
   {
@@ -13750,7 +13820,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 677,
+    "aggregatedRank": 678,
     "countryRank": 130
   },
   {
@@ -13766,8 +13836,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 678,
-    "countryRank": 10
+    "aggregatedRank": 679,
+    "countryRank": 11
   },
   {
     "name": "Al Ain University",
@@ -13782,7 +13852,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 679,
+    "aggregatedRank": 680,
     "countryRank": 7
   },
   {
@@ -13798,7 +13868,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 680,
+    "aggregatedRank": 681,
     "countryRank": 1
   },
   {
@@ -13814,7 +13884,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 681,
+    "aggregatedRank": 682,
     "countryRank": 131
   },
   {
@@ -13830,7 +13900,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 682,
+    "aggregatedRank": 683,
     "countryRank": 8
   },
   {
@@ -13849,8 +13919,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 683,
-    "countryRank": 35
+    "aggregatedRank": 684,
+    "countryRank": 36
   },
   {
     "name": "Indian Institute of Technology Indore",
@@ -13865,7 +13935,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 684,
+    "aggregatedRank": 685,
     "countryRank": 5
   },
   {
@@ -13881,7 +13951,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 685,
+    "aggregatedRank": 686,
     "countryRank": 132
   },
   {
@@ -13897,7 +13967,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 686,
+    "aggregatedRank": 687,
     "countryRank": 30
   },
   {
@@ -13913,7 +13983,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 687,
+    "aggregatedRank": 688,
     "countryRank": 6
   },
   {
@@ -13929,7 +13999,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 688,
+    "aggregatedRank": 689,
     "countryRank": 4
   },
   {
@@ -13945,7 +14015,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 689,
+    "aggregatedRank": 690,
     "countryRank": 31
   },
   {
@@ -13961,7 +14031,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 690,
+    "aggregatedRank": 691,
     "countryRank": 8
   },
   {
@@ -13977,7 +14047,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 691,
+    "aggregatedRank": 692,
     "countryRank": 61
   },
   {
@@ -13993,7 +14063,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 692,
+    "aggregatedRank": 693,
     "countryRank": 1
   },
   {
@@ -14009,7 +14079,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 693,
+    "aggregatedRank": 694,
     "countryRank": 7
   },
   {
@@ -14025,7 +14095,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 694,
+    "aggregatedRank": 695,
     "countryRank": 1
   },
   {
@@ -14041,7 +14111,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 695,
+    "aggregatedRank": 696,
     "countryRank": 13
   },
   {
@@ -14057,7 +14127,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 696,
+    "aggregatedRank": 697,
     "countryRank": 62
   },
   {
@@ -14073,7 +14143,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 697,
+    "aggregatedRank": 698,
     "countryRank": 32
   },
   {
@@ -14089,7 +14159,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 698,
+    "aggregatedRank": 699,
     "countryRank": 9
   },
   {
@@ -14105,7 +14175,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 699,
+    "aggregatedRank": 700,
     "countryRank": 10
   },
   {
@@ -14121,7 +14191,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 700,
+    "aggregatedRank": 701,
     "countryRank": 24
   },
   {
@@ -14137,8 +14207,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 701,
-    "countryRank": 66
+    "aggregatedRank": 702,
+    "countryRank": 65
   },
   {
     "name": "University of Texas Health Science Center at San Antonio",
@@ -14153,7 +14223,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 702,
+    "aggregatedRank": 703,
     "countryRank": 133
   },
   {
@@ -14169,7 +14239,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 703,
+    "aggregatedRank": 704,
     "countryRank": 134
   },
   {
@@ -14188,7 +14258,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 704,
+    "aggregatedRank": 705,
     "countryRank": 1
   },
   {
@@ -14204,7 +14274,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 705,
+    "aggregatedRank": 706,
     "countryRank": 11
   },
   {
@@ -14220,7 +14290,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 706,
+    "aggregatedRank": 707,
     "countryRank": 33
   },
   {
@@ -14236,7 +14306,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 707,
+    "aggregatedRank": 708,
     "countryRank": 8
   },
   {
@@ -14252,7 +14322,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 708,
+    "aggregatedRank": 709,
     "countryRank": 20
   },
   {
@@ -14268,7 +14338,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 709,
+    "aggregatedRank": 710,
     "countryRank": 7
   },
   {
@@ -14287,7 +14357,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 710,
+    "aggregatedRank": 711,
     "countryRank": 18
   },
   {
@@ -14303,8 +14373,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 711,
-    "countryRank": 67
+    "aggregatedRank": 712,
+    "countryRank": 66
   },
   {
     "name": "Ca' Foscari University of Venice",
@@ -14319,8 +14389,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 712,
-    "countryRank": 36
+    "aggregatedRank": 713,
+    "countryRank": 37
   },
   {
     "name": "Stevens Institute of Technology",
@@ -14335,7 +14405,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 713,
+    "aggregatedRank": 714,
     "countryRank": 135
   },
   {
@@ -14351,7 +14421,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 714,
+    "aggregatedRank": 715,
     "countryRank": 136
   },
   {
@@ -14367,8 +14437,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 715,
-    "countryRank": 68
+    "aggregatedRank": 716,
+    "countryRank": 67
   },
   {
     "name": "University of Klagenfurt",
@@ -14383,7 +14453,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 716,
+    "aggregatedRank": 717,
     "countryRank": 11
   },
   {
@@ -14399,7 +14469,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 717,
+    "aggregatedRank": 718,
     "countryRank": 9
   },
   {
@@ -14415,7 +14485,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 718,
+    "aggregatedRank": 719,
     "countryRank": 63
   },
   {
@@ -14431,7 +14501,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 719,
+    "aggregatedRank": 720,
     "countryRank": 34
   },
   {
@@ -14447,7 +14517,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 720,
+    "aggregatedRank": 721,
     "countryRank": 7
   },
   {
@@ -14463,7 +14533,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 721,
+    "aggregatedRank": 722,
     "countryRank": 1
   },
   {
@@ -14482,7 +14552,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 722,
+    "aggregatedRank": 723,
     "countryRank": 35
   },
   {
@@ -14501,7 +14571,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 723,
+    "aggregatedRank": 724,
     "countryRank": 25
   },
   {
@@ -14517,7 +14587,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 724,
+    "aggregatedRank": 725,
     "countryRank": 64
   },
   {
@@ -14533,7 +14603,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 725,
+    "aggregatedRank": 726,
     "countryRank": 137
   },
   {
@@ -14549,7 +14619,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 726,
+    "aggregatedRank": 727,
     "countryRank": 65
   },
   {
@@ -14565,7 +14635,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 727,
+    "aggregatedRank": 728,
     "countryRank": 41
   },
   {
@@ -14581,7 +14651,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 728,
+    "aggregatedRank": 729,
     "countryRank": 12
   },
   {
@@ -14600,7 +14670,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 729,
+    "aggregatedRank": 730,
     "countryRank": 8
   },
   {
@@ -14619,8 +14689,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 730,
-    "countryRank": 37
+    "aggregatedRank": 731,
+    "countryRank": 38
   },
   {
     "name": "Pontifical Catholic University of Rio de Janeiro",
@@ -14635,7 +14705,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 731,
+    "aggregatedRank": 732,
     "countryRank": 8
   },
   {
@@ -14651,7 +14721,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 732,
+    "aggregatedRank": 733,
     "countryRank": 2
   },
   {
@@ -14667,7 +14737,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 733,
+    "aggregatedRank": 734,
     "countryRank": 2
   },
   {
@@ -14683,7 +14753,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 734,
+    "aggregatedRank": 735,
     "countryRank": 5
   },
   {
@@ -14699,7 +14769,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 735,
+    "aggregatedRank": 736,
     "countryRank": 66
   },
   {
@@ -14715,7 +14785,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 736,
+    "aggregatedRank": 737,
     "countryRank": 3
   },
   {
@@ -14731,7 +14801,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 737,
+    "aggregatedRank": 738,
     "countryRank": 9
   },
   {
@@ -14747,24 +14817,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 738,
-    "countryRank": 9
-  },
-  {
-    "name": "China Medical University - Taiwan",
-    "country": "Taiwan",
-    "aggregatedScore": 378.13124999999997,
-    "originalRankings": {
-      "the": {
-        "rank": 301
-      },
-      "arwu": {
-        "rank": 401
-      }
-    },
-    "appearances": 2,
     "aggregatedRank": 739,
-    "countryRank": 11
+    "countryRank": 9
   },
   {
     "name": "Aberystwyth University",
@@ -14869,7 +14923,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 745,
-    "countryRank": 69
+    "countryRank": 68
   },
   {
     "name": "Keele University",
@@ -14901,7 +14955,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 747,
-    "countryRank": 70
+    "countryRank": 69
   },
   {
     "name": "University of Petroleum and Energy Studies",
@@ -15077,7 +15131,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 758,
-    "countryRank": 71
+    "countryRank": 70
   },
   {
     "name": "University of Engineering and Technology Taxila",
@@ -15157,7 +15211,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 763,
-    "countryRank": 72
+    "countryRank": 71
   },
   {
     "name": "Capital University of Medical Sciences",
@@ -15173,7 +15227,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 764,
-    "countryRank": 73
+    "countryRank": 72
   },
   {
     "name": "Northeastern University in China",
@@ -15189,7 +15243,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 765,
-    "countryRank": 74
+    "countryRank": 73
   },
   {
     "name": "University of Technology Brunei",
@@ -15493,7 +15547,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 784,
-    "countryRank": 75
+    "countryRank": 74
   },
   {
     "name": "Shandong University of Science & Technology",
@@ -15509,7 +15563,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 785,
-    "countryRank": 76
+    "countryRank": 75
   },
   {
     "name": "Savitribai Phule Pune University",
@@ -15605,7 +15659,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 791,
-    "countryRank": 77
+    "countryRank": 76
   },
   {
     "name": "Nanjing University of Technology",
@@ -15621,7 +15675,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 792,
-    "countryRank": 78
+    "countryRank": 77
   },
   {
     "name": "Shiraz University of Technology",
@@ -15717,7 +15771,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 798,
-    "countryRank": 38
+    "countryRank": 39
   },
   {
     "name": "University of Westminster",
@@ -15813,7 +15867,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 804,
-    "countryRank": 79
+    "countryRank": 78
   },
   {
     "name": "St George's - University of London",
@@ -15861,7 +15915,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 807,
-    "countryRank": 80
+    "countryRank": 79
   },
   {
     "name": "Jouf University",
@@ -15989,7 +16043,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 815,
-    "countryRank": 81
+    "countryRank": 80
   },
   {
     "name": "North South University",
@@ -16133,7 +16187,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 824,
-    "countryRank": 82
+    "countryRank": 81
   },
   {
     "name": "�rebro University",
@@ -16213,7 +16267,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 829,
-    "countryRank": 83
+    "countryRank": 82
   },
   {
     "name": "Guangzhou Medical University",
@@ -16229,7 +16283,7 @@
     },
     "appearances": 2,
     "aggregatedRank": 830,
-    "countryRank": 84
+    "countryRank": 83
   },
   {
     "name": "University of Strasbourg",
@@ -16248,19 +16302,6 @@
     "countryRank": 22
   },
   {
-    "name": "University of California Berkeley",
-    "country": "united states",
-    "aggregatedScore": 279.140625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 5
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 832,
-    "countryRank": 1
-  },
-  {
     "name": "Universite Paris Cite",
     "country": "France",
     "aggregatedScore": 273.203125,
@@ -16270,34 +16311,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 833,
+    "aggregatedRank": 832,
     "countryRank": 23
-  },
-  {
-    "name": "KU Leuven",
-    "country": "Belgium",
-    "aggregatedScore": 272.421875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 48
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 834,
-    "countryRank": 9
-  },
-  {
-    "name": "Ruprecht Karls University Heidelberg",
-    "country": "Germany",
-    "aggregatedScore": 271.328125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 55
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 835,
-    "countryRank": 43
   },
   {
     "name": "Leiden University",
@@ -16309,21 +16324,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 836,
+    "aggregatedRank": 833,
     "countryRank": 14
-  },
-  {
-    "name": "University of Texas Austin",
-    "country": "united states",
-    "aggregatedScore": 271.171875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 56
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 837,
-    "countryRank": 2
   },
   {
     "name": "University of Science and Technology Beijing",
@@ -16338,8 +16340,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 838,
-    "countryRank": 85
+    "aggregatedRank": 834,
+    "countryRank": 84
   },
   {
     "name": "University of Chinese Academy of Sciences, CAS",
@@ -16351,21 +16353,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 839,
-    "countryRank": 86
-  },
-  {
-    "name": "University of Wisconsin Madison",
-    "country": "united states",
-    "aggregatedScore": 268.359375,
-    "originalRankings": {
-      "usnews": {
-        "rank": 74
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 840,
-    "countryRank": 3
+    "aggregatedRank": 835,
+    "countryRank": 85
   },
   {
     "name": "Universite Paris Saclay",
@@ -16377,7 +16366,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 841,
+    "aggregatedRank": 836,
     "countryRank": 24
   },
   {
@@ -16390,7 +16379,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 842,
+    "aggregatedRank": 837,
     "countryRank": 15
   },
   {
@@ -16403,21 +16392,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 843,
-    "countryRank": 87
-  },
-  {
-    "name": "University of Tokyo",
-    "country": "Japan",
-    "aggregatedScore": 266.796875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 84
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 844,
-    "countryRank": 16
+    "aggregatedRank": 838,
+    "countryRank": 86
   },
   {
     "name": "Ecole Polytechnique Federale de Lausanne",
@@ -16429,8 +16405,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 845,
-    "countryRank": 4
+    "aggregatedRank": 839,
+    "countryRank": 1
   },
   {
     "name": "University of California Davis",
@@ -16442,8 +16418,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 846,
-    "countryRank": 5
+    "aggregatedRank": 840,
+    "countryRank": 2
   },
   {
     "name": "Campus Bio-Medico University of Rome",
@@ -16458,8 +16434,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 847,
-    "countryRank": 39
+    "aggregatedRank": 841,
+    "countryRank": 40
   },
   {
     "name": "Royal Veterinary College",
@@ -16474,7 +16450,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 848,
+    "aggregatedRank": 842,
     "countryRank": 81
   },
   {
@@ -16490,7 +16466,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 849,
+    "aggregatedRank": 843,
     "countryRank": 36
   },
   {
@@ -16506,7 +16482,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 850,
+    "aggregatedRank": 844,
     "countryRank": 152
   },
   {
@@ -16522,7 +16498,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 851,
+    "aggregatedRank": 845,
     "countryRank": 153
   },
   {
@@ -16538,7 +16514,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 852,
+    "aggregatedRank": 846,
     "countryRank": 154
   },
   {
@@ -16554,7 +16530,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 853,
+    "aggregatedRank": 847,
     "countryRank": 11
   },
   {
@@ -16570,8 +16546,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 854,
-    "countryRank": 88
+    "aggregatedRank": 848,
+    "countryRank": 87
   },
   {
     "name": "Wenzhou Medical University",
@@ -16586,8 +16562,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 855,
-    "countryRank": 89
+    "aggregatedRank": 849,
+    "countryRank": 88
   },
   {
     "name": "Queen Mary University London",
@@ -16599,7 +16575,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 856,
+    "aggregatedRank": 850,
     "countryRank": 82
   },
   {
@@ -16612,8 +16588,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 857,
-    "countryRank": 6
+    "aggregatedRank": 851,
+    "countryRank": 3
   },
   {
     "name": "Huazhong University of Science & Technology",
@@ -16625,8 +16601,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 858,
-    "countryRank": 90
+    "aggregatedRank": 852,
+    "countryRank": 89
   },
   {
     "name": "King Abdullah University of Science & Technology",
@@ -16638,47 +16614,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 859,
+    "aggregatedRank": 853,
     "countryRank": 1
-  },
-  {
-    "name": "University of California Irvine",
-    "country": "united states",
-    "aggregatedScore": 264.296875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 100
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 860,
-    "countryRank": 7
-  },
-  {
-    "name": "University of Illinois Urbana-Champaign",
-    "country": "united states",
-    "aggregatedScore": 264.296875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 100
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 861,
-    "countryRank": 8
-  },
-  {
-    "name": "Hong Kong University of Science & Technology",
-    "country": "Hong Kong",
-    "aggregatedScore": 263.515625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 105
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 862,
-    "countryRank": 7
   },
   {
     "name": "Ghent University",
@@ -16690,21 +16627,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 863,
-    "countryRank": 10
-  },
-  {
-    "name": "Universite PSL",
-    "country": "France",
-    "aggregatedScore": 262.421875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 112
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 864,
-    "countryRank": 25
+    "aggregatedRank": 854,
+    "countryRank": 9
   },
   {
     "name": "Wageningen University & Research",
@@ -16716,7 +16640,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 865,
+    "aggregatedRank": 855,
     "countryRank": 16
   },
   {
@@ -16729,21 +16653,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 866,
+    "aggregatedRank": 856,
     "countryRank": 17
-  },
-  {
-    "name": "Universidade de Sao Paulo",
-    "country": "Brazil",
-    "aggregatedScore": 260.078125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 127
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 867,
-    "countryRank": 9
   },
   {
     "name": "Indiana University Bloomington",
@@ -16755,8 +16666,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 868,
-    "countryRank": 9
+    "aggregatedRank": 857,
+    "countryRank": 4
   },
   {
     "name": "Sapienza University Rome",
@@ -16768,8 +16679,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 869,
-    "countryRank": 40
+    "aggregatedRank": 858,
+    "countryRank": 41
   },
   {
     "name": "University of Colorado Anschutz Medical Campus",
@@ -16781,8 +16692,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 870,
-    "countryRank": 10
+    "aggregatedRank": 859,
+    "countryRank": 5
   },
   {
     "name": "Oregon Health & Science University",
@@ -16794,8 +16705,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 871,
-    "countryRank": 11
+    "aggregatedRank": 860,
+    "countryRank": 6
   },
   {
     "name": "Rutgers University New Brunswick",
@@ -16807,8 +16718,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 872,
-    "countryRank": 12
+    "aggregatedRank": 861,
+    "countryRank": 7
   },
   {
     "name": "Southern University of Science & Technology",
@@ -16820,8 +16731,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 873,
-    "countryRank": 91
+    "aggregatedRank": 862,
+    "countryRank": 90
   },
   {
     "name": "Newcastle University - UK",
@@ -16833,7 +16744,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 874,
+    "aggregatedRank": 863,
     "countryRank": 83
   },
   {
@@ -16846,7 +16757,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 875,
+    "aggregatedRank": 864,
     "countryRank": 12
   },
   {
@@ -16859,8 +16770,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 876,
-    "countryRank": 13
+    "aggregatedRank": 865,
+    "countryRank": 8
   },
   {
     "name": "University of Gottingen",
@@ -16872,8 +16783,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 877,
-    "countryRank": 44
+    "aggregatedRank": 866,
+    "countryRank": 43
   },
   {
     "name": "Universite de Montreal",
@@ -16885,21 +16796,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 878,
+    "aggregatedRank": 867,
     "countryRank": 28
-  },
-  {
-    "name": "University of Massachusetts Amherst",
-    "country": "united states",
-    "aggregatedScore": 252.578125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 175
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 879,
-    "countryRank": 14
   },
   {
     "name": "Maastricht University",
@@ -16911,7 +16809,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 880,
+    "aggregatedRank": 868,
     "countryRank": 18
   },
   {
@@ -16927,8 +16825,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 881,
-    "countryRank": 45
+    "aggregatedRank": 869,
+    "countryRank": 44
   },
   {
     "name": "Royal Melbourne Institute of Technology (RMIT)",
@@ -16940,7 +16838,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 882,
+    "aggregatedRank": 870,
     "countryRank": 37
   },
   {
@@ -16953,8 +16851,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 883,
-    "countryRank": 46
+    "aggregatedRank": 871,
+    "countryRank": 45
   },
   {
     "name": "Technische Universitat Dresden",
@@ -16966,8 +16864,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 884,
-    "countryRank": 47
+    "aggregatedRank": 872,
+    "countryRank": 46
   },
   {
     "name": "Universite Catholique Louvain",
@@ -16979,8 +16877,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 885,
-    "countryRank": 11
+    "aggregatedRank": 873,
+    "countryRank": 10
   },
   {
     "name": "Indian Institute of Technology - Delhi",
@@ -16995,7 +16893,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 886,
+    "aggregatedRank": 874,
     "countryRank": 18
   },
   {
@@ -17008,8 +16906,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 887,
-    "countryRank": 48
+    "aggregatedRank": 875,
+    "countryRank": 47
   },
   {
     "name": "University of Wuppertal",
@@ -17024,8 +16922,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 888,
-    "countryRank": 49
+    "aggregatedRank": 876,
+    "countryRank": 48
   },
   {
     "name": "University of Nebraska Medical Center",
@@ -17040,7 +16938,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 889,
+    "aggregatedRank": 877,
     "countryRank": 155
   },
   {
@@ -17056,7 +16954,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 890,
+    "aggregatedRank": 878,
     "countryRank": 3
   },
   {
@@ -17072,8 +16970,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 891,
-    "countryRank": 92
+    "aggregatedRank": 879,
+    "countryRank": 91
   },
   {
     "name": "Aligarh Muslim University",
@@ -17088,7 +16986,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 892,
+    "aggregatedRank": 880,
     "countryRank": 19
   },
   {
@@ -17104,8 +17002,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 893,
-    "countryRank": 41
+    "aggregatedRank": 881,
+    "countryRank": 42
   },
   {
     "name": "Florida Atlantic University",
@@ -17120,7 +17018,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 894,
+    "aggregatedRank": 882,
     "countryRank": 156
   },
   {
@@ -17136,7 +17034,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 895,
+    "aggregatedRank": 883,
     "countryRank": 26
   },
   {
@@ -17152,8 +17050,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 896,
-    "countryRank": 93
+    "aggregatedRank": 884,
+    "countryRank": 92
   },
   {
     "name": "Northeast Agricultural University",
@@ -17168,8 +17066,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 897,
-    "countryRank": 94
+    "aggregatedRank": 885,
+    "countryRank": 93
   },
   {
     "name": "Northeast Normal University",
@@ -17184,8 +17082,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 898,
-    "countryRank": 95
+    "aggregatedRank": 886,
+    "countryRank": 94
   },
   {
     "name": "Jaume I University",
@@ -17200,7 +17098,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 899,
+    "aggregatedRank": 887,
     "countryRank": 21
   },
   {
@@ -17216,7 +17114,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 900,
+    "aggregatedRank": 888,
     "countryRank": 22
   },
   {
@@ -17232,8 +17130,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 901,
-    "countryRank": 26
+    "aggregatedRank": 889,
+    "countryRank": 25
   },
   {
     "name": "National & Kapodistrian University of Athens",
@@ -17245,7 +17143,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 902,
+    "aggregatedRank": 890,
     "countryRank": 1
   },
   {
@@ -17258,21 +17156,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 903,
-    "countryRank": 27
+    "aggregatedRank": 891,
+    "countryRank": 26
   },
   {
-    "name": "University of California Riverside",
-    "country": "united states",
-    "aggregatedScore": 245.078125,
+    "name": "China University of Geosciences",
+    "country": "China",
+    "aggregatedScore": 245.390625,
     "originalRankings": {
       "usnews": {
-        "rank": 223
+        "rank": 221
       }
     },
     "appearances": 1,
-    "aggregatedRank": 904,
-    "countryRank": 15
+    "aggregatedRank": 892,
+    "countryRank": 95
   },
   {
     "name": "Universidade de Lisboa",
@@ -17284,7 +17182,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 905,
+    "aggregatedRank": 893,
     "countryRank": 1
   },
   {
@@ -17300,7 +17198,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 906,
+    "aggregatedRank": 894,
     "countryRank": 16
   },
   {
@@ -17313,8 +17211,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 907,
-    "countryRank": 50
+    "aggregatedRank": 895,
+    "countryRank": 49
   },
   {
     "name": "Johannes Gutenberg University of Mainz",
@@ -17326,8 +17224,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 908,
-    "countryRank": 51
+    "aggregatedRank": 896,
+    "countryRank": 50
   },
   {
     "name": "University of Munster",
@@ -17339,8 +17237,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 909,
-    "countryRank": 52
+    "aggregatedRank": 897,
+    "countryRank": 51
+  },
+  {
+    "name": "University of Newcastle",
+    "country": "Australia",
+    "aggregatedScore": 243.203125,
+    "originalRankings": {
+      "usnews": {
+        "rank": 235
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 898,
+    "countryRank": 38
   },
   {
     "name": "Universite Grenoble Alpes (UGA)",
@@ -17352,47 +17263,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 910,
-    "countryRank": 28
+    "aggregatedRank": 899,
+    "countryRank": 27
   },
   {
-    "name": "London School Economics & Political Science",
-    "country": "United Kingdom",
-    "aggregatedScore": 242.578125,
+    "name": "University of Massachusetts - Amherst",
+    "country": "United States",
+    "aggregatedScore": 239.640625,
     "originalRankings": {
-      "usnews": {
-        "rank": 239
+      "the": {
+        "rank": 84
       }
     },
     "appearances": 1,
-    "aggregatedRank": 911,
-    "countryRank": 84
-  },
-  {
-    "name": "University of Tennessee Knoxville",
-    "country": "united states",
-    "aggregatedScore": 241.640625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 245
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 912,
-    "countryRank": 16
-  },
-  {
-    "name": "University of Milano-Bicocca",
-    "country": "Italy",
-    "aggregatedScore": 240.390625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 253
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 913,
-    "countryRank": 42
+    "aggregatedRank": 900,
+    "countryRank": 157
   },
   {
     "name": "Charit� - University Medicine Berlin",
@@ -17404,8 +17289,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 914,
-    "countryRank": 53
+    "aggregatedRank": 901,
+    "countryRank": 52
   },
   {
     "name": "University of Illinois Chicago",
@@ -17417,8 +17302,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 915,
-    "countryRank": 17
+    "aggregatedRank": 902,
+    "countryRank": 9
   },
   {
     "name": "Universidade do Porto",
@@ -17430,7 +17315,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 916,
+    "aggregatedRank": 903,
     "countryRank": 1
   },
   {
@@ -17443,8 +17328,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 917,
-    "countryRank": 38
+    "aggregatedRank": 904,
+    "countryRank": 39
   },
   {
     "name": "Universite de Bordeaux",
@@ -17456,21 +17341,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 918,
-    "countryRank": 29
-  },
-  {
-    "name": "Universiti Malaya",
-    "country": "Malaysia|kuala Lumpur",
-    "aggregatedScore": 236.015625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 281
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 919,
-    "countryRank": 1
+    "aggregatedRank": 905,
+    "countryRank": 28
   },
   {
     "name": "University of Erlangen Nuremberg",
@@ -17482,21 +17354,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 920,
-    "countryRank": 54
-  },
-  {
-    "name": "China Medical University Taiwan",
-    "country": "Taiwan",
-    "aggregatedScore": 235.390625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 285
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 921,
-    "countryRank": 12
+    "aggregatedRank": 906,
+    "countryRank": 53
   },
   {
     "name": "Universite Toulouse III - Paul Sabatier",
@@ -17508,8 +17367,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 922,
-    "countryRank": 30
+    "aggregatedRank": 907,
+    "countryRank": 29
   },
   {
     "name": "University of Colorado Denver",
@@ -17521,8 +17380,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 923,
-    "countryRank": 18
+    "aggregatedRank": 908,
+    "countryRank": 10
   },
   {
     "name": "University of Duisburg Essen",
@@ -17534,21 +17393,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 924,
-    "countryRank": 55
-  },
-  {
-    "name": "Durham University",
-    "country": "United Kingdom",
-    "aggregatedScore": 231.640625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 309
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 925,
-    "countryRank": 85
+    "aggregatedRank": 909,
+    "countryRank": 54
   },
   {
     "name": "Stellenbosch University",
@@ -17560,7 +17406,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 926,
+    "aggregatedRank": 910,
     "countryRank": 1
   },
   {
@@ -17573,8 +17419,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 927,
-    "countryRank": 31
+    "aggregatedRank": 911,
+    "countryRank": 30
   },
   {
     "name": "University of Lagos",
@@ -17586,7 +17432,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 928,
+    "aggregatedRank": 912,
     "countryRank": 1
   },
   {
@@ -17599,8 +17445,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 929,
-    "countryRank": 56
+    "aggregatedRank": 913,
+    "countryRank": 55
   },
   {
     "name": "Ege University",
@@ -17615,7 +17461,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 930,
+    "aggregatedRank": 914,
     "countryRank": 8
   },
   {
@@ -17631,8 +17477,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 931,
-    "countryRank": 57
+    "aggregatedRank": 915,
+    "countryRank": 56
   },
   {
     "name": "Banaras Hindu University",
@@ -17647,7 +17493,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 932,
+    "aggregatedRank": 916,
     "countryRank": 20
   },
   {
@@ -17663,7 +17509,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 933,
+    "aggregatedRank": 917,
     "countryRank": 43
   },
   {
@@ -17679,8 +17525,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 934,
-    "countryRank": 17
+    "aggregatedRank": 918,
+    "countryRank": 16
   },
   {
     "name": "Xi'an Jiaotong Liverpool University",
@@ -17695,7 +17541,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 935,
+    "aggregatedRank": 919,
     "countryRank": 96
   },
   {
@@ -17711,7 +17557,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 936,
+    "aggregatedRank": 920,
     "countryRank": 23
   },
   {
@@ -17727,8 +17573,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 937,
-    "countryRank": 86
+    "aggregatedRank": 921,
+    "countryRank": 84
   },
   {
     "name": "University of Eastern Piedmont",
@@ -17743,7 +17589,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 938,
+    "aggregatedRank": 922,
     "countryRank": 44
   },
   {
@@ -17756,7 +17602,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 939,
+    "aggregatedRank": 923,
     "countryRank": 1
   },
   {
@@ -17769,8 +17615,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 940,
-    "countryRank": 10
+    "aggregatedRank": 924,
+    "countryRank": 9
   },
   {
     "name": "Universite Claude Bernard Lyon 1",
@@ -17782,8 +17628,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 941,
-    "countryRank": 32
+    "aggregatedRank": 925,
+    "countryRank": 31
   },
   {
     "name": "Universiti Teknologi Malaysia",
@@ -17795,7 +17641,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 942,
+    "aggregatedRank": 926,
     "countryRank": 1
   },
   {
@@ -17808,8 +17654,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 943,
-    "countryRank": 87
+    "aggregatedRank": 927,
+    "countryRank": 85
   },
   {
     "name": "University of Ibadan",
@@ -17821,7 +17667,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 944,
+    "aggregatedRank": 928,
     "countryRank": 1
   },
   {
@@ -17834,21 +17680,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 945,
-    "countryRank": 58
-  },
-  {
-    "name": "Pontificia Universidad Catolica de Chile",
-    "country": "Chile|santiago",
-    "aggregatedScore": 223.828125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 359
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 946,
-    "countryRank": 1
+    "aggregatedRank": 929,
+    "countryRank": 57
   },
   {
     "name": "Queens University - Canada",
@@ -17860,7 +17693,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 947,
+    "aggregatedRank": 930,
     "countryRank": 29
   },
   {
@@ -17876,8 +17709,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 948,
-    "countryRank": 33
+    "aggregatedRank": 931,
+    "countryRank": 32
   },
   {
     "name": "Universite Cote d'Azur",
@@ -17889,8 +17722,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 949,
-    "countryRank": 34
+    "aggregatedRank": 932,
+    "countryRank": 33
   },
   {
     "name": "Islamic Azad University",
@@ -17902,7 +17735,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 950,
+    "aggregatedRank": 933,
     "countryRank": 1
   },
   {
@@ -17915,7 +17748,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 951,
+    "aggregatedRank": 934,
     "countryRank": 97
   },
   {
@@ -17928,7 +17761,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 952,
+    "aggregatedRank": 935,
     "countryRank": 45
   },
   {
@@ -17941,7 +17774,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 953,
+    "aggregatedRank": 936,
     "countryRank": 1
   },
   {
@@ -17954,8 +17787,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 954,
-    "countryRank": 12
+    "aggregatedRank": 937,
+    "countryRank": 11
   },
   {
     "name": "University of Science & Technology Beijing",
@@ -17967,7 +17800,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 955,
+    "aggregatedRank": 938,
     "countryRank": 98
   },
   {
@@ -17980,8 +17813,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 956,
-    "countryRank": 59
+    "aggregatedRank": 939,
+    "countryRank": 58
   },
   {
     "name": "Pohang University of Science & Technology (POSTECH)",
@@ -17993,7 +17826,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 957,
+    "aggregatedRank": 940,
     "countryRank": 27
   },
   {
@@ -18006,7 +17839,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 958,
+    "aggregatedRank": 941,
     "countryRank": 99
   },
   {
@@ -18019,8 +17852,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 959,
-    "countryRank": 60
+    "aggregatedRank": 942,
+    "countryRank": 59
   },
   {
     "name": "Universite de Lille",
@@ -18032,8 +17865,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 960,
-    "countryRank": 35
+    "aggregatedRank": 943,
+    "countryRank": 34
   },
   {
     "name": "Universiti Sains Malaysia",
@@ -18045,7 +17878,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 961,
+    "aggregatedRank": 944,
     "countryRank": 1
   },
   {
@@ -18058,8 +17891,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 962,
+    "aggregatedRank": 945,
     "countryRank": 1
+  },
+  {
+    "name": "Jinan University",
+    "country": "China",
+    "aggregatedScore": 216.171875,
+    "originalRankings": {
+      "usnews": {
+        "rank": 408
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 946,
+    "countryRank": 100
   },
   {
     "name": "Universita degli Studi di Bari Aldo Moro",
@@ -18071,7 +17917,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 963,
+    "aggregatedRank": 947,
     "countryRank": 46
   },
   {
@@ -18087,7 +17933,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 964,
+    "aggregatedRank": 948,
     "countryRank": 24
   },
   {
@@ -18100,8 +17946,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 965,
-    "countryRank": 39
+    "aggregatedRank": 949,
+    "countryRank": 40
   },
   {
     "name": "Royal College of Surgeons",
@@ -18113,7 +17959,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 966,
+    "aggregatedRank": 950,
     "countryRank": 8
   },
   {
@@ -18126,8 +17972,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 967,
-    "countryRank": 61
+    "aggregatedRank": 951,
+    "countryRank": 60
   },
   {
     "name": "Universidad Nacional Autonoma de Mexico",
@@ -18139,7 +17985,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 968,
+    "aggregatedRank": 952,
     "countryRank": 3
   },
   {
@@ -18155,7 +18001,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 969,
+    "aggregatedRank": 953,
     "countryRank": 1
   },
   {
@@ -18168,8 +18014,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 970,
-    "countryRank": 11
+    "aggregatedRank": 954,
+    "countryRank": 10
   },
   {
     "name": "Nantes Universite",
@@ -18181,8 +18027,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 971,
-    "countryRank": 36
+    "aggregatedRank": 955,
+    "countryRank": 35
   },
   {
     "name": "Universidad de Chile",
@@ -18194,8 +18040,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 972,
-    "countryRank": 2
+    "aggregatedRank": 956,
+    "countryRank": 1
   },
   {
     "name": "Universitat Politecnica de Catalunya",
@@ -18207,7 +18053,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 973,
+    "aggregatedRank": 957,
     "countryRank": 25
   },
   {
@@ -18220,7 +18066,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 974,
+    "aggregatedRank": 958,
     "countryRank": 1
   },
   {
@@ -18233,8 +18079,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 975,
-    "countryRank": 37
+    "aggregatedRank": 959,
+    "countryRank": 36
   },
   {
     "name": "Chengdu University of Technology",
@@ -18249,8 +18095,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 976,
-    "countryRank": 100
+    "aggregatedRank": 960,
+    "countryRank": 101
   },
   {
     "name": "China Pharmaceutical University",
@@ -18265,8 +18111,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 977,
-    "countryRank": 101
+    "aggregatedRank": 961,
+    "countryRank": 102
   },
   {
     "name": "University Savoie Mont Blanc",
@@ -18281,8 +18127,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 978,
-    "countryRank": 38
+    "aggregatedRank": 962,
+    "countryRank": 37
   },
   {
     "name": "University of Campania Luigi Vanvitelli",
@@ -18297,7 +18143,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 979,
+    "aggregatedRank": 963,
     "countryRank": 47
   },
   {
@@ -18313,8 +18159,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 980,
-    "countryRank": 157
+    "aggregatedRank": 964,
+    "countryRank": 158
   },
   {
     "name": "University of Texas at El Paso",
@@ -18329,8 +18175,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 981,
-    "countryRank": 158
+    "aggregatedRank": 965,
+    "countryRank": 159
   },
   {
     "name": "Old Dominion University",
@@ -18345,8 +18191,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 982,
-    "countryRank": 159
+    "aggregatedRank": 966,
+    "countryRank": 160
   },
   {
     "name": "University of Girona",
@@ -18361,7 +18207,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 983,
+    "aggregatedRank": 967,
     "countryRank": 26
   },
   {
@@ -18374,7 +18220,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 984,
+    "aggregatedRank": 968,
     "countryRank": 27
   },
   {
@@ -18387,8 +18233,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 985,
-    "countryRank": 19
+    "aggregatedRank": 969,
+    "countryRank": 11
   },
   {
     "name": "University of Massachusetts Worcester",
@@ -18400,12 +18246,12 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 986,
-    "countryRank": 20
+    "aggregatedRank": 970,
+    "countryRank": 12
   },
   {
-    "name": "University of Missouri Columbia",
-    "country": "united states",
+    "name": "York University - Canada",
+    "country": "Canada",
     "aggregatedScore": 207.109375,
     "originalRankings": {
       "usnews": {
@@ -18413,8 +18259,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 987,
-    "countryRank": 21
+    "aggregatedRank": 971,
+    "countryRank": 30
   },
   {
     "name": "Tampere University",
@@ -18426,7 +18272,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 988,
+    "aggregatedRank": 972,
     "countryRank": 10
   },
   {
@@ -18442,7 +18288,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 989,
+    "aggregatedRank": 973,
     "countryRank": 4
   },
   {
@@ -18458,8 +18304,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 990,
-    "countryRank": 102
+    "aggregatedRank": 974,
+    "countryRank": 103
   },
   {
     "name": "Jefferson University",
@@ -18471,8 +18317,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 991,
-    "countryRank": 22
+    "aggregatedRank": 975,
+    "countryRank": 13
   },
   {
     "name": "Universidade de Coimbra",
@@ -18484,7 +18330,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 992,
+    "aggregatedRank": 976,
     "countryRank": 1
   },
   {
@@ -18497,8 +18343,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 993,
-    "countryRank": 23
+    "aggregatedRank": 977,
+    "countryRank": 14
   },
   {
     "name": "Universite de Rennes",
@@ -18510,8 +18356,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 994,
-    "countryRank": 39
+    "aggregatedRank": 978,
+    "countryRank": 38
   },
   {
     "name": "Eotvos Lorand University",
@@ -18523,7 +18369,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 995,
+    "aggregatedRank": 979,
     "countryRank": 1
   },
   {
@@ -18536,8 +18382,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 996,
-    "countryRank": 88
+    "aggregatedRank": 980,
+    "countryRank": 86
   },
   {
     "name": "Assiut University",
@@ -18549,7 +18395,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 997,
+    "aggregatedRank": 981,
     "countryRank": 1
   },
   {
@@ -18562,8 +18408,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 998,
-    "countryRank": 103
+    "aggregatedRank": 982,
+    "countryRank": 104
   },
   {
     "name": "Universidade Federal do Rio de Janeiro",
@@ -18575,21 +18421,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 999,
-    "countryRank": 12
-  },
-  {
-    "name": "University of Nebraska Lincoln",
-    "country": "united states",
-    "aggregatedScore": 202.265625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 497
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1000,
-    "countryRank": 24
+    "aggregatedRank": 983,
+    "countryRank": 11
   },
   {
     "name": "Moscow Institute of Physics & Technology",
@@ -18601,7 +18434,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1001,
+    "aggregatedRank": 984,
     "countryRank": 1
   },
   {
@@ -18614,8 +18447,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1002,
-    "countryRank": 104
+    "aggregatedRank": 985,
+    "countryRank": 105
   },
   {
     "name": "Victoria University Wellington",
@@ -18627,7 +18460,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1003,
+    "aggregatedRank": 986,
     "countryRank": 1
   },
   {
@@ -18643,8 +18476,21 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1004,
-    "countryRank": 62
+    "aggregatedRank": 987,
+    "countryRank": 61
+  },
+  {
+    "name": "Donghua University",
+    "country": "China",
+    "aggregatedScore": 200.390625,
+    "originalRankings": {
+      "usnews": {
+        "rank": 509
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 988,
+    "countryRank": 106
   },
   {
     "name": "Justus Liebig University Giessen",
@@ -18656,8 +18502,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1005,
-    "countryRank": 63
+    "aggregatedRank": 989,
+    "countryRank": 62
   },
   {
     "name": "Universita della Campania Vanvitelli",
@@ -18669,7 +18515,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1006,
+    "aggregatedRank": 990,
     "countryRank": 48
   },
   {
@@ -18682,7 +18528,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1007,
+    "aggregatedRank": 991,
     "countryRank": 28
   },
   {
@@ -18695,7 +18541,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1008,
+    "aggregatedRank": 992,
     "countryRank": 10
   },
   {
@@ -18708,8 +18554,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1009,
-    "countryRank": 40
+    "aggregatedRank": 993,
+    "countryRank": 39
   },
   {
     "name": "L'institut Agro",
@@ -18721,8 +18567,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1010,
-    "countryRank": 41
+    "aggregatedRank": 994,
+    "countryRank": 40
   },
   {
     "name": "International School for Advanced Studies (SISSA)",
@@ -18734,7 +18580,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1011,
+    "aggregatedRank": 995,
     "countryRank": 49
   },
   {
@@ -18750,7 +18596,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1012,
+    "aggregatedRank": 996,
     "countryRank": 1
   },
   {
@@ -18763,7 +18609,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1013,
+    "aggregatedRank": 997,
     "countryRank": 50
   },
   {
@@ -18776,7 +18622,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1014,
+    "aggregatedRank": 998,
     "countryRank": 1
   },
   {
@@ -18789,8 +18635,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1015,
-    "countryRank": 13
+    "aggregatedRank": 999,
+    "countryRank": 12
   },
   {
     "name": "Istanbul University",
@@ -18805,7 +18651,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1016,
+    "aggregatedRank": 1000,
     "countryRank": 10
   },
   {
@@ -18818,7 +18664,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1017,
+    "aggregatedRank": 1001,
     "countryRank": 2
   },
   {
@@ -18834,7 +18680,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1018,
+    "aggregatedRank": 1002,
     "countryRank": 21
   },
   {
@@ -18847,7 +18693,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1019,
+    "aggregatedRank": 1003,
     "countryRank": 1
   },
   {
@@ -18860,7 +18706,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1020,
+    "aggregatedRank": 1004,
     "countryRank": 1
   },
   {
@@ -18876,7 +18722,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1021,
+    "aggregatedRank": 1005,
     "countryRank": 22
   },
   {
@@ -18889,7 +18735,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1022,
+    "aggregatedRank": 1006,
     "countryRank": 1
   },
   {
@@ -18902,7 +18748,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1023,
+    "aggregatedRank": 1007,
     "countryRank": 1
   },
   {
@@ -18915,7 +18761,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1024,
+    "aggregatedRank": 1008,
     "countryRank": 12
   },
   {
@@ -18928,7 +18774,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1025,
+    "aggregatedRank": 1009,
     "countryRank": 1
   },
   {
@@ -18944,7 +18790,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1026,
+    "aggregatedRank": 1010,
     "countryRank": 23
   },
   {
@@ -18957,7 +18803,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1027,
+    "aggregatedRank": 1011,
     "countryRank": 1
   },
   {
@@ -18970,7 +18816,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1028,
+    "aggregatedRank": 1012,
     "countryRank": 8
   },
   {
@@ -18983,8 +18829,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1029,
-    "countryRank": 64
+    "aggregatedRank": 1013,
+    "countryRank": 63
   },
   {
     "name": "Nanjing Tech University",
@@ -18996,8 +18842,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1030,
-    "countryRank": 105
+    "aggregatedRank": 1014,
+    "countryRank": 107
   },
   {
     "name": "University of Zaragoza",
@@ -19012,7 +18858,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1031,
+    "aggregatedRank": 1015,
     "countryRank": 29
   },
   {
@@ -19025,8 +18871,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1032,
-    "countryRank": 42
+    "aggregatedRank": 1016,
+    "countryRank": 41
   },
   {
     "name": "University of Ja�n",
@@ -19041,7 +18887,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1033,
+    "aggregatedRank": 1017,
     "countryRank": 30
   },
   {
@@ -19057,8 +18903,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1034,
-    "countryRank": 13
+    "aggregatedRank": 1018,
+    "countryRank": 12
   },
   {
     "name": "Abdul Wali Khan University Mardan",
@@ -19073,7 +18919,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1035,
+    "aggregatedRank": 1019,
     "countryRank": 9
   },
   {
@@ -19089,8 +18935,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1036,
-    "countryRank": 106
+    "aggregatedRank": 1020,
+    "countryRank": 108
   },
   {
     "name": "Jazan University",
@@ -19105,7 +18951,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1037,
+    "aggregatedRank": 1021,
     "countryRank": 17
   },
   {
@@ -19118,7 +18964,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1038,
+    "aggregatedRank": 1022,
     "countryRank": 1
   },
   {
@@ -19131,7 +18977,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1039,
+    "aggregatedRank": 1023,
     "countryRank": 1
   },
   {
@@ -19144,7 +18990,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1040,
+    "aggregatedRank": 1024,
     "countryRank": 11
   },
   {
@@ -19157,7 +19003,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1041,
+    "aggregatedRank": 1025,
     "countryRank": 24
   },
   {
@@ -19170,8 +19016,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1042,
-    "countryRank": 43
+    "aggregatedRank": 1026,
+    "countryRank": 42
   },
   {
     "name": "Federation University Australia",
@@ -19183,8 +19029,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1043,
-    "countryRank": 40
+    "aggregatedRank": 1027,
+    "countryRank": 41
   },
   {
     "name": "Leuphana University Luneburg",
@@ -19196,8 +19042,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1044,
-    "countryRank": 65
+    "aggregatedRank": 1028,
+    "countryRank": 64
   },
   {
     "name": "Mohammed VI Polytechnic University",
@@ -19209,7 +19055,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1045,
+    "aggregatedRank": 1029,
     "countryRank": 1
   },
   {
@@ -19222,8 +19068,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1046,
-    "countryRank": 107
+    "aggregatedRank": 1030,
+    "countryRank": 109
   },
   {
     "name": "Government College University Faisalabad",
@@ -19235,7 +19081,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1047,
+    "aggregatedRank": 1031,
     "countryRank": 1
   },
   {
@@ -19251,8 +19097,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1048,
-    "countryRank": 66
+    "aggregatedRank": 1032,
+    "countryRank": 65
   },
   {
     "name": "Ural Federal University",
@@ -19267,7 +19113,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1049,
+    "aggregatedRank": 1033,
     "countryRank": 17
   },
   {
@@ -19280,7 +19126,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1050,
+    "aggregatedRank": 1034,
     "countryRank": 1
   },
   {
@@ -19293,7 +19139,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1051,
+    "aggregatedRank": 1035,
     "countryRank": 11
   },
   {
@@ -19306,8 +19152,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1052,
-    "countryRank": 67
+    "aggregatedRank": 1036,
+    "countryRank": 66
   },
   {
     "name": "University of Passau",
@@ -19319,8 +19165,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1053,
-    "countryRank": 68
+    "aggregatedRank": 1037,
+    "countryRank": 67
   },
   {
     "name": "Roskilde University",
@@ -19332,7 +19178,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1054,
+    "aggregatedRank": 1038,
     "countryRank": 6
   },
   {
@@ -19345,8 +19191,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1055,
-    "countryRank": 44
+    "aggregatedRank": 1039,
+    "countryRank": 43
   },
   {
     "name": "National Yunlin University of Science and Technology",
@@ -19358,8 +19204,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1056,
-    "countryRank": 14
+    "aggregatedRank": 1040,
+    "countryRank": 13
   },
   {
     "name": "University of Tulsa",
@@ -19371,8 +19217,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1057,
-    "countryRank": 160
+    "aggregatedRank": 1041,
+    "countryRank": 161
   },
   {
     "name": "Anglia Ruskin University",
@@ -19384,8 +19230,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1058,
-    "countryRank": 89
+    "aggregatedRank": 1042,
+    "countryRank": 87
   },
   {
     "name": "Hamburg University of Technology",
@@ -19397,8 +19243,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1059,
-    "countryRank": 69
+    "aggregatedRank": 1043,
+    "countryRank": 68
   },
   {
     "name": "Babol Noshirvani University of Technology",
@@ -19410,7 +19256,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1060,
+    "aggregatedRank": 1044,
     "countryRank": 12
   },
   {
@@ -19423,7 +19269,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1061,
+    "aggregatedRank": 1045,
     "countryRank": 3
   },
   {
@@ -19436,7 +19282,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1062,
+    "aggregatedRank": 1046,
     "countryRank": 3
   },
   {
@@ -19449,8 +19295,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1063,
-    "countryRank": 70
+    "aggregatedRank": 1047,
+    "countryRank": 69
   },
   {
     "name": "Egypt-Japan University of Science and Technology",
@@ -19462,7 +19308,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1064,
+    "aggregatedRank": 1048,
     "countryRank": 10
   },
   {
@@ -19475,8 +19321,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1065,
-    "countryRank": 45
+    "aggregatedRank": 1049,
+    "countryRank": 44
   },
   {
     "name": "Nazarbayev University",
@@ -19488,7 +19334,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1066,
+    "aggregatedRank": 1050,
     "countryRank": 1
   },
   {
@@ -19504,8 +19350,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1067,
-    "countryRank": 108
+    "aggregatedRank": 1051,
+    "countryRank": 110
   },
   {
     "name": "City University of New York - City College",
@@ -19520,8 +19366,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1068,
-    "countryRank": 161
+    "aggregatedRank": 1052,
+    "countryRank": 162
   },
   {
     "name": "Indian Institute of Technology - Kanpur",
@@ -19536,7 +19382,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1069,
+    "aggregatedRank": 1053,
     "countryRank": 25
   },
   {
@@ -19552,7 +19398,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1070,
+    "aggregatedRank": 1054,
     "countryRank": 4
   },
   {
@@ -19568,7 +19414,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1071,
+    "aggregatedRank": 1055,
     "countryRank": 4
   },
   {
@@ -19581,7 +19427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1072,
+    "aggregatedRank": 1056,
     "countryRank": 1
   },
   {
@@ -19594,7 +19440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1073,
+    "aggregatedRank": 1057,
     "countryRank": 2
   },
   {
@@ -19607,7 +19453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1074,
+    "aggregatedRank": 1058,
     "countryRank": 1
   },
   {
@@ -19620,8 +19466,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1075,
-    "countryRank": 46
+    "aggregatedRank": 1059,
+    "countryRank": 45
   },
   {
     "name": "Ecole Nationale des Travaux Publics de l'Etat",
@@ -19633,8 +19479,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1076,
-    "countryRank": 47
+    "aggregatedRank": 1060,
+    "countryRank": 46
   },
   {
     "name": "Harokopio University",
@@ -19646,7 +19492,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1077,
+    "aggregatedRank": 1061,
     "countryRank": 5
   },
   {
@@ -19659,7 +19505,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1078,
+    "aggregatedRank": 1062,
     "countryRank": 26
   },
   {
@@ -19672,7 +19518,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1079,
+    "aggregatedRank": 1063,
     "countryRank": 13
   },
   {
@@ -19685,7 +19531,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1080,
+    "aggregatedRank": 1064,
     "countryRank": 14
   },
   {
@@ -19698,7 +19544,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1081,
+    "aggregatedRank": 1065,
     "countryRank": 15
   },
   {
@@ -19711,7 +19557,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1082,
+    "aggregatedRank": 1066,
     "countryRank": 16
   },
   {
@@ -19724,7 +19570,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1083,
+    "aggregatedRank": 1067,
     "countryRank": 17
   },
   {
@@ -19737,7 +19583,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1084,
+    "aggregatedRank": 1068,
     "countryRank": 18
   },
   {
@@ -19750,7 +19596,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1085,
+    "aggregatedRank": 1069,
     "countryRank": 19
   },
   {
@@ -19763,7 +19609,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1086,
+    "aggregatedRank": 1070,
     "countryRank": 51
   },
   {
@@ -19776,7 +19622,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1087,
+    "aggregatedRank": 1071,
     "countryRank": 52
   },
   {
@@ -19789,8 +19635,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1088,
-    "countryRank": 18
+    "aggregatedRank": 1072,
+    "countryRank": 17
   },
   {
     "name": "Air University",
@@ -19802,7 +19648,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1089,
+    "aggregatedRank": 1073,
     "countryRank": 10
   },
   {
@@ -19815,7 +19661,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1090,
+    "aggregatedRank": 1074,
     "countryRank": 8
   },
   {
@@ -19828,7 +19674,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1091,
+    "aggregatedRank": 1075,
     "countryRank": 18
   },
   {
@@ -19841,7 +19687,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1092,
+    "aggregatedRank": 1076,
     "countryRank": 13
   },
   {
@@ -19854,8 +19700,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1093,
-    "countryRank": 90
+    "aggregatedRank": 1077,
+    "countryRank": 88
   },
   {
     "name": "University of Derby",
@@ -19867,8 +19713,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1094,
-    "countryRank": 91
+    "aggregatedRank": 1078,
+    "countryRank": 89
   },
   {
     "name": "Catholic University of America",
@@ -19880,8 +19726,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1095,
-    "countryRank": 162
+    "aggregatedRank": 1079,
+    "countryRank": 163
   },
   {
     "name": "Rochester Institute of Technology",
@@ -19893,8 +19739,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1096,
-    "countryRank": 163
+    "aggregatedRank": 1080,
+    "countryRank": 164
   },
   {
     "name": "University of North Carolina at Charlotte",
@@ -19906,8 +19752,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1097,
-    "countryRank": 164
+    "aggregatedRank": 1081,
+    "countryRank": 165
   },
   {
     "name": "College of William and Mary",
@@ -19919,8 +19765,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1098,
-    "countryRank": 165
+    "aggregatedRank": 1082,
+    "countryRank": 166
   },
   {
     "name": "Cyprus University of Technology",
@@ -19932,7 +19778,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1099,
+    "aggregatedRank": 1083,
     "countryRank": 4
   },
   {
@@ -19945,7 +19791,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1100,
+    "aggregatedRank": 1084,
     "countryRank": 27
   },
   {
@@ -19958,8 +19804,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1101,
-    "countryRank": 92
+    "aggregatedRank": 1085,
+    "countryRank": 90
   },
   {
     "name": "�cole des Mines de Saint-�tienne",
@@ -19971,8 +19817,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1102,
-    "countryRank": 48
+    "aggregatedRank": 1086,
+    "countryRank": 47
   },
   {
     "name": "University of Insubria",
@@ -19984,7 +19830,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1103,
+    "aggregatedRank": 1087,
     "countryRank": 53
   },
   {
@@ -19997,7 +19843,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1104,
+    "aggregatedRank": 1088,
     "countryRank": 31
   },
   {
@@ -20010,7 +19856,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1105,
+    "aggregatedRank": 1089,
     "countryRank": 28
   },
   {
@@ -20023,7 +19869,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1106,
+    "aggregatedRank": 1090,
     "countryRank": 54
   },
   {
@@ -20036,8 +19882,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1107,
-    "countryRank": 93
+    "aggregatedRank": 1091,
+    "countryRank": 91
   },
   {
     "name": "Sultan Idris Education University",
@@ -20049,7 +19895,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1108,
+    "aggregatedRank": 1092,
     "countryRank": 12
   },
   {
@@ -20062,7 +19908,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1109,
+    "aggregatedRank": 1093,
     "countryRank": 5
   },
   {
@@ -20075,7 +19921,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1110,
+    "aggregatedRank": 1094,
     "countryRank": 20
   },
   {
@@ -20088,7 +19934,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1111,
+    "aggregatedRank": 1095,
     "countryRank": 21
   },
   {
@@ -20101,7 +19947,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1112,
+    "aggregatedRank": 1096,
     "countryRank": 22
   },
   {
@@ -20114,7 +19960,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1113,
+    "aggregatedRank": 1097,
     "countryRank": 19
   },
   {
@@ -20127,7 +19973,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1114,
+    "aggregatedRank": 1098,
     "countryRank": 11
   },
   {
@@ -20140,7 +19986,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1115,
+    "aggregatedRank": 1099,
     "countryRank": 12
   },
   {
@@ -20153,7 +19999,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1116,
+    "aggregatedRank": 1100,
     "countryRank": 29
   },
   {
@@ -20166,7 +20012,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1117,
+    "aggregatedRank": 1101,
     "countryRank": 30
   },
   {
@@ -20179,7 +20025,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1118,
+    "aggregatedRank": 1102,
     "countryRank": 31
   },
   {
@@ -20192,7 +20038,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1119,
+    "aggregatedRank": 1103,
     "countryRank": 18
   },
   {
@@ -20205,7 +20051,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1120,
+    "aggregatedRank": 1104,
     "countryRank": 13
   },
   {
@@ -20218,7 +20064,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1121,
+    "aggregatedRank": 1105,
     "countryRank": 32
   },
   {
@@ -20231,7 +20077,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1122,
+    "aggregatedRank": 1106,
     "countryRank": 33
   },
   {
@@ -20247,7 +20093,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1123,
+    "aggregatedRank": 1107,
     "countryRank": 5
   },
   {
@@ -20263,8 +20109,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1124,
-    "countryRank": 49
+    "aggregatedRank": 1108,
+    "countryRank": 48
   },
   {
     "name": "University of Rostock",
@@ -20279,8 +20125,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1125,
-    "countryRank": 71
+    "aggregatedRank": 1109,
+    "countryRank": 70
   },
   {
     "name": "Brno University of Technology",
@@ -20295,7 +20141,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1126,
+    "aggregatedRank": 1110,
     "countryRank": 6
   },
   {
@@ -20311,7 +20157,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1127,
+    "aggregatedRank": 1111,
     "countryRank": 3
   },
   {
@@ -20327,8 +20173,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1128,
-    "countryRank": 19
+    "aggregatedRank": 1112,
+    "countryRank": 18
   },
   {
     "name": "Indian Institute of Technology - Bombay",
@@ -20340,7 +20186,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1129,
+    "aggregatedRank": 1113,
     "countryRank": 34
   },
   {
@@ -20356,7 +20202,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1130,
+    "aggregatedRank": 1114,
     "countryRank": 1
   },
   {
@@ -20372,8 +20218,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1131,
-    "countryRank": 20
+    "aggregatedRank": 1115,
+    "countryRank": 19
   },
   {
     "name": "Kermanshah University of Medical Sciences",
@@ -20385,7 +20231,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1132,
+    "aggregatedRank": 1116,
     "countryRank": 23
   },
   {
@@ -20398,7 +20244,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1133,
+    "aggregatedRank": 1117,
     "countryRank": 24
   },
   {
@@ -20411,7 +20257,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1134,
+    "aggregatedRank": 1118,
     "countryRank": 14
   },
   {
@@ -20424,7 +20270,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1135,
+    "aggregatedRank": 1119,
     "countryRank": 13
   },
   {
@@ -20437,7 +20283,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1136,
+    "aggregatedRank": 1120,
     "countryRank": 3
   },
   {
@@ -20450,7 +20296,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1137,
+    "aggregatedRank": 1121,
     "countryRank": 4
   },
   {
@@ -20463,8 +20309,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1138,
-    "countryRank": 30
+    "aggregatedRank": 1122,
+    "countryRank": 31
   },
   {
     "name": "Wilfrid Laurier University",
@@ -20476,8 +20322,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1139,
-    "countryRank": 31
+    "aggregatedRank": 1123,
+    "countryRank": 32
   },
   {
     "name": "Zhejiang Gongshang University",
@@ -20489,8 +20335,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1140,
-    "countryRank": 109
+    "aggregatedRank": 1124,
+    "countryRank": 111
   },
   {
     "name": "University Pablo de Olavide",
@@ -20502,7 +20348,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1141,
+    "aggregatedRank": 1125,
     "countryRank": 32
   },
   {
@@ -20515,7 +20361,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1142,
+    "aggregatedRank": 1126,
     "countryRank": 1
   },
   {
@@ -20528,8 +20374,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1143,
-    "countryRank": 50
+    "aggregatedRank": 1127,
+    "countryRank": 49
   },
   {
     "name": "National Veterinary School of Alfort",
@@ -20541,8 +20387,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1144,
-    "countryRank": 51
+    "aggregatedRank": 1128,
+    "countryRank": 50
   },
   {
     "name": "University of Western Brittany",
@@ -20554,8 +20400,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1145,
-    "countryRank": 52
+    "aggregatedRank": 1129,
+    "countryRank": 51
   },
   {
     "name": "University of Cape Coast",
@@ -20567,7 +20413,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1146,
+    "aggregatedRank": 1130,
     "countryRank": 1
   },
   {
@@ -20580,7 +20426,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1147,
+    "aggregatedRank": 1131,
     "countryRank": 35
   },
   {
@@ -20593,7 +20439,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1148,
+    "aggregatedRank": 1132,
     "countryRank": 36
   },
   {
@@ -20606,7 +20452,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1149,
+    "aggregatedRank": 1133,
     "countryRank": 37
   },
   {
@@ -20619,7 +20465,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1150,
+    "aggregatedRank": 1134,
     "countryRank": 38
   },
   {
@@ -20632,7 +20478,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1151,
+    "aggregatedRank": 1135,
     "countryRank": 25
   },
   {
@@ -20645,7 +20491,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1152,
+    "aggregatedRank": 1136,
     "countryRank": 26
   },
   {
@@ -20658,7 +20504,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1153,
+    "aggregatedRank": 1137,
     "countryRank": 27
   },
   {
@@ -20671,7 +20517,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1154,
+    "aggregatedRank": 1138,
     "countryRank": 28
   },
   {
@@ -20684,7 +20530,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1155,
+    "aggregatedRank": 1139,
     "countryRank": 29
   },
   {
@@ -20697,7 +20543,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1156,
+    "aggregatedRank": 1140,
     "countryRank": 30
   },
   {
@@ -20710,7 +20556,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1157,
+    "aggregatedRank": 1141,
     "countryRank": 31
   },
   {
@@ -20723,7 +20569,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1158,
+    "aggregatedRank": 1142,
     "countryRank": 32
   },
   {
@@ -20736,7 +20582,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1159,
+    "aggregatedRank": 1143,
     "countryRank": 33
   },
   {
@@ -20749,7 +20595,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1160,
+    "aggregatedRank": 1144,
     "countryRank": 34
   },
   {
@@ -20762,7 +20608,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1161,
+    "aggregatedRank": 1145,
     "countryRank": 2
   },
   {
@@ -20775,7 +20621,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1162,
+    "aggregatedRank": 1146,
     "countryRank": 55
   },
   {
@@ -20788,7 +20634,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1163,
+    "aggregatedRank": 1147,
     "countryRank": 56
   },
   {
@@ -20801,7 +20647,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1164,
+    "aggregatedRank": 1148,
     "countryRank": 57
   },
   {
@@ -20814,7 +20660,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1165,
+    "aggregatedRank": 1149,
     "countryRank": 58
   },
   {
@@ -20827,7 +20673,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1166,
+    "aggregatedRank": 1150,
     "countryRank": 4
   },
   {
@@ -20840,8 +20686,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1167,
-    "countryRank": 21
+    "aggregatedRank": 1151,
+    "countryRank": 20
   },
   {
     "name": "Wakayama Medical University",
@@ -20853,8 +20699,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1168,
-    "countryRank": 22
+    "aggregatedRank": 1152,
+    "countryRank": 21
   },
   {
     "name": "Seoul University",
@@ -20866,7 +20712,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1169,
+    "aggregatedRank": 1153,
     "countryRank": 28
   },
   {
@@ -20879,7 +20725,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1170,
+    "aggregatedRank": 1154,
     "countryRank": 1
   },
   {
@@ -20892,7 +20738,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1171,
+    "aggregatedRank": 1155,
     "countryRank": 15
   },
   {
@@ -20905,7 +20751,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1172,
+    "aggregatedRank": 1156,
     "countryRank": 16
   },
   {
@@ -20918,7 +20764,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1173,
+    "aggregatedRank": 1157,
     "countryRank": 17
   },
   {
@@ -20931,7 +20777,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1174,
+    "aggregatedRank": 1158,
     "countryRank": 18
   },
   {
@@ -20944,7 +20790,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1175,
+    "aggregatedRank": 1159,
     "countryRank": 19
   },
   {
@@ -20957,7 +20803,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1176,
+    "aggregatedRank": 1160,
     "countryRank": 20
   },
   {
@@ -20970,7 +20816,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1177,
+    "aggregatedRank": 1161,
     "countryRank": 4
   },
   {
@@ -20983,7 +20829,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1178,
+    "aggregatedRank": 1162,
     "countryRank": 19
   },
   {
@@ -20996,7 +20842,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1179,
+    "aggregatedRank": 1163,
     "countryRank": 11
   },
   {
@@ -21009,7 +20855,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1180,
+    "aggregatedRank": 1164,
     "countryRank": 12
   },
   {
@@ -21022,8 +20868,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1181,
-    "countryRank": 15
+    "aggregatedRank": 1165,
+    "countryRank": 14
   },
   {
     "name": "Sumy State University",
@@ -21035,7 +20881,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1182,
+    "aggregatedRank": 1166,
     "countryRank": 1
   },
   {
@@ -21048,8 +20894,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1183,
-    "countryRank": 94
+    "aggregatedRank": 1167,
+    "countryRank": 92
   },
   {
     "name": "Roehampton University of Surrey",
@@ -21061,8 +20907,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1184,
-    "countryRank": 95
+    "aggregatedRank": 1168,
+    "countryRank": 93
   },
   {
     "name": "Sheffield Hallam University",
@@ -21074,8 +20920,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1185,
-    "countryRank": 96
+    "aggregatedRank": 1169,
+    "countryRank": 94
   },
   {
     "name": "University of Teesside",
@@ -21087,8 +20933,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1186,
-    "countryRank": 97
+    "aggregatedRank": 1170,
+    "countryRank": 95
   },
   {
     "name": "University of Wolverhampton",
@@ -21100,8 +20946,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1187,
-    "countryRank": 98
+    "aggregatedRank": 1171,
+    "countryRank": 96
   },
   {
     "name": "Hanoi Medical University",
@@ -21113,7 +20959,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1188,
+    "aggregatedRank": 1172,
     "countryRank": 4
   },
   {
@@ -21126,8 +20972,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1189,
-    "countryRank": 166
+    "aggregatedRank": 1173,
+    "countryRank": 167
   },
   {
     "name": "Northern Illinois University",
@@ -21139,8 +20985,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1190,
-    "countryRank": 167
+    "aggregatedRank": 1174,
+    "countryRank": 168
   },
   {
     "name": "Southern Illinois University at Carbondale",
@@ -21152,8 +20998,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1191,
-    "countryRank": 168
+    "aggregatedRank": 1175,
+    "countryRank": 169
   },
   {
     "name": "New Mexico State University",
@@ -21165,8 +21011,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1192,
-    "countryRank": 169
+    "aggregatedRank": 1176,
+    "countryRank": 170
   },
   {
     "name": "Portland State University",
@@ -21178,8 +21024,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1193,
-    "countryRank": 170
+    "aggregatedRank": 1177,
+    "countryRank": 171
   },
   {
     "name": "University of Memphis",
@@ -21191,8 +21037,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1194,
-    "countryRank": 171
+    "aggregatedRank": 1178,
+    "countryRank": 172
   },
   {
     "name": "Gabriele D'Annunzio University",
@@ -21204,7 +21050,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1195,
+    "aggregatedRank": 1179,
     "countryRank": 59
   },
   {
@@ -21217,8 +21063,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1196,
-    "countryRank": 99
+    "aggregatedRank": 1180,
+    "countryRank": 97
   },
   {
     "name": "National Institute of Technology Rourkela",
@@ -21230,7 +21076,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1197,
+    "aggregatedRank": 1181,
     "countryRank": 39
   },
   {
@@ -21243,7 +21089,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1198,
+    "aggregatedRank": 1182,
     "countryRank": 40
   },
   {
@@ -21256,7 +21102,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1199,
+    "aggregatedRank": 1183,
     "countryRank": 41
   },
   {
@@ -21269,7 +21115,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1200,
+    "aggregatedRank": 1184,
     "countryRank": 42
   },
   {
@@ -21282,7 +21128,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1201,
+    "aggregatedRank": 1185,
     "countryRank": 35
   },
   {
@@ -21295,8 +21141,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1202,
-    "countryRank": 100
+    "aggregatedRank": 1186,
+    "countryRank": 98
   },
   {
     "name": "Bucharest University of Economic Studies",
@@ -21308,7 +21154,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1203,
+    "aggregatedRank": 1187,
     "countryRank": 1
   },
   {
@@ -21321,7 +21167,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1204,
+    "aggregatedRank": 1188,
     "countryRank": 21
   },
   {
@@ -21334,7 +21180,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1205,
+    "aggregatedRank": 1189,
     "countryRank": 43
   },
   {
@@ -21347,7 +21193,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1206,
+    "aggregatedRank": 1190,
     "countryRank": 44
   },
   {
@@ -21360,7 +21206,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1207,
+    "aggregatedRank": 1191,
     "countryRank": 45
   },
   {
@@ -21373,7 +21219,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1208,
+    "aggregatedRank": 1192,
     "countryRank": 13
   },
   {
@@ -21386,7 +21232,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1209,
+    "aggregatedRank": 1193,
     "countryRank": 33
   },
   {
@@ -21399,7 +21245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1210,
+    "aggregatedRank": 1194,
     "countryRank": 20
   },
   {
@@ -21412,7 +21258,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1211,
+    "aggregatedRank": 1195,
     "countryRank": 5
   },
   {
@@ -21425,7 +21271,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1212,
+    "aggregatedRank": 1196,
     "countryRank": 5
   },
   {
@@ -21438,7 +21284,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1213,
+    "aggregatedRank": 1197,
     "countryRank": 6
   },
   {
@@ -21451,7 +21297,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1214,
+    "aggregatedRank": 1198,
     "countryRank": 22
   },
   {
@@ -21464,7 +21310,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1215,
+    "aggregatedRank": 1199,
     "countryRank": 2
   },
   {
@@ -21477,7 +21323,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1216,
+    "aggregatedRank": 1200,
     "countryRank": 2
   },
   {
@@ -21490,7 +21336,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1217,
+    "aggregatedRank": 1201,
     "countryRank": 46
   },
   {
@@ -21503,7 +21349,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1218,
+    "aggregatedRank": 1202,
     "countryRank": 47
   },
   {
@@ -21516,7 +21362,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1219,
+    "aggregatedRank": 1203,
     "countryRank": 48
   },
   {
@@ -21529,7 +21375,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1220,
+    "aggregatedRank": 1204,
     "countryRank": 2
   },
   {
@@ -21542,7 +21388,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1221,
+    "aggregatedRank": 1205,
     "countryRank": 21
   },
   {
@@ -21555,8 +21401,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1222,
-    "countryRank": 13
+    "aggregatedRank": 1206,
+    "countryRank": 12
   },
   {
     "name": "Reichman University",
@@ -21568,7 +21414,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1223,
+    "aggregatedRank": 1207,
     "countryRank": 9
   },
   {
@@ -21581,7 +21427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1224,
+    "aggregatedRank": 1208,
     "countryRank": 36
   },
   {
@@ -21594,7 +21440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1225,
+    "aggregatedRank": 1209,
     "countryRank": 49
   },
   {
@@ -21607,7 +21453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1226,
+    "aggregatedRank": 1210,
     "countryRank": 50
   },
   {
@@ -21620,7 +21466,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1227,
+    "aggregatedRank": 1211,
     "countryRank": 2
   },
   {
@@ -21636,7 +21482,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1228,
+    "aggregatedRank": 1212,
     "countryRank": 34
   },
   {
@@ -21652,7 +21498,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1229,
+    "aggregatedRank": 1213,
     "countryRank": 4
   },
   {
@@ -21668,7 +21514,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1230,
+    "aggregatedRank": 1214,
     "countryRank": 35
   },
   {
@@ -21684,8 +21530,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1231,
-    "countryRank": 110
+    "aggregatedRank": 1215,
+    "countryRank": 112
   },
   {
     "name": "Osaka Metropolitan University",
@@ -21700,8 +21546,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1232,
-    "countryRank": 23
+    "aggregatedRank": 1216,
+    "countryRank": 22
   },
   {
     "name": "University of Los Andes",
@@ -21713,7 +21559,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1233,
+    "aggregatedRank": 1217,
     "countryRank": 2
   },
   {
@@ -21729,7 +21575,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1234,
+    "aggregatedRank": 1218,
     "countryRank": 5
   },
   {
@@ -21745,8 +21591,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1235,
-    "countryRank": 14
+    "aggregatedRank": 1219,
+    "countryRank": 13
   },
   {
     "name": "University of Sherbrooke",
@@ -21761,8 +21607,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1236,
-    "countryRank": 32
+    "aggregatedRank": 1220,
+    "countryRank": 33
   },
   {
     "name": "Gadjah Mada University",
@@ -21774,7 +21620,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1237,
+    "aggregatedRank": 1221,
     "countryRank": 2
   },
   {
@@ -21790,8 +21636,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1238,
-    "countryRank": 16
+    "aggregatedRank": 1222,
+    "countryRank": 15
   },
   {
     "name": "Institute of Technology Bandung",
@@ -21803,7 +21649,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1239,
+    "aggregatedRank": 1223,
     "countryRank": 3
   },
   {
@@ -21819,8 +21665,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1240,
-    "countryRank": 15
+    "aggregatedRank": 1224,
+    "countryRank": 14
   },
   {
     "name": "UCSI University",
@@ -21832,7 +21678,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1241,
+    "aggregatedRank": 1225,
     "countryRank": 13
   },
   {
@@ -21848,7 +21694,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1242,
+    "aggregatedRank": 1226,
     "countryRank": 29
   },
   {
@@ -21861,7 +21707,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1243,
+    "aggregatedRank": 1227,
     "countryRank": 4
   },
   {
@@ -21877,7 +21723,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1244,
+    "aggregatedRank": 1228,
     "countryRank": 6
   },
   {
@@ -21890,7 +21736,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1245,
+    "aggregatedRank": 1229,
     "countryRank": 3
   },
   {
@@ -21906,8 +21752,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1246,
-    "countryRank": 17
+    "aggregatedRank": 1230,
+    "countryRank": 16
   },
   {
     "name": "Chungnam National University",
@@ -21922,7 +21768,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1247,
+    "aggregatedRank": 1231,
     "countryRank": 30
   },
   {
@@ -21935,7 +21781,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1248,
+    "aggregatedRank": 1232,
     "countryRank": 1
   },
   {
@@ -21951,7 +21797,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1249,
+    "aggregatedRank": 1233,
     "countryRank": 1
   },
   {
@@ -21964,7 +21810,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1250,
+    "aggregatedRank": 1234,
     "countryRank": 3
   },
   {
@@ -21977,8 +21823,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1251,
-    "countryRank": 72
+    "aggregatedRank": 1235,
+    "countryRank": 71
   },
   {
     "name": "Belarusian State University",
@@ -21990,7 +21836,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1252,
+    "aggregatedRank": 1236,
     "countryRank": 1
   },
   {
@@ -22003,7 +21849,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1253,
+    "aggregatedRank": 1237,
     "countryRank": 4
   },
   {
@@ -22019,7 +21865,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1254,
+    "aggregatedRank": 1238,
     "countryRank": 2
   },
   {
@@ -22035,7 +21881,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1255,
+    "aggregatedRank": 1239,
     "countryRank": 14
   },
   {
@@ -22051,7 +21897,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1256,
+    "aggregatedRank": 1240,
     "countryRank": 6
   },
   {
@@ -22064,8 +21910,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1257,
-    "countryRank": 18
+    "aggregatedRank": 1241,
+    "countryRank": 17
   },
   {
     "name": "Bogor Agricultural University (IPB University)",
@@ -22077,7 +21923,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1258,
+    "aggregatedRank": 1242,
     "countryRank": 5
   },
   {
@@ -22090,7 +21936,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1259,
+    "aggregatedRank": 1243,
     "countryRank": 36
   },
   {
@@ -22103,7 +21949,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1260,
+    "aggregatedRank": 1244,
     "countryRank": 4
   },
   {
@@ -22119,7 +21965,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1261,
+    "aggregatedRank": 1245,
     "countryRank": 51
   },
   {
@@ -22135,8 +21981,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1262,
-    "countryRank": 24
+    "aggregatedRank": 1246,
+    "countryRank": 23
   },
   {
     "name": "Clemson University",
@@ -22151,8 +21997,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1263,
-    "countryRank": 172
+    "aggregatedRank": 1247,
+    "countryRank": 173
   },
   {
     "name": "University of Patras",
@@ -22167,7 +22013,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1264,
+    "aggregatedRank": 1248,
     "countryRank": 6
   },
   {
@@ -22183,7 +22029,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1265,
+    "aggregatedRank": 1249,
     "countryRank": 7
   },
   {
@@ -22196,7 +22042,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1266,
+    "aggregatedRank": 1250,
     "countryRank": 2
   },
   {
@@ -22209,7 +22055,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1267,
+    "aggregatedRank": 1251,
     "countryRank": 9
   },
   {
@@ -22222,7 +22068,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1268,
+    "aggregatedRank": 1252,
     "countryRank": 1
   },
   {
@@ -22235,7 +22081,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1269,
+    "aggregatedRank": 1253,
     "countryRank": 2
   },
   {
@@ -22248,7 +22094,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1270,
+    "aggregatedRank": 1254,
     "countryRank": 14
   },
   {
@@ -22261,7 +22107,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1271,
+    "aggregatedRank": 1255,
     "countryRank": 10
   },
   {
@@ -22274,7 +22120,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1272,
+    "aggregatedRank": 1256,
     "countryRank": 3
   },
   {
@@ -22290,7 +22136,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1273,
+    "aggregatedRank": 1257,
     "countryRank": 4
   },
   {
@@ -22306,8 +22152,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1274,
-    "countryRank": 25
+    "aggregatedRank": 1258,
+    "countryRank": 24
   },
   {
     "name": "Indian Institute of Technology (BHU) Varanasi",
@@ -22319,7 +22165,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1275,
+    "aggregatedRank": 1259,
     "countryRank": 52
   },
   {
@@ -22332,7 +22178,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1276,
+    "aggregatedRank": 1260,
     "countryRank": 5
   },
   {
@@ -22345,8 +22191,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1277,
-    "countryRank": 26
+    "aggregatedRank": 1261,
+    "countryRank": 25
   },
   {
     "name": "Applied Science University Bahrain",
@@ -22358,7 +22204,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1278,
+    "aggregatedRank": 1262,
     "countryRank": 2
   },
   {
@@ -22371,7 +22217,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1279,
+    "aggregatedRank": 1263,
     "countryRank": 37
   },
   {
@@ -22384,7 +22230,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1280,
+    "aggregatedRank": 1264,
     "countryRank": 4
   },
   {
@@ -22397,7 +22243,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1281,
+    "aggregatedRank": 1265,
     "countryRank": 20
   },
   {
@@ -22410,7 +22256,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1282,
+    "aggregatedRank": 1266,
     "countryRank": 7
   },
   {
@@ -22423,7 +22269,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1283,
+    "aggregatedRank": 1267,
     "countryRank": 5
   },
   {
@@ -22436,7 +22282,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1284,
+    "aggregatedRank": 1268,
     "countryRank": 6
   },
   {
@@ -22449,7 +22295,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1285,
+    "aggregatedRank": 1269,
     "countryRank": 15
   },
   {
@@ -22465,7 +22311,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1286,
+    "aggregatedRank": 1270,
     "countryRank": 38
   },
   {
@@ -22481,7 +22327,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1287,
+    "aggregatedRank": 1271,
     "countryRank": 2
   },
   {
@@ -22497,8 +22343,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1288,
-    "countryRank": 27
+    "aggregatedRank": 1272,
+    "countryRank": 26
   },
   {
     "name": "SRM Institute Of Science and Technology ( Deemed University)",
@@ -22513,7 +22359,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1289,
+    "aggregatedRank": 1273,
     "countryRank": 8
   },
   {
@@ -22529,7 +22375,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1290,
+    "aggregatedRank": 1274,
     "countryRank": 9
   },
   {
@@ -22542,7 +22388,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1291,
+    "aggregatedRank": 1275,
     "countryRank": 7
   },
   {
@@ -22555,7 +22401,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1292,
+    "aggregatedRank": 1276,
     "countryRank": 5
   },
   {
@@ -22568,8 +22414,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1293,
-    "countryRank": 19
+    "aggregatedRank": 1277,
+    "countryRank": 18
   },
   {
     "name": "Asia Pacific University of Technology and Innovation",
@@ -22581,7 +22427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1294,
+    "aggregatedRank": 1278,
     "countryRank": 16
   },
   {
@@ -22594,7 +22440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1295,
+    "aggregatedRank": 1279,
     "countryRank": 6
   },
   {
@@ -22607,7 +22453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1296,
+    "aggregatedRank": 1280,
     "countryRank": 11
   },
   {
@@ -22620,7 +22466,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1297,
+    "aggregatedRank": 1281,
     "countryRank": 5
   },
   {
@@ -22633,7 +22479,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1298,
+    "aggregatedRank": 1282,
     "countryRank": 21
   },
   {
@@ -22646,8 +22492,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1299,
-    "countryRank": 173
+    "aggregatedRank": 1283,
+    "countryRank": 174
   },
   {
     "name": "Ritsumeikan University",
@@ -22659,8 +22505,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1300,
-    "countryRank": 28
+    "aggregatedRank": 1284,
+    "countryRank": 27
   },
   {
     "name": "De La Salle University",
@@ -22672,7 +22518,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1301,
+    "aggregatedRank": 1285,
     "countryRank": 3
   },
   {
@@ -22688,8 +22534,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1302,
-    "countryRank": 29
+    "aggregatedRank": 1286,
+    "countryRank": 28
   },
   {
     "name": "Nicolaus Copernicus University",
@@ -22704,7 +22550,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1303,
+    "aggregatedRank": 1287,
     "countryRank": 9
   },
   {
@@ -22717,7 +22563,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1304,
+    "aggregatedRank": 1288,
     "countryRank": 31
   },
   {
@@ -22730,8 +22576,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1305,
-    "countryRank": 174
+    "aggregatedRank": 1289,
+    "countryRank": 175
   },
   {
     "name": "Sofia University",
@@ -22743,7 +22589,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1306,
+    "aggregatedRank": 1290,
     "countryRank": 1
   },
   {
@@ -22756,7 +22602,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1307,
+    "aggregatedRank": 1291,
     "countryRank": 17
   },
   {
@@ -22769,7 +22615,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1308,
+    "aggregatedRank": 1292,
     "countryRank": 1
   },
   {
@@ -22782,7 +22628,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1309,
+    "aggregatedRank": 1293,
     "countryRank": 6
   },
   {
@@ -22795,7 +22641,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1310,
+    "aggregatedRank": 1294,
     "countryRank": 7
   },
   {
@@ -22808,7 +22654,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1311,
+    "aggregatedRank": 1295,
     "countryRank": 23
   },
   {
@@ -22821,7 +22667,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1312,
+    "aggregatedRank": 1296,
     "countryRank": 53
   },
   {
@@ -22834,7 +22680,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1313,
+    "aggregatedRank": 1297,
     "countryRank": 1
   },
   {
@@ -22847,7 +22693,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1314,
+    "aggregatedRank": 1298,
     "countryRank": 5
   },
   {
@@ -22860,7 +22706,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1315,
+    "aggregatedRank": 1299,
     "countryRank": 1
   },
   {
@@ -22873,7 +22719,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1316,
+    "aggregatedRank": 1300,
     "countryRank": 24
   },
   {
@@ -22886,7 +22732,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1317,
+    "aggregatedRank": 1301,
     "countryRank": 54
   },
   {
@@ -22902,8 +22748,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1318,
-    "countryRank": 30
+    "aggregatedRank": 1302,
+    "countryRank": 29
   },
   {
     "name": "Hallym University",
@@ -22918,7 +22764,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1319,
+    "aggregatedRank": 1303,
     "countryRank": 32
   },
   {
@@ -22931,7 +22777,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1320,
+    "aggregatedRank": 1304,
     "countryRank": 3
   },
   {
@@ -22944,8 +22790,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1321,
-    "countryRank": 53
+    "aggregatedRank": 1305,
+    "countryRank": 52
   },
   {
     "name": "Lingnan University",
@@ -22957,8 +22803,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1322,
-    "countryRank": 8
+    "aggregatedRank": 1306,
+    "countryRank": 7
   },
   {
     "name": "University of Mumbai",
@@ -22970,7 +22816,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1323,
+    "aggregatedRank": 1307,
     "countryRank": 55
   },
   {
@@ -22983,7 +22829,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1324,
+    "aggregatedRank": 1308,
     "countryRank": 22
   },
   {
@@ -22996,7 +22842,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1325,
+    "aggregatedRank": 1309,
     "countryRank": 5
   },
   {
@@ -23009,7 +22855,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1326,
+    "aggregatedRank": 1310,
     "countryRank": 8
   },
   {
@@ -23022,7 +22868,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1327,
+    "aggregatedRank": 1311,
     "countryRank": 56
   },
   {
@@ -23035,7 +22881,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1328,
+    "aggregatedRank": 1312,
     "countryRank": 1
   },
   {
@@ -23048,7 +22894,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1329,
+    "aggregatedRank": 1313,
     "countryRank": 22
   },
   {
@@ -23061,7 +22907,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1330,
+    "aggregatedRank": 1314,
     "countryRank": 3
   },
   {
@@ -23074,7 +22920,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1331,
+    "aggregatedRank": 1315,
     "countryRank": 23
   },
   {
@@ -23087,7 +22933,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1332,
+    "aggregatedRank": 1316,
     "countryRank": 2
   },
   {
@@ -23100,7 +22946,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1333,
+    "aggregatedRank": 1317,
     "countryRank": 2
   },
   {
@@ -23113,7 +22959,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1334,
+    "aggregatedRank": 1318,
     "countryRank": 3
   },
   {
@@ -23126,7 +22972,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1335,
+    "aggregatedRank": 1319,
     "countryRank": 4
   },
   {
@@ -23139,7 +22985,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1336,
+    "aggregatedRank": 1320,
     "countryRank": 6
   },
   {
@@ -23152,8 +22998,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1337,
-    "countryRank": 111
+    "aggregatedRank": 1321,
+    "countryRank": 113
   },
   {
     "name": "University of Massachusetts Medical School",
@@ -23165,8 +23011,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1338,
-    "countryRank": 175
+    "aggregatedRank": 1322,
+    "countryRank": 176
   },
   {
     "name": "King Abdullah University of Science and Technology",
@@ -23178,7 +23024,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1339,
+    "aggregatedRank": 1323,
     "countryRank": 23
   },
   {
@@ -23191,7 +23037,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1340,
+    "aggregatedRank": 1324,
     "countryRank": 7
   },
   {
@@ -23204,7 +23050,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1341,
+    "aggregatedRank": 1325,
     "countryRank": 4
   },
   {
@@ -23217,7 +23063,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1342,
+    "aggregatedRank": 1326,
     "countryRank": 7
   },
   {
@@ -23230,7 +23076,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1343,
+    "aggregatedRank": 1327,
     "countryRank": 6
   },
   {
@@ -23243,7 +23089,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1344,
+    "aggregatedRank": 1328,
     "countryRank": 7
   },
   {
@@ -23256,7 +23102,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1345,
+    "aggregatedRank": 1329,
     "countryRank": 2
   },
   {
@@ -23269,7 +23115,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1346,
+    "aggregatedRank": 1330,
     "countryRank": 3
   },
   {
@@ -23282,7 +23128,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1347,
+    "aggregatedRank": 1331,
     "countryRank": 6
   },
   {
@@ -23295,7 +23141,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1348,
+    "aggregatedRank": 1332,
     "countryRank": 2
   },
   {
@@ -23308,8 +23154,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1349,
-    "countryRank": 176
+    "aggregatedRank": 1333,
+    "countryRank": 177
   },
   {
     "name": "Zurich University of Applied Sciences",
@@ -23321,7 +23167,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1350,
+    "aggregatedRank": 1334,
     "countryRank": 12
   },
   {
@@ -23334,7 +23180,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1351,
+    "aggregatedRank": 1335,
     "countryRank": 5
   },
   {
@@ -23347,7 +23193,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1352,
+    "aggregatedRank": 1336,
     "countryRank": 1
   },
   {
@@ -23360,7 +23206,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1353,
+    "aggregatedRank": 1337,
     "countryRank": 6
   },
   {
@@ -23373,7 +23219,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1354,
+    "aggregatedRank": 1338,
     "countryRank": 2
   },
   {
@@ -23386,7 +23232,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1355,
+    "aggregatedRank": 1339,
     "countryRank": 57
   },
   {
@@ -23399,7 +23245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1356,
+    "aggregatedRank": 1340,
     "countryRank": 2
   },
   {
@@ -23412,7 +23258,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1357,
+    "aggregatedRank": 1341,
     "countryRank": 8
   },
   {
@@ -23425,7 +23271,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1358,
+    "aggregatedRank": 1342,
     "countryRank": 18
   },
   {
@@ -23438,7 +23284,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1359,
+    "aggregatedRank": 1343,
     "countryRank": 4
   },
   {
@@ -23451,7 +23297,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1360,
+    "aggregatedRank": 1344,
     "countryRank": 4
   },
   {
@@ -23464,7 +23310,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1361,
+    "aggregatedRank": 1345,
     "countryRank": 9
   },
   {
@@ -23477,7 +23323,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1362,
+    "aggregatedRank": 1346,
     "countryRank": 9
   },
   {
@@ -23490,7 +23336,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1363,
+    "aggregatedRank": 1347,
     "countryRank": 1
   },
   {
@@ -23503,7 +23349,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1364,
+    "aggregatedRank": 1348,
     "countryRank": 2
   },
   {
@@ -23516,7 +23362,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1365,
+    "aggregatedRank": 1349,
     "countryRank": 24
   },
   {
@@ -23529,7 +23375,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1366,
+    "aggregatedRank": 1350,
     "countryRank": 8
   },
   {
@@ -23542,7 +23388,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1367,
+    "aggregatedRank": 1351,
     "countryRank": 1
   },
   {
@@ -23555,7 +23401,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1368,
+    "aggregatedRank": 1352,
     "countryRank": 12
   },
   {
@@ -23568,7 +23414,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1369,
+    "aggregatedRank": 1353,
     "countryRank": 8
   },
   {
@@ -23581,7 +23427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1370,
+    "aggregatedRank": 1354,
     "countryRank": 1
   },
   {
@@ -23594,7 +23440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1371,
+    "aggregatedRank": 1355,
     "countryRank": 3
   },
   {
@@ -23607,7 +23453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1372,
+    "aggregatedRank": 1356,
     "countryRank": 9
   },
   {
@@ -23620,7 +23466,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1373,
+    "aggregatedRank": 1357,
     "countryRank": 5
   },
   {
@@ -23633,7 +23479,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1374,
+    "aggregatedRank": 1358,
     "countryRank": 4
   },
   {
@@ -23646,7 +23492,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1375,
+    "aggregatedRank": 1359,
     "countryRank": 10
   },
   {
@@ -23659,7 +23505,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1376,
+    "aggregatedRank": 1360,
     "countryRank": 11
   },
   {
@@ -23672,7 +23518,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1377,
+    "aggregatedRank": 1361,
     "countryRank": 2
   },
   {
@@ -23685,7 +23531,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1378,
+    "aggregatedRank": 1362,
     "countryRank": 3
   },
   {
@@ -23698,8 +23544,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1379,
-    "countryRank": 177
+    "aggregatedRank": 1363,
+    "countryRank": 178
   },
   {
     "name": "Swarthmore College",
@@ -23711,8 +23557,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1380,
-    "countryRank": 178
+    "aggregatedRank": 1364,
+    "countryRank": 179
   },
   {
     "name": "Viet Nam National University - Hanoi",
@@ -23724,7 +23570,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1381,
+    "aggregatedRank": 1365,
     "countryRank": 5
   },
   {
@@ -23737,7 +23583,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1382,
+    "aggregatedRank": 1366,
     "countryRank": 9
   },
   {
@@ -23750,7 +23596,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1383,
+    "aggregatedRank": 1367,
     "countryRank": 12
   },
   {
@@ -23763,8 +23609,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1384,
-    "countryRank": 112
+    "aggregatedRank": 1368,
+    "countryRank": 114
   },
   {
     "name": "Guangxi University",
@@ -23776,8 +23622,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1385,
-    "countryRank": 113
+    "aggregatedRank": 1369,
+    "countryRank": 115
   },
   {
     "name": "University of Shanghai for Science and Technology",
@@ -23789,8 +23635,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1386,
-    "countryRank": 114
+    "aggregatedRank": 1370,
+    "countryRank": 116
   },
   {
     "name": "Albert Einstein College of Medicine - Yeshiva University",
@@ -23802,8 +23648,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1387,
-    "countryRank": 179
+    "aggregatedRank": 1371,
+    "countryRank": 180
+  },
+  {
+    "name": "China University of Geosciences - Beijing",
+    "country": "China",
+    "aggregatedScore": 18.046875,
+    "originalRankings": {
+      "arwu": {
+        "rank": 301
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 1372,
+    "countryRank": 117
   },
   {
     "name": "Yerevan State University",
@@ -23815,7 +23674,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1388,
+    "aggregatedRank": 1373,
     "countryRank": 1
   },
   {
@@ -23828,7 +23687,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1389,
+    "aggregatedRank": 1374,
     "countryRank": 6
   },
   {
@@ -23841,7 +23700,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1390,
+    "aggregatedRank": 1375,
     "countryRank": 7
   },
   {
@@ -23854,7 +23713,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1391,
+    "aggregatedRank": 1376,
     "countryRank": 2
   },
   {
@@ -23867,8 +23726,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1392,
-    "countryRank": 54
+    "aggregatedRank": 1377,
+    "countryRank": 53
   },
   {
     "name": "Georgian Technical University",
@@ -23880,7 +23739,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1393,
+    "aggregatedRank": 1378,
     "countryRank": 2
   },
   {
@@ -23893,7 +23752,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1394,
+    "aggregatedRank": 1379,
     "countryRank": 5
   },
   {
@@ -23906,7 +23765,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1395,
+    "aggregatedRank": 1380,
     "countryRank": 6
   },
   {
@@ -23919,8 +23778,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1396,
-    "countryRank": 31
+    "aggregatedRank": 1381,
+    "countryRank": 30
   },
   {
     "name": "University of Nairobi",
@@ -23932,7 +23791,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1397,
+    "aggregatedRank": 1382,
     "countryRank": 1
   },
   {
@@ -23945,7 +23804,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1398,
+    "aggregatedRank": 1383,
     "countryRank": 2
   },
   {
@@ -23958,7 +23817,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1399,
+    "aggregatedRank": 1384,
     "countryRank": 10
   },
   {
@@ -23971,7 +23830,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1400,
+    "aggregatedRank": 1385,
     "countryRank": 2
   },
   {
@@ -23984,7 +23843,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1401,
+    "aggregatedRank": 1386,
     "countryRank": 25
   },
   {
@@ -23997,7 +23856,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1402,
+    "aggregatedRank": 1387,
     "countryRank": 13
   },
   {
@@ -24010,7 +23869,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1403,
+    "aggregatedRank": 1388,
     "countryRank": 25
   },
   {
@@ -24023,7 +23882,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1404,
+    "aggregatedRank": 1389,
     "countryRank": 3
   },
   {
@@ -24036,7 +23895,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1405,
+    "aggregatedRank": 1390,
     "countryRank": 15
   },
   {
@@ -24049,7 +23908,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1406,
+    "aggregatedRank": 1391,
     "countryRank": 1
   },
   {
@@ -24062,8 +23921,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1407,
-    "countryRank": 101
+    "aggregatedRank": 1392,
+    "countryRank": 99
   },
   {
     "name": "Catholic University of Uruguay",
@@ -24075,7 +23934,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1408,
+    "aggregatedRank": 1393,
     "countryRank": 4
   },
   {
@@ -24088,8 +23947,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1409,
-    "countryRank": 180
+    "aggregatedRank": 1394,
+    "countryRank": 181
   },
   {
     "name": "Wroclaw University of Science and Technology",
@@ -24101,7 +23960,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1410,
+    "aggregatedRank": 1395,
     "countryRank": 14
   },
   {
@@ -24114,7 +23973,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1411,
+    "aggregatedRank": 1396,
     "countryRank": 6
   },
   {
@@ -24127,7 +23986,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1412,
+    "aggregatedRank": 1397,
     "countryRank": 8
   },
   {
@@ -24140,7 +23999,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1413,
+    "aggregatedRank": 1398,
     "countryRank": 11
   },
   {
@@ -24153,7 +24012,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1414,
+    "aggregatedRank": 1399,
     "countryRank": 26
   },
   {
@@ -24166,7 +24025,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1415,
+    "aggregatedRank": 1400,
     "countryRank": 7
   },
   {
@@ -24179,7 +24038,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1416,
+    "aggregatedRank": 1401,
     "countryRank": 8
   },
   {
@@ -24192,7 +24051,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1417,
+    "aggregatedRank": 1402,
     "countryRank": 9
   },
   {
@@ -24205,7 +24064,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1418,
+    "aggregatedRank": 1403,
     "countryRank": 10
   },
   {
@@ -24218,7 +24077,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1419,
+    "aggregatedRank": 1404,
     "countryRank": 1
   },
   {
@@ -24231,7 +24090,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1420,
+    "aggregatedRank": 1405,
     "countryRank": 4
   },
   {
@@ -24244,7 +24103,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1421,
+    "aggregatedRank": 1406,
     "countryRank": 7
   },
   {
@@ -24257,7 +24116,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1422,
+    "aggregatedRank": 1407,
     "countryRank": 8
   },
   {
@@ -24270,7 +24129,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1423,
+    "aggregatedRank": 1408,
     "countryRank": 9
   },
   {
@@ -24283,7 +24142,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1424,
+    "aggregatedRank": 1409,
     "countryRank": 9
   },
   {
@@ -24296,7 +24155,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1425,
+    "aggregatedRank": 1410,
     "countryRank": 3
   },
   {
@@ -24309,7 +24168,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1426,
+    "aggregatedRank": 1411,
     "countryRank": 39
   },
   {
@@ -24322,8 +24181,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1427,
-    "countryRank": 55
+    "aggregatedRank": 1412,
+    "countryRank": 54
   },
   {
     "name": "Athens University of Economics and Business",
@@ -24335,7 +24194,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1428,
+    "aggregatedRank": 1413,
     "countryRank": 7
   },
   {
@@ -24348,7 +24207,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1429,
+    "aggregatedRank": 1414,
     "countryRank": 10
   },
   {
@@ -24361,7 +24220,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1430,
+    "aggregatedRank": 1415,
     "countryRank": 7
   },
   {
@@ -24374,8 +24233,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1431,
-    "countryRank": 32
+    "aggregatedRank": 1416,
+    "countryRank": 31
   },
   {
     "name": "Sophia University",
@@ -24387,8 +24246,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1432,
-    "countryRank": 33
+    "aggregatedRank": 1417,
+    "countryRank": 32
   },
   {
     "name": "University of Colombo",
@@ -24400,7 +24259,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1433,
+    "aggregatedRank": 1418,
     "countryRank": 1
   },
   {
@@ -24413,7 +24272,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1434,
+    "aggregatedRank": 1419,
     "countryRank": 10
   },
   {
@@ -24426,7 +24285,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1435,
+    "aggregatedRank": 1420,
     "countryRank": 7
   },
   {
@@ -24439,7 +24298,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1436,
+    "aggregatedRank": 1421,
     "countryRank": 8
   },
   {
@@ -24452,7 +24311,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1437,
+    "aggregatedRank": 1422,
     "countryRank": 10
   },
   {
@@ -24465,7 +24324,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1438,
+    "aggregatedRank": 1423,
     "countryRank": 27
   },
   {
@@ -24478,7 +24337,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1439,
+    "aggregatedRank": 1424,
     "countryRank": 3
   },
   {
@@ -24491,7 +24350,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1440,
+    "aggregatedRank": 1425,
     "countryRank": 58
   },
   {
@@ -24504,7 +24363,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1441,
+    "aggregatedRank": 1426,
     "countryRank": 12
   },
   {
@@ -24517,8 +24376,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1442,
-    "countryRank": 115
+    "aggregatedRank": 1427,
+    "countryRank": 118
   },
   {
     "name": "Hefei University of Technology",
@@ -24530,8 +24389,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1443,
-    "countryRank": 116
+    "aggregatedRank": 1428,
+    "countryRank": 119
   },
   {
     "name": "Henan University",
@@ -24543,8 +24402,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1444,
-    "countryRank": 117
+    "aggregatedRank": 1429,
+    "countryRank": 120
   },
   {
     "name": "Nanjing University of Posts and Telecommunications",
@@ -24556,8 +24415,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1445,
-    "countryRank": 118
+    "aggregatedRank": 1430,
+    "countryRank": 121
   },
   {
     "name": "National University of Defense Technology",
@@ -24569,8 +24428,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1446,
-    "countryRank": 119
+    "aggregatedRank": 1431,
+    "countryRank": 122
   },
   {
     "name": "Ningbo University",
@@ -24582,8 +24441,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1447,
-    "countryRank": 120
+    "aggregatedRank": 1432,
+    "countryRank": 123
   },
   {
     "name": "Yunnan University",
@@ -24595,8 +24454,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1448,
-    "countryRank": 121
+    "aggregatedRank": 1433,
+    "countryRank": 124
   },
   {
     "name": "The Graduate Center - CUNY",
@@ -24608,8 +24467,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1449,
-    "countryRank": 181
+    "aggregatedRank": 1434,
+    "countryRank": 182
   },
   {
     "name": "University of Texas Medical Branch Galveston",
@@ -24621,8 +24480,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1450,
-    "countryRank": 182
+    "aggregatedRank": 1435,
+    "countryRank": 183
   },
   {
     "name": "Utah State University",
@@ -24634,8 +24493,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1451,
-    "countryRank": 183
+    "aggregatedRank": 1436,
+    "countryRank": 184
   },
   {
     "name": "Kunming University of Science and Technology",
@@ -24647,8 +24506,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1452,
-    "countryRank": 122
+    "aggregatedRank": 1437,
+    "countryRank": 125
   },
   {
     "name": "Okinawa Institute of Science and Technology Graduate University",
@@ -24660,8 +24519,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1453,
-    "countryRank": 34
+    "aggregatedRank": 1438,
+    "countryRank": 33
   },
   {
     "name": "Hohai University Changzhou",
@@ -24673,8 +24532,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1454,
-    "countryRank": 123
+    "aggregatedRank": 1439,
+    "countryRank": 126
   },
   {
     "name": "Anhui Medical University",
@@ -24686,8 +24545,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1455,
-    "countryRank": 124
+    "aggregatedRank": 1440,
+    "countryRank": 127
   },
   {
     "name": "Chongqing Medical University",
@@ -24699,8 +24558,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1456,
-    "countryRank": 125
+    "aggregatedRank": 1441,
+    "countryRank": 128
   },
   {
     "name": "Fujian Medical University",
@@ -24712,8 +24571,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1457,
-    "countryRank": 126
+    "aggregatedRank": 1442,
+    "countryRank": 129
   },
   {
     "name": "Guizhou University",
@@ -24725,8 +24584,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1458,
-    "countryRank": 127
+    "aggregatedRank": 1443,
+    "countryRank": 130
   },
   {
     "name": "Nanjing University of Traditional Chinese Medicine",
@@ -24738,8 +24597,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1459,
-    "countryRank": 128
+    "aggregatedRank": 1444,
+    "countryRank": 131
   },
   {
     "name": "Shaanxi Normal University",
@@ -24751,8 +24610,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1460,
-    "countryRank": 129
+    "aggregatedRank": 1445,
+    "countryRank": 132
   },
   {
     "name": "Tianjin Medical University",
@@ -24764,8 +24623,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1461,
-    "countryRank": 130
+    "aggregatedRank": 1446,
+    "countryRank": 133
   },
   {
     "name": "Xi'an University of Technology",
@@ -24777,8 +24636,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1462,
-    "countryRank": 131
+    "aggregatedRank": 1447,
+    "countryRank": 134
   },
   {
     "name": "University of La Laguna",
@@ -24790,7 +24649,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1463,
+    "aggregatedRank": 1448,
     "countryRank": 40
   },
   {
@@ -24803,7 +24662,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1464,
+    "aggregatedRank": 1449,
     "countryRank": 7
   },
   {
@@ -24816,8 +24675,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1465,
-    "countryRank": 184
+    "aggregatedRank": 1450,
+    "countryRank": 185
   },
   {
     "name": "University of Maine - Orono",
@@ -24829,8 +24688,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1466,
-    "countryRank": 185
+    "aggregatedRank": 1451,
+    "countryRank": 186
   },
   {
     "name": "University of North Texas",
@@ -24842,8 +24701,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1467,
-    "countryRank": 186
+    "aggregatedRank": 1452,
+    "countryRank": 187
   },
   {
     "name": "West Virginia University",
@@ -24855,8 +24714,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1468,
-    "countryRank": 187
+    "aggregatedRank": 1453,
+    "countryRank": 188
   },
   {
     "name": "Zhejiang Science-Technology University",
@@ -24868,8 +24727,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1469,
-    "countryRank": 132
+    "aggregatedRank": 1454,
+    "countryRank": 135
   },
   {
     "name": "Hangzhou Dianzi University",
@@ -24881,8 +24740,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1470,
-    "countryRank": 133
+    "aggregatedRank": 1455,
+    "countryRank": 136
+  },
+  {
+    "name": "The Chinese University of Hong Kong - Shenzhen",
+    "country": "China",
+    "aggregatedScore": -13.203125,
+    "originalRankings": {
+      "arwu": {
+        "rank": 501
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 1456,
+    "countryRank": 137
   },
   {
     "name": "Hebei University of Technology",
@@ -24894,8 +24766,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1471,
-    "countryRank": 134
+    "aggregatedRank": 1457,
+    "countryRank": 138
   },
   {
     "name": "Second Military Medical University",
@@ -24907,8 +24779,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1472,
-    "countryRank": 135
+    "aggregatedRank": 1458,
+    "countryRank": 139
   },
   {
     "name": "Air Force Medical University",
@@ -24920,8 +24792,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1473,
-    "countryRank": 136
+    "aggregatedRank": 1459,
+    "countryRank": 140
+  },
+  {
+    "name": "China University of Mining Technology - Beijing",
+    "country": "China",
+    "aggregatedScore": -28.828125,
+    "originalRankings": {
+      "arwu": {
+        "rank": 601
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 1460,
+    "countryRank": 141
   },
   {
     "name": "Dalian Maritime University",
@@ -24933,8 +24818,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1474,
-    "countryRank": 137
+    "aggregatedRank": 1461,
+    "countryRank": 142
   },
   {
     "name": "Fujian Normal University",
@@ -24946,8 +24831,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1475,
-    "countryRank": 138
+    "aggregatedRank": 1462,
+    "countryRank": 143
   },
   {
     "name": "Henan Normal University",
@@ -24959,8 +24844,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1476,
-    "countryRank": 139
+    "aggregatedRank": 1463,
+    "countryRank": 144
   },
   {
     "name": "Hunan Normal University",
@@ -24972,8 +24857,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1477,
-    "countryRank": 140
+    "aggregatedRank": 1464,
+    "countryRank": 145
   },
   {
     "name": "Qingdao University of Science and Technology",
@@ -24985,8 +24870,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1478,
-    "countryRank": 141
+    "aggregatedRank": 1465,
+    "countryRank": 146
   },
   {
     "name": "Shandong Agricultural University",
@@ -24998,8 +24883,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1479,
-    "countryRank": 142
+    "aggregatedRank": 1466,
+    "countryRank": 147
   },
   {
     "name": "Shanxi University",
@@ -25011,8 +24896,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1480,
-    "countryRank": 143
+    "aggregatedRank": 1467,
+    "countryRank": 148
   },
   {
     "name": "Taiyuan University of Technology",
@@ -25024,8 +24909,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1481,
-    "countryRank": 144
+    "aggregatedRank": 1468,
+    "countryRank": 149
   },
   {
     "name": "University of Lubeck",
@@ -25037,8 +24922,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1482,
-    "countryRank": 73
+    "aggregatedRank": 1469,
+    "countryRank": 72
   },
   {
     "name": "University of Bielefeld",
@@ -25050,8 +24935,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1483,
-    "countryRank": 74
+    "aggregatedRank": 1470,
+    "countryRank": 73
   },
   {
     "name": "Tarbiat Modares University",
@@ -25063,7 +24948,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1484,
+    "aggregatedRank": 1471,
     "countryRank": 37
   },
   {
@@ -25076,8 +24961,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1485,
-    "countryRank": 35
+    "aggregatedRank": 1472,
+    "countryRank": 34
   },
   {
     "name": "University of Louisville",
@@ -25089,8 +24974,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1486,
-    "countryRank": 188
+    "aggregatedRank": 1473,
+    "countryRank": 189
   },
   {
     "name": "University of Nevada - Reno",
@@ -25102,8 +24987,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1487,
-    "countryRank": 189
+    "aggregatedRank": 1474,
+    "countryRank": 190
   },
   {
     "name": "University of New Hampshire",
@@ -25115,8 +25000,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1488,
-    "countryRank": 190
+    "aggregatedRank": 1475,
+    "countryRank": 191
   },
   {
     "name": "Thomas Jefferson University",
@@ -25128,8 +25013,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1489,
-    "countryRank": 191
+    "aggregatedRank": 1476,
+    "countryRank": 192
   },
   {
     "name": "Brigham Young University",
@@ -25141,8 +25026,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1490,
-    "countryRank": 192
+    "aggregatedRank": 1477,
+    "countryRank": 193
   },
   {
     "name": "Medical College of Wisconsin",
@@ -25154,8 +25039,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1491,
-    "countryRank": 193
+    "aggregatedRank": 1478,
+    "countryRank": 194
   },
   {
     "name": "University of Natural Resources and Life Sciences",
@@ -25167,7 +25052,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1492,
+    "aggregatedRank": 1479,
     "countryRank": 14
   },
   {
@@ -25180,8 +25065,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1493,
-    "countryRank": 145
+    "aggregatedRank": 1480,
+    "countryRank": 150
   },
   {
     "name": "Yanshan University",
@@ -25193,8 +25078,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1494,
-    "countryRank": 146
+    "aggregatedRank": 1481,
+    "countryRank": 151
   },
   {
     "name": "Fujian Agriculture and Forestry University",
@@ -25206,8 +25091,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1495,
-    "countryRank": 147
+    "aggregatedRank": 1482,
+    "countryRank": 152
   },
   {
     "name": "Duke-NUS Medical School",
@@ -25219,7 +25104,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1496,
+    "aggregatedRank": 1483,
     "countryRank": 5
   },
   {
@@ -25232,8 +25117,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1497,
-    "countryRank": 148
+    "aggregatedRank": 1484,
+    "countryRank": 153
   },
   {
     "name": "Qilu University of Technology",
@@ -25245,8 +25130,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1498,
-    "countryRank": 149
+    "aggregatedRank": 1485,
+    "countryRank": 154
   },
   {
     "name": "Shandong First Medical University",
@@ -25258,8 +25143,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1499,
-    "countryRank": 150
+    "aggregatedRank": 1486,
+    "countryRank": 155
   },
   {
     "name": "University of Health Sciences Turkey",
@@ -25271,7 +25156,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1500,
+    "aggregatedRank": 1487,
     "countryRank": 16
   },
   {
@@ -25284,8 +25169,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1501,
-    "countryRank": 16
+    "aggregatedRank": 1488,
+    "countryRank": 15
   },
   {
     "name": "Federal University of Paran�",
@@ -25297,8 +25182,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1502,
-    "countryRank": 17
+    "aggregatedRank": 1489,
+    "countryRank": 16
   },
   {
     "name": "Beijing Forestry University",
@@ -25310,8 +25195,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1503,
-    "countryRank": 151
+    "aggregatedRank": 1490,
+    "countryRank": 156
   },
   {
     "name": "China Medical University",
@@ -25323,8 +25208,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1504,
-    "countryRank": 152
+    "aggregatedRank": 1491,
+    "countryRank": 157
   },
   {
     "name": "Chongqing University of Posts and Telecommunications",
@@ -25336,8 +25221,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1505,
-    "countryRank": 153
+    "aggregatedRank": 1492,
+    "countryRank": 158
   },
   {
     "name": "Harbin Medical University",
@@ -25349,8 +25234,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1506,
-    "countryRank": 154
+    "aggregatedRank": 1493,
+    "countryRank": 159
   },
   {
     "name": "Hubei University",
@@ -25362,8 +25247,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1507,
-    "countryRank": 155
+    "aggregatedRank": 1494,
+    "countryRank": 160
   },
   {
     "name": "Shantou University",
@@ -25375,8 +25260,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1508,
-    "countryRank": 156
+    "aggregatedRank": 1495,
+    "countryRank": 161
   },
   {
     "name": "Xinjiang University",
@@ -25388,8 +25273,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1509,
-    "countryRank": 157
+    "aggregatedRank": 1496,
+    "countryRank": 162
   },
   {
     "name": "University of Oldenburg",
@@ -25401,8 +25286,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1510,
-    "countryRank": 75
+    "aggregatedRank": 1497,
+    "countryRank": 74
   },
   {
     "name": "University of Magdeburg",
@@ -25414,8 +25299,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1511,
-    "countryRank": 76
+    "aggregatedRank": 1498,
+    "countryRank": 75
   },
   {
     "name": "University of Augsburg",
@@ -25427,8 +25312,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1512,
-    "countryRank": 77
+    "aggregatedRank": 1499,
+    "countryRank": 76
   },
   {
     "name": "Copenhagen Business School",
@@ -25440,7 +25325,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1513,
+    "aggregatedRank": 1500,
     "countryRank": 7
   },
   {
@@ -25453,7 +25338,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1514,
+    "aggregatedRank": 1501,
     "countryRank": 41
   },
   {
@@ -25466,7 +25351,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1515,
+    "aggregatedRank": 1502,
     "countryRank": 42
   },
   {
@@ -25479,8 +25364,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1516,
-    "countryRank": 36
+    "aggregatedRank": 1503,
+    "countryRank": 35
   },
   {
     "name": "Kitasato University",
@@ -25492,8 +25377,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1517,
-    "countryRank": 37
+    "aggregatedRank": 1504,
+    "countryRank": 36
   },
   {
     "name": "Chungbuk National University",
@@ -25505,7 +25390,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1518,
+    "aggregatedRank": 1505,
     "countryRank": 33
   },
   {
@@ -25518,7 +25403,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1519,
+    "aggregatedRank": 1506,
     "countryRank": 14
   },
   {
@@ -25531,8 +25416,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1520,
-    "countryRank": 194
+    "aggregatedRank": 1507,
+    "countryRank": 195
   },
   {
     "name": "Kent State University",
@@ -25544,8 +25429,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1521,
-    "countryRank": 195
+    "aggregatedRank": 1508,
+    "countryRank": 196
   },
   {
     "name": "Southern Methodist University",
@@ -25557,8 +25442,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1522,
-    "countryRank": 196
+    "aggregatedRank": 1509,
+    "countryRank": 197
   },
   {
     "name": "University of Tennessee Health Science Center",
@@ -25570,8 +25455,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1523,
-    "countryRank": 197
+    "aggregatedRank": 1510,
+    "countryRank": 198
   },
   {
     "name": "University Paris-Est Cr�teil Val de Marne",
@@ -25583,8 +25468,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1524,
-    "countryRank": 56
+    "aggregatedRank": 1511,
+    "countryRank": 55
   },
   {
     "name": "Army Medical University",
@@ -25596,8 +25481,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1525,
-    "countryRank": 158
+    "aggregatedRank": 1512,
+    "countryRank": 163
   },
   {
     "name": "Chang'an University",
@@ -25609,8 +25494,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1526,
-    "countryRank": 159
+    "aggregatedRank": 1513,
+    "countryRank": 164
   },
   {
     "name": "Beijing Technology and Business University",
@@ -25622,8 +25507,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1527,
-    "countryRank": 160
+    "aggregatedRank": 1514,
+    "countryRank": 165
   },
   {
     "name": "Lanzhou University of Technology",
@@ -25635,8 +25520,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1528,
-    "countryRank": 161
+    "aggregatedRank": 1515,
+    "countryRank": 166
   },
   {
     "name": "Shanghai Ocean University",
@@ -25648,8 +25533,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1529,
-    "countryRank": 162
+    "aggregatedRank": 1516,
+    "countryRank": 167
   },
   {
     "name": "Homi Bhabha National Institute",
@@ -25661,7 +25546,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1530,
+    "aggregatedRank": 1517,
     "countryRank": 59
   },
   {
@@ -25674,8 +25559,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1531,
-    "countryRank": 163
+    "aggregatedRank": 1518,
+    "countryRank": 168
   },
   {
     "name": "Federal University of S�o Carlos",
@@ -25687,8 +25572,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1532,
-    "countryRank": 18
+    "aggregatedRank": 1519,
+    "countryRank": 17
   },
   {
     "name": "Federal University of Vi�osa",
@@ -25700,8 +25585,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1533,
-    "countryRank": 19
+    "aggregatedRank": 1520,
+    "countryRank": 18
   },
   {
     "name": "University of Qu�bec at Montreal",
@@ -25713,8 +25598,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1534,
-    "countryRank": 33
+    "aggregatedRank": 1521,
+    "countryRank": 34
   },
   {
     "name": "Capital Normal University",
@@ -25726,8 +25611,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1535,
-    "countryRank": 164
+    "aggregatedRank": 1522,
+    "countryRank": 169
   },
   {
     "name": "Hebei Medical University",
@@ -25739,8 +25624,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1536,
-    "countryRank": 165
+    "aggregatedRank": 1523,
+    "countryRank": 170
   },
   {
     "name": "Heilongjiang University",
@@ -25752,8 +25637,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1537,
-    "countryRank": 166
+    "aggregatedRank": 1524,
+    "countryRank": 171
   },
   {
     "name": "Jiangxi Normal University",
@@ -25765,8 +25650,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1538,
-    "countryRank": 167
+    "aggregatedRank": 1525,
+    "countryRank": 172
   },
   {
     "name": "Jimei University",
@@ -25778,8 +25663,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1539,
-    "countryRank": 168
+    "aggregatedRank": 1526,
+    "countryRank": 173
   },
   {
     "name": "Liaocheng Teachers University",
@@ -25791,8 +25676,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1540,
-    "countryRank": 169
+    "aggregatedRank": 1527,
+    "countryRank": 174
   },
   {
     "name": "Shandong Normal University",
@@ -25804,8 +25689,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1541,
-    "countryRank": 170
+    "aggregatedRank": 1528,
+    "countryRank": 175
   },
   {
     "name": "Shanghai Normal University",
@@ -25817,8 +25702,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1542,
-    "countryRank": 171
+    "aggregatedRank": 1529,
+    "countryRank": 176
   },
   {
     "name": "Sichuan Agricultural University",
@@ -25830,8 +25715,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1543,
-    "countryRank": 172
+    "aggregatedRank": 1530,
+    "countryRank": 177
   },
   {
     "name": "Xi'an University of Architecture and Technology",
@@ -25843,8 +25728,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1544,
-    "countryRank": 173
+    "aggregatedRank": 1531,
+    "countryRank": 178
   },
   {
     "name": "Xiangtan University",
@@ -25856,8 +25741,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1545,
-    "countryRank": 174
+    "aggregatedRank": 1532,
+    "countryRank": 179
   },
   {
     "name": "Zhongnan University of Economics and Law",
@@ -25869,8 +25754,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1546,
-    "countryRank": 175
+    "aggregatedRank": 1533,
+    "countryRank": 180
   },
   {
     "name": "University of Kassel",
@@ -25882,8 +25767,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1547,
-    "countryRank": 78
+    "aggregatedRank": 1534,
+    "countryRank": 77
   },
   {
     "name": "University of Oviedo",
@@ -25895,7 +25780,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1548,
+    "aggregatedRank": 1535,
     "countryRank": 43
   },
   {
@@ -25908,8 +25793,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1549,
-    "countryRank": 57
+    "aggregatedRank": 1536,
+    "countryRank": 56
   },
   {
     "name": "University of Thessaly",
@@ -25921,7 +25806,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1550,
+    "aggregatedRank": 1537,
     "countryRank": 8
   },
   {
@@ -25934,8 +25819,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1551,
-    "countryRank": 9
+    "aggregatedRank": 1538,
+    "countryRank": 8
   },
   {
     "name": "Graduate University for Advanced Studies",
@@ -25947,8 +25832,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1552,
-    "countryRank": 38
+    "aggregatedRank": 1539,
+    "countryRank": 37
   },
   {
     "name": "Kangwon National University",
@@ -25960,7 +25845,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1553,
+    "aggregatedRank": 1540,
     "countryRank": 34
   },
   {
@@ -25973,8 +25858,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1554,
-    "countryRank": 102
+    "aggregatedRank": 1541,
+    "countryRank": 100
   },
   {
     "name": "University of Missouri - Kansas City",
@@ -25986,8 +25871,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1555,
-    "countryRank": 198
+    "aggregatedRank": 1542,
+    "countryRank": 199
   },
   {
     "name": "University of Wisconsin-Milwaukee",
@@ -25999,8 +25884,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1556,
-    "countryRank": 199
+    "aggregatedRank": 1543,
+    "countryRank": 200
   },
   {
     "name": "Northeast Forestry University",
@@ -26012,8 +25897,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1557,
-    "countryRank": 176
+    "aggregatedRank": 1544,
+    "countryRank": 181
   },
   {
     "name": "Hangzhou Normal University",
@@ -26025,8 +25910,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1558,
-    "countryRank": 177
+    "aggregatedRank": 1545,
+    "countryRank": 182
   },
   {
     "name": "Southwest Petroleum University",
@@ -26038,8 +25923,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1559,
-    "countryRank": 178
+    "aggregatedRank": 1546,
+    "countryRank": 183
   },
   {
     "name": "Anhui Agricultural University",
@@ -26051,8 +25936,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1560,
-    "countryRank": 179
+    "aggregatedRank": 1547,
+    "countryRank": 184
   },
   {
     "name": "Xuzhou Medical College",
@@ -26064,8 +25949,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1561,
-    "countryRank": 180
+    "aggregatedRank": 1548,
+    "countryRank": 185
   },
   {
     "name": "Shaanxi University of Science and Technology",
@@ -26077,8 +25962,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1562,
-    "countryRank": 181
+    "aggregatedRank": 1549,
+    "countryRank": 186
   },
   {
     "name": "Qingdao Agricultural University",
@@ -26090,8 +25975,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1563,
-    "countryRank": 182
+    "aggregatedRank": 1550,
+    "countryRank": 187
   },
   {
     "name": "Skolkovo Institute of Science and Technology",
@@ -26103,7 +25988,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1564,
+    "aggregatedRank": 1551,
     "countryRank": 28
   },
   {
@@ -26116,7 +26001,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1565,
+    "aggregatedRank": 1552,
     "countryRank": 17
   },
   {
@@ -26129,8 +26014,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1566,
-    "countryRank": 200
+    "aggregatedRank": 1553,
+    "countryRank": 201
   },
   {
     "name": "University of Texas Rio Grande Valley",
@@ -26142,8 +26027,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1567,
-    "countryRank": 201
+    "aggregatedRank": 1554,
+    "countryRank": 202
   },
   {
     "name": "Federal University of Bahia",
@@ -26155,8 +26040,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1568,
-    "countryRank": 20
+    "aggregatedRank": 1555,
+    "countryRank": 19
   },
   {
     "name": "Federal University of Goi�s",
@@ -26168,8 +26053,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1569,
-    "countryRank": 21
+    "aggregatedRank": 1556,
+    "countryRank": 20
   },
   {
     "name": "Federal University of Pelotas",
@@ -26181,8 +26066,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1570,
-    "countryRank": 22
+    "aggregatedRank": 1557,
+    "countryRank": 21
   },
   {
     "name": "Federal University of Pernambuco",
@@ -26194,8 +26079,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1571,
-    "countryRank": 23
+    "aggregatedRank": 1558,
+    "countryRank": 22
   },
   {
     "name": "Federal University of Cear�",
@@ -26207,8 +26092,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1572,
-    "countryRank": 24
+    "aggregatedRank": 1559,
+    "countryRank": 23
   },
   {
     "name": "Lakehead University",
@@ -26220,8 +26105,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1573,
-    "countryRank": 34
+    "aggregatedRank": 1560,
+    "countryRank": 35
   },
   {
     "name": "National University Andr�s Bello",
@@ -26233,7 +26118,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1574,
+    "aggregatedRank": 1561,
     "countryRank": 9
   },
   {
@@ -26246,8 +26131,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1575,
-    "countryRank": 183
+    "aggregatedRank": 1562,
+    "countryRank": 188
   },
   {
     "name": "Guangzhou University of Traditional Chinese Medicine",
@@ -26259,8 +26144,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1576,
-    "countryRank": 184
+    "aggregatedRank": 1563,
+    "countryRank": 189
   },
   {
     "name": "Harbin University of Science and Technology",
@@ -26272,8 +26157,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1577,
-    "countryRank": 185
+    "aggregatedRank": 1564,
+    "countryRank": 190
   },
   {
     "name": "Henan Agricultural University",
@@ -26285,8 +26170,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1578,
-    "countryRank": 186
+    "aggregatedRank": 1565,
+    "countryRank": 191
   },
   {
     "name": "Inner Mongolia University",
@@ -26298,8 +26183,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1579,
-    "countryRank": 187
+    "aggregatedRank": 1566,
+    "countryRank": 192
   },
   {
     "name": "Huaqiao University",
@@ -26311,8 +26196,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1580,
-    "countryRank": 188
+    "aggregatedRank": 1567,
+    "countryRank": 193
   },
   {
     "name": "North China University of Technology",
@@ -26324,8 +26209,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1581,
-    "countryRank": 189
+    "aggregatedRank": 1568,
+    "countryRank": 194
   },
   {
     "name": "Shanghai University of Finance and Economics",
@@ -26337,8 +26222,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1582,
-    "countryRank": 190
+    "aggregatedRank": 1569,
+    "countryRank": 195
   },
   {
     "name": "Shanghai University of Traditional Chinese Medicine and Pharmacology",
@@ -26350,8 +26235,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1583,
-    "countryRank": 191
+    "aggregatedRank": 1570,
+    "countryRank": 196
   },
   {
     "name": "Yantai University",
@@ -26363,8 +26248,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1584,
-    "countryRank": 192
+    "aggregatedRank": 1571,
+    "countryRank": 197
   },
   {
     "name": "Suez Canal University",
@@ -26376,7 +26261,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1585,
+    "aggregatedRank": 1572,
     "countryRank": 11
   },
   {
@@ -26389,7 +26274,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1586,
+    "aggregatedRank": 1573,
     "countryRank": 12
   },
   {
@@ -26402,7 +26287,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1587,
+    "aggregatedRank": 1574,
     "countryRank": 44
   },
   {
@@ -26415,8 +26300,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1588,
-    "countryRank": 58
+    "aggregatedRank": 1575,
+    "countryRank": 57
   },
   {
     "name": "Tokushima University",
@@ -26428,8 +26313,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1589,
-    "countryRank": 39
+    "aggregatedRank": 1576,
+    "countryRank": 38
   },
   {
     "name": "Gyeongsang National University",
@@ -26441,7 +26326,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1590,
+    "aggregatedRank": 1577,
     "countryRank": 35
   },
   {
@@ -26454,7 +26339,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1591,
+    "aggregatedRank": 1578,
     "countryRank": 18
   },
   {
@@ -26467,7 +26352,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1592,
+    "aggregatedRank": 1579,
     "countryRank": 19
   },
   {
@@ -26480,8 +26365,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1593,
-    "countryRank": 202
+    "aggregatedRank": 1580,
+    "countryRank": 203
   },
   {
     "name": "Loyola University of Chicago",
@@ -26493,8 +26378,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1594,
-    "countryRank": 203
+    "aggregatedRank": 1581,
+    "countryRank": 204
   },
   {
     "name": "Amherst College",
@@ -26506,8 +26391,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1595,
-    "countryRank": 204
+    "aggregatedRank": 1582,
+    "countryRank": 205
   },
   {
     "name": "North Dakota State University",
@@ -26519,8 +26404,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1596,
-    "countryRank": 205
+    "aggregatedRank": 1583,
+    "countryRank": 206
   },
   {
     "name": "Guangxi Medical University",
@@ -26532,8 +26417,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1597,
-    "countryRank": 193
+    "aggregatedRank": 1584,
+    "countryRank": 198
   },
   {
     "name": "University of Novi Sad",
@@ -26545,7 +26430,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1598,
+    "aggregatedRank": 1585,
     "countryRank": 2
   },
   {
@@ -26558,8 +26443,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1599,
-    "countryRank": 206
+    "aggregatedRank": 1586,
+    "countryRank": 207
   },
   {
     "name": "Liaoning University of Technology",
@@ -26571,8 +26456,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1600,
-    "countryRank": 194
+    "aggregatedRank": 1587,
+    "countryRank": 199
   },
   {
     "name": "Linnaeus University",
@@ -26584,7 +26469,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1601,
+    "aggregatedRank": 1588,
     "countryRank": 15
   },
   {
@@ -26597,8 +26482,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1602,
-    "countryRank": 195
+    "aggregatedRank": 1589,
+    "countryRank": 200
   },
   {
     "name": "Henan Polytechnic University",
@@ -26610,8 +26495,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1603,
-    "countryRank": 196
+    "aggregatedRank": 1590,
+    "countryRank": 201
   },
   {
     "name": "Yangtze University",
@@ -26623,8 +26508,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1604,
-    "countryRank": 197
+    "aggregatedRank": 1591,
+    "countryRank": 202
   },
   {
     "name": "Western Norway University of Applied Sciences",
@@ -26636,7 +26521,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1605,
+    "aggregatedRank": 1592,
     "countryRank": 8
   },
   {
@@ -26649,8 +26534,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1606,
-    "countryRank": 198
+    "aggregatedRank": 1593,
+    "countryRank": 203
   },
   {
     "name": "Dalian Polytechnic University",
@@ -26662,8 +26547,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1607,
-    "countryRank": 199
+    "aggregatedRank": 1594,
+    "countryRank": 204
   },
   {
     "name": "Guangdong Ocean University",
@@ -26675,8 +26560,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1608,
-    "countryRank": 200
+    "aggregatedRank": 1595,
+    "countryRank": 205
   },
   {
     "name": "Guilin University of Electronic Technology",
@@ -26688,8 +26573,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1609,
-    "countryRank": 201
+    "aggregatedRank": 1596,
+    "countryRank": 206
   },
   {
     "name": "Hassan II University of Casablanca",
@@ -26701,7 +26586,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1610,
+    "aggregatedRank": 1597,
     "countryRank": 2
   }
 ]

--- a/scripts/scrape-rankings.js
+++ b/scripts/scrape-rankings.js
@@ -57,6 +57,25 @@ const aliasMap = new Map([
     ['university of michigan - ann arbor', 'University of Michigan'],
     ['newcastle university newcastle upon tyne', 'Newcastle University'],
     ['swiss federal institute of technology zurich', 'ETH Zurich'],
+    ['swiss federal institute of technology lausanne epfl', 'Ecole Polytechnique Federale de Lausanne'],
+    ['university of new south wales', 'University of New South Wales Sydney'],
+    ['psl research university paris', 'Universite PSL'],
+    ['hong kong university of science and technology', 'Hong Kong University of Science & Technology'],
+    ['the university of tokyo', 'University of Tokyo'],
+    ['london school of economics', 'London School Economics & Political Science'],
+    ['korea advanced institute of science and technology', 'Korea Advanced Institute of Science & Technology (KAIST)'],
+    ['university of malaya', 'Universiti Malaya'],
+    ['catholic university of leuven', 'KU Leuven'],
+    ['sorbonne university', 'Sorbonne Universite'],
+    ['university of texas at austin', 'University of Texas Austin'],
+    ['university of illinois at urbana-champaign', 'University of Illinois Urbana-Champaign'],
+    ['universite paris saclay', 'Universite Paris Saclay'],
+    ['kth - royal institute of technology', 'Royal Institute of Technology'],
+    ['university of washington', 'University of Washington Seattle'],
+    ['university of heidelberg', 'Ruprecht Karls University Heidelberg'],
+    ['university of durham', 'Durham University'],
+    ['university of sao paulo', 'Universidade de Sao Paulo'],
+    ['pontifical catholic university of chile', 'Pontificia Universidad Catolica de Chile'],
     // Resolve discrepancies around Washington University in St. Louis
     ['washington university in st louis', 'Washington University (WUSTL)'],
     ['washington university st louis', 'Washington University (WUSTL)'],
@@ -74,8 +93,8 @@ function canonicalizeName(name) {
     cleaned = cleaned.replace(/[–—−]/g, '-');
     // Remove parenthetical notes
     cleaned = cleaned.replace(/\s*\([^)]*\)\s*$/, '');
-    // Remove trailing short tokens like "- MIT" or "- Caltech"
-    cleaned = cleaned.replace(/\s*-\s*[A-Za-z.&]{1,10}$/, '');
+    // Remove trailing short tokens like "- MIT" while keeping campus names
+    cleaned = cleaned.replace(/\s*-\s*[A-Za-z.&]{1,5}$/, '');
     // Remove campus designations at the end
     cleaned = cleaned.replace(/\s*-?\s*(?:main|city|west|east|north|south)?\s*\w*\s*campus$/i, '');
     cleaned = cleaned.replace(/\s*-\s*/g, ' ');


### PR DESCRIPTION
## Summary
- manually map more university name variants to fix mismatches
- tighten the trailing token cleanup so campus names like *Berkeley* survive
- regenerate aggregated rankings

## Testing
- `node scripts/scrape-rankings.js 30`
- `npm test` *(fails: Missing script)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438f70f5b88320baa9e1bd7c77bc48