### PR TITLE
UI overhaul with gothic green gradient

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -215,32 +215,32 @@ function App() {
       {/* Hero Section */}
       <div className="relative overflow-hidden">
         <div className="absolute inset-0">
-          <div className="absolute inset-0 bg-gradient-to-r from-blue-600/20 to-purple-600/20 animate-pulse"></div>
-          <div className="absolute top-10 left-10 w-32 h-32 bg-yellow-400/10 rounded-full blur-3xl animate-bounce"></div>
-          <div className="absolute bottom-10 right-10 w-40 h-40 bg-pink-400/10 rounded-full blur-3xl animate-pulse"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-emerald-700/20 to-green-700/20 animate-pulse"></div>
+          <div className="absolute top-10 left-10 w-32 h-32 bg-emerald-400/10 rounded-full blur-3xl animate-bounce"></div>
+          <div className="absolute bottom-10 right-10 w-40 h-40 bg-teal-400/10 rounded-full blur-3xl animate-pulse"></div>
         </div>
         
-        <div className="relative container mx-auto px-6 py-16">
+        <div className="relative container mx-auto px-6 py-12">
           <div className="text-center mb-8">
             <div className="inline-flex items-center gap-2 bg-white/10 backdrop-blur-md rounded-full px-6 py-2 mb-6 text-base md:text-lg" style={{ fontSize: '95%' }}>
-              <Globe className="w-5 h-5 text-blue-400" />
+              <Globe className="w-5 h-5 text-emerald-400" />
               <span className="text-white font-medium">Global University Rankings</span>
             </div>
             
             <div className="flex items-center justify-center gap-4 mb-6">
-              <div className="w-16 h-16 bg-gradient-to-br from-blue-500 to-purple-600 rounded-2xl flex items-center justify-center transform rotate-12 shadow-lg">
+              <div className="w-16 h-16 bg-gradient-to-br from-emerald-600 to-teal-700 rounded-2xl flex items-center justify-center transform rotate-12 shadow-lg">
                 <BookOpen className="w-8 h-8 text-white" />
               </div>
-              <h1 className="text-6xl md:text-7xl font-black text-transparent bg-clip-text bg-gradient-to-r from-white to-purple-200 leading-tight">
+              <h1 className="text-6xl md:text-7xl font-black text-transparent bg-clip-text bg-gradient-to-r from-white to-green-200 leading-tight">
                 UniRank
                 <br />
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400">
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-teal-400">
                   Global
                 </span>
               </h1>
             </div>
             
-            <p className="text-xl text-purple-200 max-w-2xl mx-auto leading-relaxed" style={{ fontSize: '95%' }}>
+            <p className="text-xl text-emerald-200 max-w-2xl mx-auto leading-relaxed" style={{ fontSize: '95%' }}>
               Your comprehensive guide to global university rankings, aggregating data from QS, Times Higher Education, ARWU, and US News
             </p>
           </div>
@@ -249,27 +249,27 @@ function App() {
       </div>
 
       {/* Metrics Overview */}
-      <div className="container mx-auto px-6 py-8">
+      <div className="container mx-auto px-6 py-6">
         <div className="max-w-5xl mx-auto bg-white/5 backdrop-blur-md rounded-3xl border border-white/20 p-8 flex flex-col md:flex-row items-center gap-8 transition-transform hover:-translate-y-1 hover:shadow-2xl pulse-glow scale-75">
           <div className="md:w-2/5 space-y-6">
             <div>
-              <div className="text-4xl font-extrabold text-white font-orbitron">{metrics.totalUniversities}</div>
-              <div className="text-sm text-purple-200 uppercase">Universities</div>
+              <div className="text-4xl font-extrabold text-white">{metrics.totalUniversities}</div>
+              <div className="text-sm text-emerald-200 uppercase">Universities</div>
             </div>
             <div>
-              <div className="text-4xl font-extrabold text-white font-orbitron">{metrics.totalCountries}</div>
-              <div className="text-sm text-purple-200 uppercase">Countries</div>
+              <div className="text-4xl font-extrabold text-white">{metrics.totalCountries}</div>
+              <div className="text-sm text-emerald-200 uppercase">Countries</div>
             </div>
             <div>
-              <div className="text-4xl font-extrabold text-white font-orbitron">{metrics.averageScore}</div>
-              <div className="text-sm text-purple-200 uppercase">Avg. Score</div>
+              <div className="text-4xl font-extrabold text-white">{metrics.averageScore}</div>
+              <div className="text-sm text-emerald-200 uppercase">Avg. Score</div>
             </div>
           </div>
           <div className="w-full md:w-3/5 flex flex-col items-center">
             <Doughnut data={metrics.chartData} options={chartOptions} />
             <div className="flex justify-center mt-4 space-x-4">
               {metrics.chartData.labels.map((label, i) => (
-                <div key={label} className="flex items-center gap-1 text-sm text-purple-200">
+                <div key={label} className="flex items-center gap-1 text-sm text-emerald-200">
                   <span
                     className="w-3 h-3 inline-block rounded-sm"
                     style={{ backgroundColor: metrics.chartData.datasets[0].backgroundColor[i] }}
@@ -347,7 +347,7 @@ function App() {
             <div
               key={index}
               ref={index === 0 ? firstCardRef : null}
-              className="group bg-white/10 backdrop-blur-md rounded-3xl border border-white/20 overflow-hidden hover:bg-white/15 transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl"
+              className="group bg-gradient-to-br from-slate-700/40 via-slate-800/30 to-slate-900/40 backdrop-blur-md rounded-3xl border border-white/20 overflow-hidden hover:brightness-110 transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl"
               style={{
                 animationDelay: `${index * 100}ms`
               }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -25,14 +24,11 @@
 @layer utilities {
   .gradient-bg {
     background-image:
-      radial-gradient(circle at 15% 25%, rgba(59, 130, 246, 0.3) 0%, transparent 50%),
-      radial-gradient(circle at 85% 75%, rgba(168, 85, 247, 0.3) 0%, transparent 50%),
-      radial-gradient(circle at 50% 100%, rgba(16, 185, 129, 0.2) 0%, transparent 50%),
-      radial-gradient(circle at 70% 10%, rgba(251, 146, 60, 0.2) 0%, transparent 50%),
-      linear-gradient(135deg, #0f0f23 0%, #1a1a2e 25%, #16213e 50%, #0f3460 75%, #1a1a2e 100%);
-  }
-  .font-orbitron {
-    font-family: 'Orbitron', sans-serif;
+      radial-gradient(circle at 20% 20%, rgba(34, 197, 94, 0.25) 0%, transparent 50%),
+      radial-gradient(circle at 80% 30%, rgba(6, 95, 70, 0.25) 0%, transparent 50%),
+      radial-gradient(circle at 50% 90%, rgba(20, 184, 166, 0.2) 0%, transparent 50%),
+      radial-gradient(circle at 70% 10%, rgba(110, 231, 183, 0.2) 0%, transparent 50%),
+      linear-gradient(135deg, #0a0f0b 0%, #102e26 50%, #0d251f 75%, #0b1c17 100%);
   }
 }
 
@@ -48,8 +44,8 @@
 }
 
 @keyframes pulseGlow {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.4); }
-  50% { box-shadow: 0 0 20px 0 rgba(124, 58, 237, 0.8); }
+  0%, 100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.4); }
+  50% { box-shadow: 0 0 20px 0 rgba(16, 185, 129, 0.8); }
 }
 
 code {


### PR DESCRIPTION
## Summary
- unify fonts across metrics dashboard and rest of app
- revamp hero section and overall background with green gothic gradient
- update card styling to slate matte glass
- tweak padding and colors for a consistent theme

## Testing
- `npm test` *(fails: jest not found)*
- `cd frontend && npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462505a52483209c1dfa897118894c