### PR TITLE
Improve SEO metadata

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -10,12 +10,31 @@
       name="description"
       content="UniRank Global - Your comprehensive guide to global university rankings, aggregating data from QS, Times Higher Education, ARWU, and US News"
     />
+    <meta
+      name="keywords"
+      content="university rankings, global universities, QS rankings, Times Higher Education, ARWU, US News, ranking aggregator"
+    />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link
+      rel="canonical"
+      href="https://mmostagirbhuiyan.com/university-ranking-aggregator/"
+    />
+    <meta property="og:title" content="UniRank Global - University Rankings Aggregator" />
+    <meta
+      property="og:description"
+      content="Explore global university rankings aggregated from QS, THE, ARWU, and US News."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://mmostagirbhuiyan.com/university-ranking-aggregator/"
+    />
+    <meta property="og:image" content="%PUBLIC_URL%/logo512.png" />
     <!-- Inter Font -->
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
     <!-- Material Icons -->

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,3 +1,4 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+Sitemap: https://mmostagirbhuiyan.com/university-ranking-aggregator/sitemap.xml

--- a/frontend/public/sitemap.xml
+++ b/frontend/public/sitemap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://mmostagirbhuiyan.com/university-ranking-aggregator/</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- add meta keywords and canonical link
- add Open Graph metadata for social previews
- provide sitemap.xml
- reference sitemap in robots.txt

## Testing
- `npm test --silent -- --passWithNoTests`
- `cd frontend && CI=true npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_6850bb2ea51483208aaa2bd14db2b27a