### PR TITLE
UI tweaks for teal theme

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -47,8 +47,10 @@ function App() {
     const totalCountries = uniqueCountries.length;
     const averageScore = universities.reduce((acc, u) => acc + u.aggregatedScore, 0) / (universities.length || 1);
     const counts = {};
+    const sourceSet = new Set();
     universities.forEach(u => {
       counts[u.country] = (counts[u.country] || 0) + 1;
+      Object.keys(u.originalRankings).forEach(s => sourceSet.add(s));
     });
     const sorted = Object.entries(counts)
       .sort((a, b) => b[1] - a[1])
@@ -74,6 +76,7 @@ function App() {
       totalUniversities,
       totalCountries,
       averageScore: averageScore.toFixed(1),
+      totalSources: sourceSet.size,
       chartData,
     };
   }, [universities, uniqueCountries]);
@@ -172,7 +175,7 @@ function App() {
     if (score >= 1710) return 'bg-gradient-to-r from-pink-500 to-rose-500 text-white';
     if (score >= 1700) return 'bg-gradient-to-r from-purple-500 to-indigo-500 text-white';
     if (score >= 1650) return 'bg-gradient-to-r from-blue-500 to-cyan-500 text-white';
-    return 'bg-gradient-to-r from-green-500 to-emerald-500 text-white';
+    return 'bg-gradient-to-r from-teal-500 to-cyan-500 text-white';
   };
 
   const getBestRanking = (originalRankings) => {
@@ -215,32 +218,32 @@ function App() {
       {/* Hero Section */}
       <div className="relative overflow-hidden">
         <div className="absolute inset-0">
-          <div className="absolute inset-0 bg-gradient-to-r from-emerald-700/20 to-green-700/20 animate-pulse"></div>
-          <div className="absolute top-10 left-10 w-32 h-32 bg-emerald-400/10 rounded-full blur-3xl animate-bounce"></div>
-          <div className="absolute bottom-10 right-10 w-40 h-40 bg-teal-400/10 rounded-full blur-3xl animate-pulse"></div>
+          <div className="absolute inset-0 bg-gradient-to-r from-teal-800/20 to-cyan-900/20 animate-pulse"></div>
+          <div className="absolute top-10 left-10 w-32 h-32 bg-teal-500/10 rounded-full blur-3xl animate-bounce"></div>
+          <div className="absolute bottom-10 right-10 w-40 h-40 bg-cyan-500/10 rounded-full blur-3xl animate-pulse"></div>
         </div>
         
         <div className="relative container mx-auto px-6 py-12">
           <div className="text-center mb-8">
             <div className="inline-flex items-center gap-2 bg-white/10 backdrop-blur-md rounded-full px-6 py-2 mb-6 text-base md:text-lg" style={{ fontSize: '95%' }}>
-              <Globe className="w-5 h-5 text-emerald-400" />
+              <Globe className="w-5 h-5 text-teal-400" />
               <span className="text-white font-medium">Global University Rankings</span>
             </div>
             
             <div className="flex items-center justify-center gap-4 mb-6">
-              <div className="w-16 h-16 bg-gradient-to-br from-emerald-600 to-teal-700 rounded-2xl flex items-center justify-center transform rotate-12 shadow-lg">
+              <div className="w-16 h-16 bg-gradient-to-br from-teal-700 to-cyan-900 rounded-2xl flex items-center justify-center transform rotate-12 shadow-lg">
                 <BookOpen className="w-8 h-8 text-white" />
               </div>
-              <h1 className="text-6xl md:text-7xl font-black text-transparent bg-clip-text bg-gradient-to-r from-white to-green-200 leading-tight">
+              <h1 className="text-6xl md:text-7xl font-black text-transparent bg-clip-text bg-gradient-to-r from-white to-teal-200 leading-tight">
                 UniRank
                 <br />
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-green-400 to-teal-400">
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-teal-400 to-cyan-400">
                   Global
                 </span>
               </h1>
             </div>
             
-            <p className="text-xl text-emerald-200 max-w-2xl mx-auto leading-relaxed" style={{ fontSize: '95%' }}>
+            <p className="text-xl text-teal-200 max-w-2xl mx-auto leading-relaxed" style={{ fontSize: '95%' }}>
               Your comprehensive guide to global university rankings, aggregating data from QS, Times Higher Education, ARWU, and US News
             </p>
           </div>
@@ -249,27 +252,31 @@ function App() {
       </div>
 
       {/* Metrics Overview */}
-      <div className="container mx-auto px-6 py-6">
-        <div className="max-w-5xl mx-auto bg-white/5 backdrop-blur-md rounded-3xl border border-white/20 p-8 flex flex-col md:flex-row items-center gap-8 transition-transform hover:-translate-y-1 hover:shadow-2xl pulse-glow scale-75">
+      <div className="container mx-auto px-6 py-4">
+        <div className="max-w-5xl mx-auto bg-white/5 backdrop-blur-md rounded-3xl border border-white/20 p-8 flex flex-col md:flex-row items-center gap-8 transition-transform hover:-translate-y-1 hover:shadow-2xl pulse-glow">
           <div className="md:w-2/5 space-y-6">
             <div>
               <div className="text-4xl font-extrabold text-white">{metrics.totalUniversities}</div>
-              <div className="text-sm text-emerald-200 uppercase">Universities</div>
+              <div className="text-sm text-teal-200 uppercase">Universities</div>
             </div>
             <div>
               <div className="text-4xl font-extrabold text-white">{metrics.totalCountries}</div>
-              <div className="text-sm text-emerald-200 uppercase">Countries</div>
+              <div className="text-sm text-teal-200 uppercase">Countries</div>
             </div>
             <div>
               <div className="text-4xl font-extrabold text-white">{metrics.averageScore}</div>
-              <div className="text-sm text-emerald-200 uppercase">Avg. Score</div>
+              <div className="text-sm text-teal-200 uppercase">Avg. Score</div>
+            </div>
+            <div>
+              <div className="text-4xl font-extrabold text-white">{metrics.totalSources}</div>
+              <div className="text-sm text-teal-200 uppercase">Sources</div>
             </div>
           </div>
           <div className="w-full md:w-3/5 flex flex-col items-center">
             <Doughnut data={metrics.chartData} options={chartOptions} />
             <div className="flex justify-center mt-4 space-x-4">
               {metrics.chartData.labels.map((label, i) => (
-                <div key={label} className="flex items-center gap-1 text-sm text-emerald-200">
+                <div key={label} className="flex items-center gap-1 text-sm text-teal-200">
                   <span
                     className="w-3 h-3 inline-block rounded-sm"
                     style={{ backgroundColor: metrics.chartData.datasets[0].backgroundColor[i] }}
@@ -347,7 +354,7 @@ function App() {
             <div
               key={index}
               ref={index === 0 ? firstCardRef : null}
-              className="group bg-gradient-to-br from-slate-700/40 via-slate-800/30 to-slate-900/40 backdrop-blur-md rounded-3xl border border-white/20 overflow-hidden hover:brightness-110 transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl"
+              className="group bg-gradient-to-br from-teal-800/40 via-cyan-900/30 to-slate-900/40 backdrop-blur-md rounded-3xl border border-white/20 overflow-hidden hover:brightness-110 transition-all duration-500 hover:scale-[1.02] hover:shadow-2xl"
               style={{
                 animationDelay: `${index * 100}ms`
               }}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,11 +24,11 @@
 @layer utilities {
   .gradient-bg {
     background-image:
-      radial-gradient(circle at 20% 20%, rgba(34, 197, 94, 0.25) 0%, transparent 50%),
-      radial-gradient(circle at 80% 30%, rgba(6, 95, 70, 0.25) 0%, transparent 50%),
-      radial-gradient(circle at 50% 90%, rgba(20, 184, 166, 0.2) 0%, transparent 50%),
-      radial-gradient(circle at 70% 10%, rgba(110, 231, 183, 0.2) 0%, transparent 50%),
-      linear-gradient(135deg, #0a0f0b 0%, #102e26 50%, #0d251f 75%, #0b1c17 100%);
+      radial-gradient(circle at 20% 20%, rgba(37, 99, 135, 0.3) 0%, transparent 50%),
+      radial-gradient(circle at 80% 30%, rgba(17, 94, 119, 0.3) 0%, transparent 50%),
+      radial-gradient(circle at 50% 90%, rgba(21, 94, 117, 0.25) 0%, transparent 50%),
+      radial-gradient(circle at 70% 10%, rgba(12, 74, 110, 0.25) 0%, transparent 50%),
+      linear-gradient(135deg, #0d1b2a 0%, #1b263b 50%, #415a77 75%, #0d1b2a 100%);
   }
 }
 


### PR DESCRIPTION
## Summary
- refine hero and page background with a dark teal gradient
- align metrics dashboard width and add ranking source count
- switch metrics and hero accents from emerald to teal
- update university card gradient for steel look

## Testing
- `npx jest --runInBand` *(fails: jest not found)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684626f7d15c8320a8f70adfad1c38d5