### PR TITLE
Add average ranking metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,4 +81,11 @@ To view the aggregated rankings in the web browser:
    npm start
    ```
 
-   This will open the application in your default web browser (usually at `http://localhost:3000`). The frontend reads the data from `frontend/src/data/aggregated-rankings.json`. 
+   This will open the application in your default web browser (usually at `http://localhost:3000`). The frontend reads the data from `frontend/src/data/aggregated-rankings.json`.
+## Advanced Metrics
+
+When viewing details for a university, the frontend shows additional insights:
+
+- **Best/Worst Ranking** – extremes across ranking sources.
+- **Consistency** – variation (standard deviation) across sources.
+- **Average Rank** – mean position among the individual rankings.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -124,6 +124,12 @@ function App() {
     return Math.sqrt(variance);
   };
 
+  const getAverageRanking = (originalRankings) => {
+    const ranks = Object.values(originalRankings).map(r => r.rank);
+    const avg = ranks.reduce((a, b) => a + b, 0) / ranks.length;
+    return avg;
+  };
+
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-800 flex items-center justify-center">
@@ -338,6 +344,10 @@ function App() {
                                  getRankingConsistency(university.originalRankings) < 5 ? 'High' :
                                  getRankingConsistency(university.originalRankings) < 10 ? 'Medium' : 'Variable'}
                               </span>
+                            </div>
+                            <div className="flex justify-between items-center mt-2">
+                              <span className="text-purple-200">Average Rank</span>
+                              <span className="text-yellow-300 font-bold">#{getAverageRanking(university.originalRankings).toFixed(1)}</span>
                             </div>
                           </div>
                           


### PR DESCRIPTION
## Summary
- add a helper to compute average ranking for each university
- display the Average Rank in the Ranking Analysis section
- document advanced metrics in README

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68439f4984b0832098f229e3f6da8cb7