### PR TITLE
Fix encoding for rankings CSV

### DIFF
--- a/frontend/public/data/aggregated-rankings.json
+++ b/frontend/public/data/aggregated-rankings.json
@@ -792,6 +792,28 @@
     "countryRank": 1
   },
   {
+    "name": "Technical University of Munich",
+    "country": "Germany",
+    "aggregatedScore": 1667.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 28
+      },
+      "the": {
+        "rank": 26
+      },
+      "arwu": {
+        "rank": 47
+      },
+      "usnews": {
+        "rank": 79
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 37,
+    "countryRank": 1
+  },
+  {
     "name": "Shanghai Jiao Tong University",
     "country": "China",
     "aggregatedScore": 1667,
@@ -810,7 +832,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 37,
+    "aggregatedRank": 38,
     "countryRank": 4
   },
   {
@@ -832,7 +854,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 38,
+    "aggregatedRank": 39,
     "countryRank": 2
   },
   {
@@ -854,8 +876,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 39,
+    "aggregatedRank": 40,
     "countryRank": 5
+  },
+  {
+    "name": "University of Munich",
+    "country": "Germany",
+    "aggregatedScore": 1663,
+    "originalRankings": {
+      "qs": {
+        "rank": 59
+      },
+      "the": {
+        "rank": 38
+      },
+      "arwu": {
+        "rank": 43
+      },
+      "usnews": {
+        "rank": 57
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 41,
+    "countryRank": 2
   },
   {
     "name": "Ecole Polytechnique Federale de Lausanne",
@@ -876,7 +920,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 40,
+    "aggregatedRank": 42,
     "countryRank": 2
   },
   {
@@ -898,7 +942,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 41,
+    "aggregatedRank": 43,
     "countryRank": 1
   },
   {
@@ -920,7 +964,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 42,
+    "aggregatedRank": 44,
     "countryRank": 7
   },
   {
@@ -942,7 +986,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 43,
+    "aggregatedRank": 45,
     "countryRank": 3
   },
   {
@@ -964,7 +1008,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 44,
+    "aggregatedRank": 46,
     "countryRank": 3
   },
   {
@@ -986,7 +1030,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 45,
+    "aggregatedRank": 47,
     "countryRank": 4
   },
   {
@@ -1008,7 +1052,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 46,
+    "aggregatedRank": 48,
     "countryRank": 2
   },
   {
@@ -1030,7 +1074,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 47,
+    "aggregatedRank": 49,
     "countryRank": 5
   },
   {
@@ -1052,8 +1096,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 48,
+    "aggregatedRank": 50,
     "countryRank": 20
+  },
+  {
+    "name": "Universite Paris Saclay",
+    "country": "France",
+    "aggregatedScore": 1655.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 73
+      },
+      "the": {
+        "rank": 64
+      },
+      "arwu": {
+        "rank": 12
+      },
+      "usnews": {
+        "rank": 78
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 51,
+    "countryRank": 2
   },
   {
     "name": "KU Leuven",
@@ -1074,7 +1140,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 49,
+    "aggregatedRank": 52,
     "countryRank": 1
   },
   {
@@ -1096,8 +1162,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 50,
-    "countryRank": 1
+    "aggregatedRank": 53,
+    "countryRank": 3
   },
   {
     "name": "Sorbonne Universite",
@@ -1118,8 +1184,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 51,
-    "countryRank": 2
+    "aggregatedRank": 54,
+    "countryRank": 3
   },
   {
     "name": "University of Amsterdam",
@@ -1140,7 +1206,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 52,
+    "aggregatedRank": 55,
     "countryRank": 1
   },
   {
@@ -1162,7 +1228,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 53,
+    "aggregatedRank": 56,
     "countryRank": 1
   },
   {
@@ -1184,7 +1250,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 54,
+    "aggregatedRank": 57,
     "countryRank": 21
   },
   {
@@ -1206,7 +1272,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 55,
+    "aggregatedRank": 58,
     "countryRank": 22
   },
   {
@@ -1228,7 +1294,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 56,
+    "aggregatedRank": 59,
     "countryRank": 6
   },
   {
@@ -1250,7 +1316,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 57,
+    "aggregatedRank": 60,
     "countryRank": 3
   },
   {
@@ -1272,7 +1338,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 58,
+    "aggregatedRank": 61,
     "countryRank": 6
   },
   {
@@ -1294,7 +1360,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 59,
+    "aggregatedRank": 62,
     "countryRank": 23
   },
   {
@@ -1316,7 +1382,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 60,
+    "aggregatedRank": 63,
     "countryRank": 24
   },
   {
@@ -1338,7 +1404,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 61,
+    "aggregatedRank": 64,
     "countryRank": 25
   },
   {
@@ -1360,7 +1426,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 62,
+    "aggregatedRank": 65,
     "countryRank": 1
   },
   {
@@ -1382,7 +1448,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 63,
+    "aggregatedRank": 66,
     "countryRank": 8
   },
   {
@@ -1404,7 +1470,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 64,
+    "aggregatedRank": 67,
     "countryRank": 9
   },
   {
@@ -1426,7 +1492,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 65,
+    "aggregatedRank": 68,
     "countryRank": 26
   },
   {
@@ -1448,7 +1514,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 66,
+    "aggregatedRank": 69,
     "countryRank": 2
   },
   {
@@ -1470,7 +1536,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 67,
+    "aggregatedRank": 70,
     "countryRank": 4
   },
   {
@@ -1492,7 +1558,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 68,
+    "aggregatedRank": 71,
     "countryRank": 27
   },
   {
@@ -1514,7 +1580,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 69,
+    "aggregatedRank": 72,
     "countryRank": 2
   },
   {
@@ -1536,7 +1602,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 70,
+    "aggregatedRank": 73,
     "countryRank": 7
   },
   {
@@ -1558,7 +1624,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 71,
+    "aggregatedRank": 74,
     "countryRank": 28
   },
   {
@@ -1580,7 +1646,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 72,
+    "aggregatedRank": 75,
     "countryRank": 3
   },
   {
@@ -1602,7 +1668,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 73,
+    "aggregatedRank": 76,
     "countryRank": 29
   },
   {
@@ -1624,7 +1690,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 74,
+    "aggregatedRank": 77,
     "countryRank": 30
   },
   {
@@ -1646,7 +1712,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 75,
+    "aggregatedRank": 78,
     "countryRank": 31
   },
   {
@@ -1668,7 +1734,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 76,
+    "aggregatedRank": 79,
     "countryRank": 1
   },
   {
@@ -1690,7 +1756,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 77,
+    "aggregatedRank": 80,
     "countryRank": 32
   },
   {
@@ -1712,7 +1778,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 78,
+    "aggregatedRank": 81,
     "countryRank": 1
   },
   {
@@ -1734,7 +1800,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 79,
+    "aggregatedRank": 82,
     "countryRank": 33
   },
   {
@@ -1756,7 +1822,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 80,
+    "aggregatedRank": 83,
     "countryRank": 5
   },
   {
@@ -1778,7 +1844,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 81,
+    "aggregatedRank": 84,
     "countryRank": 10
   },
   {
@@ -1800,7 +1866,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 82,
+    "aggregatedRank": 85,
     "countryRank": 7
   },
   {
@@ -1822,7 +1888,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 83,
+    "aggregatedRank": 86,
     "countryRank": 1
   },
   {
@@ -1844,7 +1910,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 84,
+    "aggregatedRank": 87,
     "countryRank": 34
   },
   {
@@ -1866,7 +1932,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 85,
+    "aggregatedRank": 88,
     "countryRank": 4
   },
   {
@@ -1888,7 +1954,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 86,
+    "aggregatedRank": 89,
     "countryRank": 5
   },
   {
@@ -1910,7 +1976,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 87,
+    "aggregatedRank": 90,
     "countryRank": 2
   },
   {
@@ -1932,7 +1998,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 88,
+    "aggregatedRank": 91,
     "countryRank": 11
   },
   {
@@ -1954,7 +2020,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 89,
+    "aggregatedRank": 92,
     "countryRank": 8
   },
   {
@@ -1976,7 +2042,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 90,
+    "aggregatedRank": 93,
     "countryRank": 35
   },
   {
@@ -1998,7 +2064,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 91,
+    "aggregatedRank": 94,
     "countryRank": 2
   },
   {
@@ -2020,7 +2086,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 92,
+    "aggregatedRank": 95,
     "countryRank": 12
   },
   {
@@ -2042,7 +2108,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 93,
+    "aggregatedRank": 96,
     "countryRank": 36
   },
   {
@@ -2064,7 +2130,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 94,
+    "aggregatedRank": 97,
     "countryRank": 4
   },
   {
@@ -2086,7 +2152,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 95,
+    "aggregatedRank": 98,
     "countryRank": 37
   },
   {
@@ -2108,7 +2174,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 96,
+    "aggregatedRank": 99,
     "countryRank": 38
   },
   {
@@ -2130,7 +2196,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 97,
+    "aggregatedRank": 100,
     "countryRank": 3
   },
   {
@@ -2152,7 +2218,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 98,
+    "aggregatedRank": 101,
     "countryRank": 13
   },
   {
@@ -2174,7 +2240,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 99,
+    "aggregatedRank": 102,
     "countryRank": 6
   },
   {
@@ -2196,7 +2262,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 100,
+    "aggregatedRank": 103,
     "countryRank": 14
   },
   {
@@ -2218,7 +2284,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 101,
+    "aggregatedRank": 104,
     "countryRank": 15
   },
   {
@@ -2240,7 +2306,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 102,
+    "aggregatedRank": 105,
     "countryRank": 8
   },
   {
@@ -2262,7 +2328,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 103,
+    "aggregatedRank": 106,
     "countryRank": 16
   },
   {
@@ -2284,7 +2350,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 104,
+    "aggregatedRank": 107,
     "countryRank": 9
   },
   {
@@ -2306,7 +2372,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 105,
+    "aggregatedRank": 108,
     "countryRank": 4
   },
   {
@@ -2328,7 +2394,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 106,
+    "aggregatedRank": 109,
     "countryRank": 1
   },
   {
@@ -2350,7 +2416,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 107,
+    "aggregatedRank": 110,
     "countryRank": 2
   },
   {
@@ -2372,7 +2438,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 108,
+    "aggregatedRank": 111,
     "countryRank": 5
   },
   {
@@ -2394,8 +2460,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 109,
-    "countryRank": 2
+    "aggregatedRank": 112,
+    "countryRank": 4
   },
   {
     "name": "University of Auckland",
@@ -2416,7 +2482,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 110,
+    "aggregatedRank": 113,
     "countryRank": 1
   },
   {
@@ -2438,7 +2504,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 111,
+    "aggregatedRank": 114,
     "countryRank": 1
   },
   {
@@ -2460,7 +2526,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 112,
+    "aggregatedRank": 115,
     "countryRank": 5
   },
   {
@@ -2482,7 +2548,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 113,
+    "aggregatedRank": 116,
     "countryRank": 39
   },
   {
@@ -2504,7 +2570,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 114,
+    "aggregatedRank": 117,
     "countryRank": 17
   },
   {
@@ -2526,7 +2592,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 115,
+    "aggregatedRank": 118,
     "countryRank": 40
   },
   {
@@ -2548,7 +2614,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 116,
+    "aggregatedRank": 119,
     "countryRank": 41
   },
   {
@@ -2570,7 +2636,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 117,
+    "aggregatedRank": 120,
     "countryRank": 1
   },
   {
@@ -2592,7 +2658,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 118,
+    "aggregatedRank": 121,
     "countryRank": 3
   },
   {
@@ -2614,7 +2680,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 119,
+    "aggregatedRank": 122,
     "countryRank": 18
   },
   {
@@ -2636,7 +2702,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 120,
+    "aggregatedRank": 123,
     "countryRank": 42
   },
   {
@@ -2658,7 +2724,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 121,
+    "aggregatedRank": 124,
     "countryRank": 43
   },
   {
@@ -2680,7 +2746,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 122,
+    "aggregatedRank": 125,
     "countryRank": 3
   },
   {
@@ -2702,8 +2768,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 123,
+    "aggregatedRank": 126,
     "countryRank": 1
+  },
+  {
+    "name": "Universite Paris Cite",
+    "country": "France",
+    "aggregatedScore": 1564.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 302
+      },
+      "the": {
+        "rank": 183
+      },
+      "arwu": {
+        "rank": 60
+      },
+      "usnews": {
+        "rank": 47
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 127,
+    "countryRank": 4
   },
   {
     "name": "University of Lausanne",
@@ -2724,7 +2812,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 124,
+    "aggregatedRank": 128,
     "countryRank": 6
   },
   {
@@ -2746,7 +2834,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 125,
+    "aggregatedRank": 129,
     "countryRank": 3
   },
   {
@@ -2768,8 +2856,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 126,
-    "countryRank": 3
+    "aggregatedRank": 130,
+    "countryRank": 5
   },
   {
     "name": "University of Exeter",
@@ -2790,7 +2878,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 127,
+    "aggregatedRank": 131,
     "countryRank": 19
   },
   {
@@ -2812,7 +2900,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 128,
+    "aggregatedRank": 132,
     "countryRank": 2
   },
   {
@@ -2834,7 +2922,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 129,
+    "aggregatedRank": 133,
     "countryRank": 9
   },
   {
@@ -2856,7 +2944,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 130,
+    "aggregatedRank": 134,
     "countryRank": 4
   },
   {
@@ -2878,7 +2966,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 131,
+    "aggregatedRank": 135,
     "countryRank": 6
   },
   {
@@ -2900,7 +2988,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 132,
+    "aggregatedRank": 136,
     "countryRank": 10
   },
   {
@@ -2922,7 +3010,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 133,
+    "aggregatedRank": 137,
     "countryRank": 1
   },
   {
@@ -2944,7 +3032,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 134,
+    "aggregatedRank": 138,
     "countryRank": 44
   },
   {
@@ -2966,7 +3054,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 135,
+    "aggregatedRank": 139,
     "countryRank": 11
   },
   {
@@ -2988,7 +3076,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 136,
+    "aggregatedRank": 140,
     "countryRank": 4
   },
   {
@@ -3010,8 +3098,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 137,
-    "countryRank": 4
+    "aggregatedRank": 141,
+    "countryRank": 6
   },
   {
     "name": "University of Hamburg",
@@ -3032,8 +3120,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 138,
-    "countryRank": 5
+    "aggregatedRank": 142,
+    "countryRank": 7
   },
   {
     "name": "University of Cape Town",
@@ -3054,7 +3142,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 139,
+    "aggregatedRank": 143,
     "countryRank": 1
   },
   {
@@ -3076,7 +3164,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 140,
+    "aggregatedRank": 144,
     "countryRank": 1
   },
   {
@@ -3098,7 +3186,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 141,
+    "aggregatedRank": 145,
     "countryRank": 1
   },
   {
@@ -3120,7 +3208,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 142,
+    "aggregatedRank": 146,
     "countryRank": 10
   },
   {
@@ -3142,7 +3230,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 143,
+    "aggregatedRank": 147,
     "countryRank": 12
   },
   {
@@ -3164,8 +3252,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 144,
+    "aggregatedRank": 148,
     "countryRank": 45
+  },
+  {
+    "name": "University of Gottingen",
+    "country": "Germany",
+    "aggregatedScore": 1535.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 252
+      },
+      "the": {
+        "rank": 121
+      },
+      "arwu": {
+        "rank": 151
+      },
+      "usnews": {
+        "rank": 182
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 149,
+    "countryRank": 8
   },
   {
     "name": "University of Rochester",
@@ -3186,7 +3296,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 145,
+    "aggregatedRank": 150,
     "countryRank": 46
   },
   {
@@ -3208,7 +3318,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 146,
+    "aggregatedRank": 151,
     "countryRank": 47
   },
   {
@@ -3230,7 +3340,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 147,
+    "aggregatedRank": 152,
     "countryRank": 20
   },
   {
@@ -3252,7 +3362,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 148,
+    "aggregatedRank": 153,
     "countryRank": 13
   },
   {
@@ -3274,7 +3384,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 149,
+    "aggregatedRank": 154,
     "countryRank": 3
   },
   {
@@ -3296,8 +3406,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 150,
-    "countryRank": 3
+    "aggregatedRank": 155,
+    "countryRank": 5
   },
   {
     "name": "Beijing Normal University",
@@ -3318,7 +3428,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 151,
+    "aggregatedRank": 156,
     "countryRank": 14
   },
   {
@@ -3340,7 +3450,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 152,
+    "aggregatedRank": 157,
     "countryRank": 48
   },
   {
@@ -3362,7 +3472,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 153,
+    "aggregatedRank": 158,
     "countryRank": 5
   },
   {
@@ -3384,7 +3494,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 154,
+    "aggregatedRank": 159,
     "countryRank": 49
   },
   {
@@ -3406,8 +3516,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 155,
-    "countryRank": 6
+    "aggregatedRank": 160,
+    "countryRank": 9
   },
   {
     "name": "Tianjin University",
@@ -3428,7 +3538,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 156,
+    "aggregatedRank": 161,
     "countryRank": 15
   },
   {
@@ -3450,7 +3560,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 157,
+    "aggregatedRank": 162,
     "countryRank": 7
   },
   {
@@ -3472,8 +3582,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 158,
-    "countryRank": 7
+    "aggregatedRank": 163,
+    "countryRank": 10
   },
   {
     "name": "Beijing Institute of Technology",
@@ -3494,7 +3604,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 159,
+    "aggregatedRank": 164,
     "countryRank": 16
   },
   {
@@ -3516,7 +3626,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 160,
+    "aggregatedRank": 165,
     "countryRank": 11
   },
   {
@@ -3538,7 +3648,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 161,
+    "aggregatedRank": 166,
     "countryRank": 3
   },
   {
@@ -3560,8 +3670,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 162,
+    "aggregatedRank": 167,
     "countryRank": 12
+  },
+  {
+    "name": "Universite Libre de Bruxelles",
+    "country": "Belgium",
+    "aggregatedScore": 1516.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 230
+      },
+      "the": {
+        "rank": 201
+      },
+      "arwu": {
+        "rank": 101
+      },
+      "usnews": {
+        "rank": 252
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 168,
+    "countryRank": 2
   },
   {
     "name": "Queensland University of Technology (QUT)",
@@ -3582,7 +3714,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 163,
+    "aggregatedRank": 169,
     "countryRank": 13
   },
   {
@@ -3604,7 +3736,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 164,
+    "aggregatedRank": 170,
     "countryRank": 50
   },
   {
@@ -3626,7 +3758,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 165,
+    "aggregatedRank": 171,
     "countryRank": 2
   },
   {
@@ -3648,7 +3780,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 166,
+    "aggregatedRank": 172,
     "countryRank": 2
   },
   {
@@ -3670,7 +3802,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 167,
+    "aggregatedRank": 173,
     "countryRank": 4
   },
   {
@@ -3692,7 +3824,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 168,
+    "aggregatedRank": 174,
     "countryRank": 1
   },
   {
@@ -3714,7 +3846,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 169,
+    "aggregatedRank": 175,
     "countryRank": 17
   },
   {
@@ -3736,8 +3868,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 170,
-    "countryRank": 8
+    "aggregatedRank": 176,
+    "countryRank": 11
   },
   {
     "name": "Lomonosov Moscow State University",
@@ -3758,7 +3890,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 171,
+    "aggregatedRank": 177,
     "countryRank": 1
   },
   {
@@ -3780,7 +3912,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 172,
+    "aggregatedRank": 178,
     "countryRank": 8
   },
   {
@@ -3802,7 +3934,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 173,
+    "aggregatedRank": 179,
     "countryRank": 9
   },
   {
@@ -3824,7 +3956,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 174,
+    "aggregatedRank": 180,
     "countryRank": 4
   },
   {
@@ -3846,7 +3978,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 175,
+    "aggregatedRank": 181,
     "countryRank": 21
   },
   {
@@ -3868,7 +4000,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 176,
+    "aggregatedRank": 182,
     "countryRank": 51
   },
   {
@@ -3890,7 +4022,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 177,
+    "aggregatedRank": 183,
     "countryRank": 2
   },
   {
@@ -3912,7 +4044,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 178,
+    "aggregatedRank": 184,
     "countryRank": 52
   },
   {
@@ -3934,7 +4066,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 179,
+    "aggregatedRank": 185,
     "countryRank": 22
   },
   {
@@ -3956,7 +4088,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 180,
+    "aggregatedRank": 186,
     "countryRank": 14
   },
   {
@@ -3978,7 +4110,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 181,
+    "aggregatedRank": 187,
     "countryRank": 5
   },
   {
@@ -4000,7 +4132,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 182,
+    "aggregatedRank": 188,
     "countryRank": 18
   },
   {
@@ -4022,7 +4154,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 183,
+    "aggregatedRank": 189,
     "countryRank": 19
   },
   {
@@ -4044,7 +4176,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 184,
+    "aggregatedRank": 190,
     "countryRank": 23
   },
   {
@@ -4066,7 +4198,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 185,
+    "aggregatedRank": 191,
     "countryRank": 6
   },
   {
@@ -4088,7 +4220,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 186,
+    "aggregatedRank": 192,
     "countryRank": 24
   },
   {
@@ -4110,8 +4242,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 187,
+    "aggregatedRank": 193,
     "countryRank": 2
+  },
+  {
+    "name": "University of Munster",
+    "country": "Germany",
+    "aggregatedScore": 1478.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 367
+      },
+      "the": {
+        "rank": 188
+      },
+      "arwu": {
+        "rank": 151
+      },
+      "usnews": {
+        "rank": 228
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 194,
+    "countryRank": 12
   },
   {
     "name": "Queens University Belfast",
@@ -4132,7 +4286,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 188,
+    "aggregatedRank": 195,
     "countryRank": 25
   },
   {
@@ -4154,8 +4308,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 189,
-    "countryRank": 2
+    "aggregatedRank": 196,
+    "countryRank": 3
   },
   {
     "name": "University of Leicester",
@@ -4176,7 +4330,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 190,
+    "aggregatedRank": 197,
     "countryRank": 26
   },
   {
@@ -4198,7 +4352,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 191,
+    "aggregatedRank": 198,
     "countryRank": 1
   },
   {
@@ -4220,7 +4374,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 192,
+    "aggregatedRank": 199,
     "countryRank": 2
   },
   {
@@ -4242,7 +4396,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 193,
+    "aggregatedRank": 200,
     "countryRank": 53
   },
   {
@@ -4264,7 +4418,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 194,
+    "aggregatedRank": 201,
     "countryRank": 54
   },
   {
@@ -4286,7 +4440,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 195,
+    "aggregatedRank": 202,
     "countryRank": 2
   },
   {
@@ -4308,7 +4462,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 196,
+    "aggregatedRank": 203,
     "countryRank": 15
   },
   {
@@ -4330,7 +4484,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 197,
+    "aggregatedRank": 204,
     "countryRank": 20
   },
   {
@@ -4352,7 +4506,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 198,
+    "aggregatedRank": 205,
     "countryRank": 3
   },
   {
@@ -4374,7 +4528,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 199,
+    "aggregatedRank": 206,
     "countryRank": 27
   },
   {
@@ -4396,8 +4550,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 200,
+    "aggregatedRank": 207,
     "countryRank": 21
+  },
+  {
+    "name": "University of Wurzburg",
+    "country": "Germany",
+    "aggregatedScore": 1459,
+    "originalRankings": {
+      "qs": {
+        "rank": 428
+      },
+      "the": {
+        "rank": 163
+      },
+      "arwu": {
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 221
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 208,
+    "countryRank": 13
   },
   {
     "name": "Pompeu Fabra University",
@@ -4418,7 +4594,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 201,
+    "aggregatedRank": 209,
     "countryRank": 3
   },
   {
@@ -4440,7 +4616,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 202,
+    "aggregatedRank": 210,
     "countryRank": 5
   },
   {
@@ -4462,7 +4638,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 203,
+    "aggregatedRank": 211,
     "countryRank": 55
   },
   {
@@ -4484,7 +4660,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 204,
+    "aggregatedRank": 212,
     "countryRank": 56
   },
   {
@@ -4506,7 +4682,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 205,
+    "aggregatedRank": 213,
     "countryRank": 22
   },
   {
@@ -4528,8 +4704,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 206,
-    "countryRank": 4
+    "aggregatedRank": 214,
+    "countryRank": 6
   },
   {
     "name": "Universiti Malaya",
@@ -4550,7 +4726,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 207,
+    "aggregatedRank": 215,
     "countryRank": 1
   },
   {
@@ -4572,7 +4748,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 208,
+    "aggregatedRank": 216,
     "countryRank": 16
   },
   {
@@ -4594,7 +4770,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 209,
+    "aggregatedRank": 217,
     "countryRank": 57
   },
   {
@@ -4616,7 +4792,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 210,
+    "aggregatedRank": 218,
     "countryRank": 23
   },
   {
@@ -4638,7 +4814,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 211,
+    "aggregatedRank": 219,
     "countryRank": 7
   },
   {
@@ -4660,7 +4836,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 212,
+    "aggregatedRank": 220,
     "countryRank": 6
   },
   {
@@ -4682,7 +4858,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 213,
+    "aggregatedRank": 221,
     "countryRank": 5
   },
   {
@@ -4704,7 +4880,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 214,
+    "aggregatedRank": 222,
     "countryRank": 24
   },
   {
@@ -4726,7 +4902,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 215,
+    "aggregatedRank": 223,
     "countryRank": 6
   },
   {
@@ -4748,7 +4924,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 216,
+    "aggregatedRank": 224,
     "countryRank": 10
   },
   {
@@ -4770,7 +4946,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 217,
+    "aggregatedRank": 225,
     "countryRank": 58
   },
   {
@@ -4792,7 +4968,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 218,
+    "aggregatedRank": 226,
     "countryRank": 59
   },
   {
@@ -4814,7 +4990,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 219,
+    "aggregatedRank": 227,
     "countryRank": 17
   },
   {
@@ -4836,7 +5012,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 220,
+    "aggregatedRank": 228,
     "countryRank": 60
   },
   {
@@ -4858,8 +5034,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 221,
-    "countryRank": 3
+    "aggregatedRank": 229,
+    "countryRank": 4
   },
   {
     "name": "Eindhoven University of Technology",
@@ -4880,7 +5056,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 222,
+    "aggregatedRank": 230,
     "countryRank": 7
   },
   {
@@ -4902,7 +5078,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 223,
+    "aggregatedRank": 231,
     "countryRank": 4
   },
   {
@@ -4924,7 +5100,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 224,
+    "aggregatedRank": 232,
     "countryRank": 4
   },
   {
@@ -4946,7 +5122,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 225,
+    "aggregatedRank": 233,
     "countryRank": 2
   },
   {
@@ -4968,7 +5144,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 226,
+    "aggregatedRank": 234,
     "countryRank": 7
   },
   {
@@ -4990,7 +5166,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 227,
+    "aggregatedRank": 235,
     "countryRank": 8
   },
   {
@@ -5012,7 +5188,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 228,
+    "aggregatedRank": 236,
     "countryRank": 28
   },
   {
@@ -5034,7 +5210,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 229,
+    "aggregatedRank": 237,
     "countryRank": 6
   },
   {
@@ -5056,7 +5232,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 230,
+    "aggregatedRank": 238,
     "countryRank": 25
   },
   {
@@ -5078,7 +5254,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 231,
+    "aggregatedRank": 239,
     "countryRank": 26
   },
   {
@@ -5100,7 +5276,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 232,
+    "aggregatedRank": 240,
     "countryRank": 1
   },
   {
@@ -5122,7 +5298,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 233,
+    "aggregatedRank": 241,
     "countryRank": 61
   },
   {
@@ -5144,7 +5320,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 234,
+    "aggregatedRank": 242,
     "countryRank": 8
   },
   {
@@ -5166,7 +5342,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 235,
+    "aggregatedRank": 243,
     "countryRank": 29
   },
   {
@@ -5188,7 +5364,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 236,
+    "aggregatedRank": 244,
     "countryRank": 9
   },
   {
@@ -5210,8 +5386,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 237,
-    "countryRank": 5
+    "aggregatedRank": 245,
+    "countryRank": 7
   },
   {
     "name": "University of Surrey",
@@ -5232,7 +5408,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 238,
+    "aggregatedRank": 246,
     "countryRank": 30
   },
   {
@@ -5254,7 +5430,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 239,
+    "aggregatedRank": 247,
     "countryRank": 62
   },
   {
@@ -5276,7 +5452,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 240,
+    "aggregatedRank": 248,
     "countryRank": 5
   },
   {
@@ -5298,7 +5474,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 241,
+    "aggregatedRank": 249,
     "countryRank": 63
   },
   {
@@ -5320,7 +5496,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 242,
+    "aggregatedRank": 250,
     "countryRank": 8
   },
   {
@@ -5342,7 +5518,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 243,
+    "aggregatedRank": 251,
     "countryRank": 64
   },
   {
@@ -5364,7 +5540,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 244,
+    "aggregatedRank": 252,
     "countryRank": 27
   },
   {
@@ -5386,7 +5562,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 245,
+    "aggregatedRank": 253,
     "countryRank": 2
   },
   {
@@ -5408,7 +5584,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 246,
+    "aggregatedRank": 254,
     "countryRank": 11
   },
   {
@@ -5430,7 +5606,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 247,
+    "aggregatedRank": 255,
     "countryRank": 65
   },
   {
@@ -5452,7 +5628,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 248,
+    "aggregatedRank": 256,
     "countryRank": 3
   },
   {
@@ -5474,7 +5650,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 249,
+    "aggregatedRank": 257,
     "countryRank": 10
   },
   {
@@ -5496,7 +5672,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 250,
+    "aggregatedRank": 258,
     "countryRank": 3
   },
   {
@@ -5518,7 +5694,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 251,
+    "aggregatedRank": 259,
     "countryRank": 5
   },
   {
@@ -5540,7 +5716,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 252,
+    "aggregatedRank": 260,
     "countryRank": 2
   },
   {
@@ -5562,7 +5738,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 253,
+    "aggregatedRank": 261,
     "countryRank": 31
   },
   {
@@ -5584,8 +5760,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 254,
+    "aggregatedRank": 262,
     "countryRank": 66
+  },
+  {
+    "name": "University of Liege",
+    "country": "Belgium",
+    "aggregatedScore": 1385.25,
+    "originalRankings": {
+      "qs": {
+        "rank": 396
+      },
+      "the": {
+        "rank": 251
+      },
+      "arwu": {
+        "rank": 301
+      },
+      "usnews": {
+        "rank": 360
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 263,
+    "countryRank": 5
   },
   {
     "name": "University of Potsdam",
@@ -5606,8 +5804,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 255,
-    "countryRank": 9
+    "aggregatedRank": 264,
+    "countryRank": 14
   },
   {
     "name": "Dalian University of Technology",
@@ -5628,7 +5826,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 256,
+    "aggregatedRank": 265,
     "countryRank": 28
   },
   {
@@ -5650,7 +5848,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 257,
+    "aggregatedRank": 266,
     "countryRank": 3
   },
   {
@@ -5672,7 +5870,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 258,
+    "aggregatedRank": 267,
     "countryRank": 9
   },
   {
@@ -5694,7 +5892,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 259,
+    "aggregatedRank": 268,
     "countryRank": 12
   },
   {
@@ -5716,7 +5914,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 260,
+    "aggregatedRank": 269,
     "countryRank": 2
   },
   {
@@ -5738,7 +5936,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 261,
+    "aggregatedRank": 270,
     "countryRank": 6
   },
   {
@@ -5760,8 +5958,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 262,
-    "countryRank": 6
+    "aggregatedRank": 271,
+    "countryRank": 8
   },
   {
     "name": "Colorado State University",
@@ -5782,7 +5980,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 263,
+    "aggregatedRank": 272,
     "countryRank": 67
   },
   {
@@ -5804,7 +6002,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 264,
+    "aggregatedRank": 273,
     "countryRank": 68
   },
   {
@@ -5826,7 +6024,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 265,
+    "aggregatedRank": 274,
     "countryRank": 29
   },
   {
@@ -5848,7 +6046,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 266,
+    "aggregatedRank": 275,
     "countryRank": 3
   },
   {
@@ -5870,7 +6068,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 267,
+    "aggregatedRank": 276,
     "countryRank": 7
   },
   {
@@ -5892,7 +6090,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 268,
+    "aggregatedRank": 277,
     "countryRank": 4
   },
   {
@@ -5914,7 +6112,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 269,
+    "aggregatedRank": 278,
     "countryRank": 13
   },
   {
@@ -5936,7 +6134,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 270,
+    "aggregatedRank": 279,
     "countryRank": 3
   },
   {
@@ -5958,7 +6156,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 271,
+    "aggregatedRank": 280,
     "countryRank": 11
   },
   {
@@ -5980,7 +6178,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 272,
+    "aggregatedRank": 281,
     "countryRank": 69
   },
   {
@@ -6002,7 +6200,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 273,
+    "aggregatedRank": 282,
     "countryRank": 1
   },
   {
@@ -6024,8 +6222,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 274,
-    "countryRank": 10
+    "aggregatedRank": 283,
+    "countryRank": 15
   },
   {
     "name": "University of Connecticut",
@@ -6046,7 +6244,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 275,
+    "aggregatedRank": 284,
     "countryRank": 70
   },
   {
@@ -6068,7 +6266,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 276,
+    "aggregatedRank": 285,
     "countryRank": 18
   },
   {
@@ -6090,7 +6288,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 277,
+    "aggregatedRank": 286,
     "countryRank": 10
   },
   {
@@ -6112,7 +6310,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 278,
+    "aggregatedRank": 287,
     "countryRank": 19
   },
   {
@@ -6134,7 +6332,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 279,
+    "aggregatedRank": 288,
     "countryRank": 12
   },
   {
@@ -6156,7 +6354,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 280,
+    "aggregatedRank": 289,
     "countryRank": 71
   },
   {
@@ -6178,7 +6376,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 281,
+    "aggregatedRank": 290,
     "countryRank": 13
   },
   {
@@ -6200,7 +6398,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 282,
+    "aggregatedRank": 291,
     "countryRank": 72
   },
   {
@@ -6222,7 +6420,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 283,
+    "aggregatedRank": 292,
     "countryRank": 1
   },
   {
@@ -6244,7 +6442,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 284,
+    "aggregatedRank": 293,
     "countryRank": 1
   },
   {
@@ -6266,7 +6464,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 285,
+    "aggregatedRank": 294,
     "countryRank": 73
   },
   {
@@ -6288,7 +6486,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 286,
+    "aggregatedRank": 295,
     "countryRank": 2
   },
   {
@@ -6310,7 +6508,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 287,
+    "aggregatedRank": 296,
     "countryRank": 32
   },
   {
@@ -6332,7 +6530,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 288,
+    "aggregatedRank": 297,
     "countryRank": 74
   },
   {
@@ -6354,7 +6552,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 289,
+    "aggregatedRank": 298,
     "countryRank": 33
   },
   {
@@ -6376,8 +6574,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 290,
-    "countryRank": 11
+    "aggregatedRank": 299,
+    "countryRank": 16
   },
   {
     "name": "Hong Kong Baptist University",
@@ -6398,7 +6596,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 291,
+    "aggregatedRank": 300,
     "countryRank": 6
   },
   {
@@ -6420,7 +6618,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 292,
+    "aggregatedRank": 301,
     "countryRank": 34
   },
   {
@@ -6442,7 +6640,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 293,
+    "aggregatedRank": 302,
     "countryRank": 20
   },
   {
@@ -6464,7 +6662,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 294,
+    "aggregatedRank": 303,
     "countryRank": 1
   },
   {
@@ -6486,7 +6684,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 295,
+    "aggregatedRank": 304,
     "countryRank": 14
   },
   {
@@ -6508,7 +6706,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 296,
+    "aggregatedRank": 305,
     "countryRank": 30
   },
   {
@@ -6530,7 +6728,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 297,
+    "aggregatedRank": 306,
     "countryRank": 21
   },
   {
@@ -6552,7 +6750,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 298,
+    "aggregatedRank": 307,
     "countryRank": 1
   },
   {
@@ -6574,7 +6772,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 299,
+    "aggregatedRank": 308,
     "countryRank": 75
   },
   {
@@ -6596,7 +6794,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 300,
+    "aggregatedRank": 309,
     "countryRank": 7
   },
   {
@@ -6618,7 +6816,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 301,
+    "aggregatedRank": 310,
     "countryRank": 3
   },
   {
@@ -6640,7 +6838,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 302,
+    "aggregatedRank": 311,
     "countryRank": 1
   },
   {
@@ -6662,8 +6860,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 303,
-    "countryRank": 12
+    "aggregatedRank": 312,
+    "countryRank": 17
   },
   {
     "name": "University of Duisburg Essen",
@@ -6684,8 +6882,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 304,
-    "countryRank": 13
+    "aggregatedRank": 313,
+    "countryRank": 18
   },
   {
     "name": "King Khalid University",
@@ -6706,7 +6904,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 305,
+    "aggregatedRank": 314,
     "countryRank": 4
   },
   {
@@ -6728,7 +6926,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 306,
+    "aggregatedRank": 315,
     "countryRank": 14
   },
   {
@@ -6750,7 +6948,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 307,
+    "aggregatedRank": 316,
     "countryRank": 76
   },
   {
@@ -6772,7 +6970,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 308,
+    "aggregatedRank": 317,
     "countryRank": 2
   },
   {
@@ -6794,7 +6992,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 309,
+    "aggregatedRank": 318,
     "countryRank": 77
   },
   {
@@ -6816,7 +7014,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 310,
+    "aggregatedRank": 319,
     "countryRank": 78
   },
   {
@@ -6838,7 +7036,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 311,
+    "aggregatedRank": 320,
     "countryRank": 8
   },
   {
@@ -6860,7 +7058,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 312,
+    "aggregatedRank": 321,
     "countryRank": 1
   },
   {
@@ -6882,7 +7080,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 313,
+    "aggregatedRank": 322,
     "countryRank": 15
   },
   {
@@ -6904,7 +7102,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 314,
+    "aggregatedRank": 323,
     "countryRank": 79
   },
   {
@@ -6926,7 +7124,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 315,
+    "aggregatedRank": 324,
     "countryRank": 3
   },
   {
@@ -6948,7 +7146,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 316,
+    "aggregatedRank": 325,
     "countryRank": 7
   },
   {
@@ -6970,7 +7168,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 317,
+    "aggregatedRank": 326,
     "countryRank": 1
   },
   {
@@ -6992,7 +7190,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 318,
+    "aggregatedRank": 327,
     "countryRank": 16
   },
   {
@@ -7014,7 +7212,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 319,
+    "aggregatedRank": 328,
     "countryRank": 4
   },
   {
@@ -7036,7 +7234,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 320,
+    "aggregatedRank": 329,
     "countryRank": 2
   },
   {
@@ -7058,7 +7256,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 321,
+    "aggregatedRank": 330,
     "countryRank": 35
   },
   {
@@ -7080,7 +7278,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 322,
+    "aggregatedRank": 331,
     "countryRank": 80
   },
   {
@@ -7102,8 +7300,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 323,
-    "countryRank": 14
+    "aggregatedRank": 332,
+    "countryRank": 19
   },
   {
     "name": "University of South Carolina Columbia",
@@ -7124,7 +7322,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 324,
+    "aggregatedRank": 333,
     "countryRank": 81
   },
   {
@@ -7146,7 +7344,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 325,
+    "aggregatedRank": 334,
     "countryRank": 82
   },
   {
@@ -7168,7 +7366,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 326,
+    "aggregatedRank": 335,
     "countryRank": 2
   },
   {
@@ -7190,7 +7388,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 327,
+    "aggregatedRank": 336,
     "countryRank": 2
   },
   {
@@ -7212,7 +7410,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 328,
+    "aggregatedRank": 337,
     "countryRank": 4
   },
   {
@@ -7234,8 +7432,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 329,
-    "countryRank": 15
+    "aggregatedRank": 338,
+    "countryRank": 20
   },
   {
     "name": "Murdoch University",
@@ -7256,7 +7454,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 330,
+    "aggregatedRank": 339,
     "countryRank": 22
   },
   {
@@ -7278,7 +7476,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 331,
+    "aggregatedRank": 340,
     "countryRank": 83
   },
   {
@@ -7300,7 +7498,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 332,
+    "aggregatedRank": 341,
     "countryRank": 84
   },
   {
@@ -7322,7 +7520,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 333,
+    "aggregatedRank": 342,
     "countryRank": 85
   },
   {
@@ -7344,7 +7542,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 334,
+    "aggregatedRank": 343,
     "countryRank": 86
   },
   {
@@ -7366,7 +7564,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 335,
+    "aggregatedRank": 344,
     "countryRank": 2
   },
   {
@@ -7388,7 +7586,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 336,
+    "aggregatedRank": 345,
     "countryRank": 17
   },
   {
@@ -7410,7 +7608,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 337,
+    "aggregatedRank": 346,
     "countryRank": 4
   },
   {
@@ -7432,7 +7630,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 338,
+    "aggregatedRank": 347,
     "countryRank": 23
   },
   {
@@ -7454,7 +7652,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 339,
+    "aggregatedRank": 348,
     "countryRank": 87
   },
   {
@@ -7476,7 +7674,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 340,
+    "aggregatedRank": 349,
     "countryRank": 1
   },
   {
@@ -7498,7 +7696,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 341,
+    "aggregatedRank": 350,
     "countryRank": 9
   },
   {
@@ -7520,7 +7718,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 342,
+    "aggregatedRank": 351,
     "countryRank": 36
   },
   {
@@ -7542,7 +7740,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 343,
+    "aggregatedRank": 352,
     "countryRank": 88
   },
   {
@@ -7564,7 +7762,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 344,
+    "aggregatedRank": 353,
     "countryRank": 1
   },
   {
@@ -7586,7 +7784,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 345,
+    "aggregatedRank": 354,
     "countryRank": 89
   },
   {
@@ -7608,7 +7806,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 346,
+    "aggregatedRank": 355,
     "countryRank": 1
   },
   {
@@ -7630,7 +7828,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 347,
+    "aggregatedRank": 356,
     "countryRank": 90
   },
   {
@@ -7652,7 +7850,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 348,
+    "aggregatedRank": 357,
     "countryRank": 91
   },
   {
@@ -7674,7 +7872,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 349,
+    "aggregatedRank": 358,
     "countryRank": 2
   },
   {
@@ -7696,8 +7894,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 350,
-    "countryRank": 16
+    "aggregatedRank": 359,
+    "countryRank": 21
   },
   {
     "name": "Princess Nourah bint Abdulrahman University",
@@ -7718,7 +7916,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 351,
+    "aggregatedRank": 360,
     "countryRank": 5
   },
   {
@@ -7740,7 +7938,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 352,
+    "aggregatedRank": 361,
     "countryRank": 5
   },
   {
@@ -7762,7 +7960,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 353,
+    "aggregatedRank": 362,
     "countryRank": 92
   },
   {
@@ -7781,8 +7979,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 354,
-    "countryRank": 17
+    "aggregatedRank": 363,
+    "countryRank": 22
   },
   {
     "name": "Free University of Berlin",
@@ -7800,8 +7998,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 355,
-    "countryRank": 18
+    "aggregatedRank": 364,
+    "countryRank": 23
   },
   {
     "name": "University of Bayreuth",
@@ -7822,8 +8020,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 356,
-    "countryRank": 19
+    "aggregatedRank": 365,
+    "countryRank": 24
   },
   {
     "name": "Nanjing University of Aeronautics & Astronautics",
@@ -7844,7 +8042,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 357,
+    "aggregatedRank": 366,
     "countryRank": 31
   },
   {
@@ -7866,7 +8064,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 358,
+    "aggregatedRank": 367,
     "countryRank": 32
   },
   {
@@ -7888,7 +8086,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 359,
+    "aggregatedRank": 368,
     "countryRank": 93
   },
   {
@@ -7910,7 +8108,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 360,
+    "aggregatedRank": 369,
     "countryRank": 7
   },
   {
@@ -7932,7 +8130,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 361,
+    "aggregatedRank": 370,
     "countryRank": 15
   },
   {
@@ -7954,7 +8152,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 362,
+    "aggregatedRank": 371,
     "countryRank": 1
   },
   {
@@ -7976,7 +8174,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 363,
+    "aggregatedRank": 372,
     "countryRank": 16
   },
   {
@@ -7998,7 +8196,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 364,
+    "aggregatedRank": 373,
     "countryRank": 11
   },
   {
@@ -8020,7 +8218,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 365,
+    "aggregatedRank": 374,
     "countryRank": 94
   },
   {
@@ -8042,7 +8240,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 366,
+    "aggregatedRank": 375,
     "countryRank": 5
   },
   {
@@ -8064,7 +8262,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 367,
+    "aggregatedRank": 376,
     "countryRank": 4
   },
   {
@@ -8086,7 +8284,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 368,
+    "aggregatedRank": 377,
     "countryRank": 8
   },
   {
@@ -8108,7 +8306,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 369,
+    "aggregatedRank": 378,
     "countryRank": 2
   },
   {
@@ -8130,7 +8328,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 370,
+    "aggregatedRank": 379,
     "countryRank": 1
   },
   {
@@ -8152,7 +8350,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 371,
+    "aggregatedRank": 380,
     "countryRank": 12
   },
   {
@@ -8174,7 +8372,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 372,
+    "aggregatedRank": 381,
     "countryRank": 5
   },
   {
@@ -8196,7 +8394,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 373,
+    "aggregatedRank": 382,
     "countryRank": 6
   },
   {
@@ -8218,7 +8416,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 374,
+    "aggregatedRank": 383,
     "countryRank": 9
   },
   {
@@ -8240,7 +8438,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 375,
+    "aggregatedRank": 384,
     "countryRank": 2
   },
   {
@@ -8262,7 +8460,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 376,
+    "aggregatedRank": 385,
     "countryRank": 1
   },
   {
@@ -8284,7 +8482,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 377,
+    "aggregatedRank": 386,
     "countryRank": 1
   },
   {
@@ -8306,7 +8504,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 378,
+    "aggregatedRank": 387,
     "countryRank": 17
   },
   {
@@ -8328,7 +8526,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 379,
+    "aggregatedRank": 388,
     "countryRank": 1
   },
   {
@@ -8350,7 +8548,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 380,
+    "aggregatedRank": 389,
     "countryRank": 24
   },
   {
@@ -8372,7 +8570,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 381,
+    "aggregatedRank": 390,
     "countryRank": 95
   },
   {
@@ -8394,7 +8592,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 382,
+    "aggregatedRank": 391,
     "countryRank": 6
   },
   {
@@ -8416,7 +8614,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 383,
+    "aggregatedRank": 392,
     "countryRank": 10
   },
   {
@@ -8438,7 +8636,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 384,
+    "aggregatedRank": 393,
     "countryRank": 18
   },
   {
@@ -8460,7 +8658,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 385,
+    "aggregatedRank": 394,
     "countryRank": 96
   },
   {
@@ -8482,7 +8680,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 386,
+    "aggregatedRank": 395,
     "countryRank": 3
   },
   {
@@ -8504,8 +8702,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 387,
-    "countryRank": 4
+    "aggregatedRank": 396,
+    "countryRank": 6
   },
   {
     "name": "University of Hull",
@@ -8526,7 +8724,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 388,
+    "aggregatedRank": 397,
     "countryRank": 37
   },
   {
@@ -8548,7 +8746,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 389,
+    "aggregatedRank": 398,
     "countryRank": 2
   },
   {
@@ -8570,7 +8768,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 390,
+    "aggregatedRank": 399,
     "countryRank": 97
   },
   {
@@ -8592,8 +8790,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 391,
+    "aggregatedRank": 400,
     "countryRank": 18
+  },
+  {
+    "name": "Eotvos Lorand University",
+    "country": "Hungary",
+    "aggregatedScore": 1122,
+    "originalRankings": {
+      "qs": {
+        "rank": 564
+      },
+      "the": {
+        "rank": 801
+      },
+      "arwu": {
+        "rank": 501
+      },
+      "usnews": {
+        "rank": 495
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 401,
+    "countryRank": 1
   },
   {
     "name": "Amirkabir University of Technology",
@@ -8614,7 +8834,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 392,
+    "aggregatedRank": 402,
     "countryRank": 3
   },
   {
@@ -8636,7 +8856,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 393,
+    "aggregatedRank": 403,
     "countryRank": 38
   },
   {
@@ -8658,7 +8878,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 394,
+    "aggregatedRank": 404,
     "countryRank": 5
   },
   {
@@ -8680,7 +8900,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 395,
+    "aggregatedRank": 405,
     "countryRank": 98
   },
   {
@@ -8702,7 +8922,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 396,
+    "aggregatedRank": 406,
     "countryRank": 39
   },
   {
@@ -8724,7 +8944,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 397,
+    "aggregatedRank": 407,
     "countryRank": 1
   },
   {
@@ -8746,7 +8966,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 398,
+    "aggregatedRank": 408,
     "countryRank": 2
   },
   {
@@ -8768,7 +8988,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 399,
+    "aggregatedRank": 409,
     "countryRank": 40
   },
   {
@@ -8787,7 +9007,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 400,
+    "aggregatedRank": 410,
     "countryRank": 8
   },
   {
@@ -8809,7 +9029,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 401,
+    "aggregatedRank": 411,
     "countryRank": 99
   },
   {
@@ -8831,7 +9051,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 402,
+    "aggregatedRank": 412,
     "countryRank": 100
   },
   {
@@ -8853,7 +9073,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 403,
+    "aggregatedRank": 413,
     "countryRank": 41
   },
   {
@@ -8875,7 +9095,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 404,
+    "aggregatedRank": 414,
     "countryRank": 25
   },
   {
@@ -8897,7 +9117,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 405,
+    "aggregatedRank": 415,
     "countryRank": 2
   },
   {
@@ -8919,7 +9139,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 406,
+    "aggregatedRank": 416,
     "countryRank": 42
   },
   {
@@ -8941,7 +9161,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 407,
+    "aggregatedRank": 417,
     "countryRank": 3
   },
   {
@@ -8963,7 +9183,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 408,
+    "aggregatedRank": 418,
     "countryRank": 43
   },
   {
@@ -8985,7 +9205,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 409,
+    "aggregatedRank": 419,
     "countryRank": 44
   },
   {
@@ -9007,7 +9227,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 410,
+    "aggregatedRank": 420,
     "countryRank": 2
   },
   {
@@ -9029,7 +9249,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 411,
+    "aggregatedRank": 421,
     "countryRank": 4
   },
   {
@@ -9051,7 +9271,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 412,
+    "aggregatedRank": 422,
     "countryRank": 45
   },
   {
@@ -9073,7 +9293,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 413,
+    "aggregatedRank": 423,
     "countryRank": 46
   },
   {
@@ -9095,7 +9315,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 414,
+    "aggregatedRank": 424,
     "countryRank": 1
   },
   {
@@ -9117,7 +9337,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 415,
+    "aggregatedRank": 425,
     "countryRank": 13
   },
   {
@@ -9139,7 +9359,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 416,
+    "aggregatedRank": 426,
     "countryRank": 47
   },
   {
@@ -9161,7 +9381,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 417,
+    "aggregatedRank": 427,
     "countryRank": 2
   },
   {
@@ -9183,7 +9403,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 418,
+    "aggregatedRank": 428,
     "countryRank": 5
   },
   {
@@ -9205,7 +9425,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 419,
+    "aggregatedRank": 429,
     "countryRank": 6
   },
   {
@@ -9227,7 +9447,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 420,
+    "aggregatedRank": 430,
     "countryRank": 19
   },
   {
@@ -9249,7 +9469,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 421,
+    "aggregatedRank": 431,
     "countryRank": 9
   },
   {
@@ -9271,7 +9491,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 422,
+    "aggregatedRank": 432,
     "countryRank": 4
   },
   {
@@ -9293,7 +9513,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 423,
+    "aggregatedRank": 433,
     "countryRank": 101
   },
   {
@@ -9315,7 +9535,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 424,
+    "aggregatedRank": 434,
     "countryRank": 7
   },
   {
@@ -9337,7 +9557,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 425,
+    "aggregatedRank": 435,
     "countryRank": 20
   },
   {
@@ -9359,7 +9579,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 426,
+    "aggregatedRank": 436,
     "countryRank": 19
   },
   {
@@ -9381,7 +9601,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 427,
+    "aggregatedRank": 437,
     "countryRank": 3
   },
   {
@@ -9403,7 +9623,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 428,
+    "aggregatedRank": 438,
     "countryRank": 21
   },
   {
@@ -9425,7 +9645,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 429,
+    "aggregatedRank": 439,
     "countryRank": 102
   },
   {
@@ -9447,7 +9667,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 430,
+    "aggregatedRank": 440,
     "countryRank": 22
   },
   {
@@ -9469,7 +9689,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 431,
+    "aggregatedRank": 441,
     "countryRank": 23
   },
   {
@@ -9491,7 +9711,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 432,
+    "aggregatedRank": 442,
     "countryRank": 24
   },
   {
@@ -9513,7 +9733,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 433,
+    "aggregatedRank": 443,
     "countryRank": 6
   },
   {
@@ -9535,7 +9755,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 434,
+    "aggregatedRank": 444,
     "countryRank": 25
   },
   {
@@ -9557,7 +9777,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 435,
+    "aggregatedRank": 445,
     "countryRank": 3
   },
   {
@@ -9576,7 +9796,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 436,
+    "aggregatedRank": 446,
     "countryRank": 2
   },
   {
@@ -9598,7 +9818,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 437,
+    "aggregatedRank": 447,
     "countryRank": 103
   },
   {
@@ -9620,7 +9840,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 438,
+    "aggregatedRank": 448,
     "countryRank": 48
   },
   {
@@ -9642,7 +9862,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 439,
+    "aggregatedRank": 449,
     "countryRank": 104
   },
   {
@@ -9661,7 +9881,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 440,
+    "aggregatedRank": 450,
     "countryRank": 4
   },
   {
@@ -9683,7 +9903,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 441,
+    "aggregatedRank": 451,
     "countryRank": 3
   },
   {
@@ -9702,7 +9922,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 442,
+    "aggregatedRank": 452,
     "countryRank": 105
   },
   {
@@ -9724,7 +9944,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 443,
+    "aggregatedRank": 453,
     "countryRank": 14
   },
   {
@@ -9746,7 +9966,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 444,
+    "aggregatedRank": 454,
     "countryRank": 7
   },
   {
@@ -9768,7 +9988,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 445,
+    "aggregatedRank": 455,
     "countryRank": 106
   },
   {
@@ -9787,7 +10007,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 446,
+    "aggregatedRank": 456,
     "countryRank": 49
   },
   {
@@ -9806,7 +10026,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 447,
+    "aggregatedRank": 457,
     "countryRank": 1
   },
   {
@@ -9825,7 +10045,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 448,
+    "aggregatedRank": 458,
     "countryRank": 10
   },
   {
@@ -9847,7 +10067,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 449,
+    "aggregatedRank": 459,
     "countryRank": 3
   },
   {
@@ -9869,7 +10089,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 450,
+    "aggregatedRank": 460,
     "countryRank": 26
   },
   {
@@ -9888,7 +10108,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 451,
+    "aggregatedRank": 461,
     "countryRank": 8
   },
   {
@@ -9910,7 +10130,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 452,
+    "aggregatedRank": 462,
     "countryRank": 20
   },
   {
@@ -9929,27 +10149,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 453,
-    "countryRank": 20
-  },
-  {
-    "name": "Technical University of M�nchen",
-    "country": "Germany",
-    "aggregatedScore": 934.5,
-    "originalRankings": {
-      "qs": {
-        "rank": 28
-      },
-      "the": {
-        "rank": 26
-      },
-      "arwu": {
-        "rank": 47
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 454,
-    "countryRank": 21
+    "aggregatedRank": 463,
+    "countryRank": 25
   },
   {
     "name": "Okayama University",
@@ -9970,7 +10171,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 455,
+    "aggregatedRank": 464,
     "countryRank": 11
   },
   {
@@ -9992,7 +10193,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 456,
+    "aggregatedRank": 465,
     "countryRank": 4
   },
   {
@@ -10011,46 +10212,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 457,
+    "aggregatedRank": 466,
     "countryRank": 5
-  },
-  {
-    "name": "University of M�nchen",
-    "country": "Germany",
-    "aggregatedScore": 925.96875,
-    "originalRankings": {
-      "qs": {
-        "rank": 59
-      },
-      "the": {
-        "rank": 38
-      },
-      "arwu": {
-        "rank": 43
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 458,
-    "countryRank": 22
-  },
-  {
-    "name": "Universit� Paris-Saclay",
-    "country": "France",
-    "aggregatedScore": 924,
-    "originalRankings": {
-      "qs": {
-        "rank": 73
-      },
-      "the": {
-        "rank": 64
-      },
-      "arwu": {
-        "rank": 12
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 459,
-    "countryRank": 7
   },
   {
     "name": "Prince Sultan University",
@@ -10068,7 +10231,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 460,
+    "aggregatedRank": 467,
     "countryRank": 8
   },
   {
@@ -10087,7 +10250,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 461,
+    "aggregatedRank": 468,
     "countryRank": 1
   },
   {
@@ -10106,7 +10269,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 462,
+    "aggregatedRank": 469,
     "countryRank": 8
   },
   {
@@ -10125,7 +10288,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 463,
+    "aggregatedRank": 470,
     "countryRank": 9
   },
   {
@@ -10144,7 +10307,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 464,
+    "aggregatedRank": 471,
     "countryRank": 10
   },
   {
@@ -10163,7 +10326,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 465,
+    "aggregatedRank": 472,
     "countryRank": 6
   },
   {
@@ -10185,7 +10348,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 466,
+    "aggregatedRank": 473,
     "countryRank": 27
   },
   {
@@ -10207,7 +10370,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 467,
+    "aggregatedRank": 474,
     "countryRank": 3
   },
   {
@@ -10229,7 +10392,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 468,
+    "aggregatedRank": 475,
     "countryRank": 50
   },
   {
@@ -10248,7 +10411,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 469,
+    "aggregatedRank": 476,
     "countryRank": 3
   },
   {
@@ -10267,7 +10430,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 470,
+    "aggregatedRank": 477,
     "countryRank": 4
   },
   {
@@ -10286,7 +10449,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 471,
+    "aggregatedRank": 478,
     "countryRank": 107
   },
   {
@@ -10308,7 +10471,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 472,
+    "aggregatedRank": 479,
     "countryRank": 10
   },
   {
@@ -10327,7 +10490,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 473,
+    "aggregatedRank": 480,
     "countryRank": 9
   },
   {
@@ -10346,7 +10509,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 474,
+    "aggregatedRank": 481,
     "countryRank": 5
   },
   {
@@ -10365,7 +10528,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 475,
+    "aggregatedRank": 482,
     "countryRank": 2
   },
   {
@@ -10384,7 +10547,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 476,
+    "aggregatedRank": 483,
     "countryRank": 108
   },
   {
@@ -10403,7 +10566,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 477,
+    "aggregatedRank": 484,
     "countryRank": 33
   },
   {
@@ -10422,7 +10585,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 478,
+    "aggregatedRank": 485,
     "countryRank": 109
   },
   {
@@ -10441,7 +10604,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 479,
+    "aggregatedRank": 486,
     "countryRank": 28
   },
   {
@@ -10460,7 +10623,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 480,
+    "aggregatedRank": 487,
     "countryRank": 12
   },
   {
@@ -10479,7 +10642,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 481,
+    "aggregatedRank": 488,
     "countryRank": 6
   },
   {
@@ -10498,7 +10661,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 482,
+    "aggregatedRank": 489,
     "countryRank": 21
   },
   {
@@ -10517,7 +10680,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 483,
+    "aggregatedRank": 490,
     "countryRank": 26
   },
   {
@@ -10536,7 +10699,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 484,
+    "aggregatedRank": 491,
     "countryRank": 27
   },
   {
@@ -10555,7 +10718,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 485,
+    "aggregatedRank": 492,
     "countryRank": 13
   },
   {
@@ -10577,7 +10740,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 486,
+    "aggregatedRank": 493,
     "countryRank": 28
   },
   {
@@ -10596,7 +10759,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 487,
+    "aggregatedRank": 494,
     "countryRank": 34
   },
   {
@@ -10615,11 +10778,11 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 488,
+    "aggregatedRank": 495,
     "countryRank": 35
   },
   {
-    "name": "University of T�bingen",
+    "name": "University of Tübingen",
     "country": "Germany",
     "aggregatedScore": 853.125,
     "originalRankings": {
@@ -10634,8 +10797,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 489,
-    "countryRank": 23
+    "aggregatedRank": 496,
+    "countryRank": 26
   },
   {
     "name": "Shandong University",
@@ -10653,7 +10816,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 490,
+    "aggregatedRank": 497,
     "countryRank": 36
   },
   {
@@ -10672,11 +10835,11 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 491,
+    "aggregatedRank": 498,
     "countryRank": 51
   },
   {
-    "name": "G�teborg University",
+    "name": "Göteborg University",
     "country": "Sweden",
     "aggregatedScore": 848.09375,
     "originalRankings": {
@@ -10691,7 +10854,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 492,
+    "aggregatedRank": 499,
     "countryRank": 10
   },
   {
@@ -10710,7 +10873,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 493,
+    "aggregatedRank": 500,
     "countryRank": 37
   },
   {
@@ -10729,7 +10892,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 494,
+    "aggregatedRank": 501,
     "countryRank": 110
   },
   {
@@ -10748,7 +10911,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 495,
+    "aggregatedRank": 502,
     "countryRank": 29
   },
   {
@@ -10767,7 +10930,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 496,
+    "aggregatedRank": 503,
     "countryRank": 11
   },
   {
@@ -10786,7 +10949,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 497,
+    "aggregatedRank": 504,
     "countryRank": 9
   },
   {
@@ -10805,7 +10968,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 498,
+    "aggregatedRank": 505,
     "countryRank": 1
   },
   {
@@ -10824,27 +10987,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 499,
+    "aggregatedRank": 506,
     "countryRank": 12
-  },
-  {
-    "name": "University of G�ttingen",
-    "country": "Germany",
-    "aggregatedScore": 841.96875,
-    "originalRankings": {
-      "qs": {
-        "rank": 252
-      },
-      "the": {
-        "rank": 121
-      },
-      "arwu": {
-        "rank": 151
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 500,
-    "countryRank": 24
   },
   {
     "name": "Eastern Mediterranean University",
@@ -10862,27 +11006,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 501,
+    "aggregatedRank": 507,
     "countryRank": 2
-  },
-  {
-    "name": "Universit� Libre de Bruxelles",
-    "country": "Belgium",
-    "aggregatedScore": 840.21875,
-    "originalRankings": {
-      "qs": {
-        "rank": 230
-      },
-      "the": {
-        "rank": 201
-      },
-      "arwu": {
-        "rank": 101
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 502,
-    "countryRank": 5
   },
   {
     "name": "Bilkent University",
@@ -10900,27 +11025,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 503,
+    "aggregatedRank": 508,
     "countryRank": 7
-  },
-  {
-    "name": "Paris Cit� University",
-    "country": "France",
-    "aggregatedScore": 837.375,
-    "originalRankings": {
-      "qs": {
-        "rank": 302
-      },
-      "the": {
-        "rank": 183
-      },
-      "arwu": {
-        "rank": 60
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 504,
-    "countryRank": 8
   },
   {
     "name": "The American University in Cairo",
@@ -10938,7 +11044,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 505,
+    "aggregatedRank": 509,
     "countryRank": 3
   },
   {
@@ -10957,7 +11063,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 506,
+    "aggregatedRank": 510,
     "countryRank": 1
   },
   {
@@ -10976,7 +11082,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 507,
+    "aggregatedRank": 511,
     "countryRank": 38
   },
   {
@@ -10995,7 +11101,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 508,
+    "aggregatedRank": 512,
     "countryRank": 39
   },
   {
@@ -11014,7 +11120,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 509,
+    "aggregatedRank": 513,
     "countryRank": 13
   },
   {
@@ -11033,8 +11139,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 510,
-    "countryRank": 6
+    "aggregatedRank": 514,
+    "countryRank": 7
   },
   {
     "name": "University of St. Andrews",
@@ -11052,7 +11158,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 511,
+    "aggregatedRank": 515,
     "countryRank": 52
   },
   {
@@ -11071,8 +11177,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 512,
-    "countryRank": 1
+    "aggregatedRank": 516,
+    "countryRank": 2
   },
   {
     "name": "Symbiosis International University",
@@ -11090,7 +11196,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 513,
+    "aggregatedRank": 517,
     "countryRank": 3
   },
   {
@@ -11109,7 +11215,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 514,
+    "aggregatedRank": 518,
     "countryRank": 53
   },
   {
@@ -11128,8 +11234,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 515,
-    "countryRank": 25
+    "aggregatedRank": 519,
+    "countryRank": 27
   },
   {
     "name": "Zhejiang University of Technology",
@@ -11147,7 +11253,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 516,
+    "aggregatedRank": 520,
     "countryRank": 40
   },
   {
@@ -11166,7 +11272,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 517,
+    "aggregatedRank": 521,
     "countryRank": 41
   },
   {
@@ -11185,7 +11291,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 518,
+    "aggregatedRank": 522,
     "countryRank": 7
   },
   {
@@ -11204,7 +11310,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 519,
+    "aggregatedRank": 523,
     "countryRank": 11
   },
   {
@@ -11223,7 +11329,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 520,
+    "aggregatedRank": 524,
     "countryRank": 5
   },
   {
@@ -11242,11 +11348,11 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 521,
+    "aggregatedRank": 525,
     "countryRank": 42
   },
   {
-    "name": "University of Erlangen-N�rnberg",
+    "name": "University of Erlangen-Nürnberg",
     "country": "Germany",
     "aggregatedScore": 819.65625,
     "originalRankings": {
@@ -11261,8 +11367,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 522,
-    "countryRank": 26
+    "aggregatedRank": 526,
+    "countryRank": 28
   },
   {
     "name": "Guangzhou University",
@@ -11280,7 +11386,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 523,
+    "aggregatedRank": 527,
     "countryRank": 43
   },
   {
@@ -11299,8 +11405,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 524,
-    "countryRank": 27
+    "aggregatedRank": 528,
+    "countryRank": 29
   },
   {
     "name": "Tehran University of Medical Sciences",
@@ -11318,7 +11424,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 525,
+    "aggregatedRank": 529,
     "countryRank": 6
   },
   {
@@ -11337,7 +11443,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 526,
+    "aggregatedRank": 530,
     "countryRank": 29
   },
   {
@@ -11356,7 +11462,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 527,
+    "aggregatedRank": 531,
     "countryRank": 111
   },
   {
@@ -11375,7 +11481,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 528,
+    "aggregatedRank": 532,
     "countryRank": 112
   },
   {
@@ -11394,7 +11500,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 529,
+    "aggregatedRank": 533,
     "countryRank": 44
   },
   {
@@ -11413,27 +11519,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 530,
+    "aggregatedRank": 534,
     "countryRank": 45
-  },
-  {
-    "name": "University of M�nster",
-    "country": "Germany",
-    "aggregatedScore": 802.15625,
-    "originalRankings": {
-      "qs": {
-        "rank": 367
-      },
-      "the": {
-        "rank": 188
-      },
-      "arwu": {
-        "rank": 151
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 531,
-    "countryRank": 28
   },
   {
     "name": "China Agricultural University",
@@ -11451,7 +11538,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 532,
+    "aggregatedRank": 535,
     "countryRank": 46
   },
   {
@@ -11470,7 +11557,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 533,
+    "aggregatedRank": 536,
     "countryRank": 47
   },
   {
@@ -11489,7 +11576,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 534,
+    "aggregatedRank": 537,
     "countryRank": 113
   },
   {
@@ -11508,7 +11595,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 535,
+    "aggregatedRank": 538,
     "countryRank": 54
   },
   {
@@ -11527,7 +11614,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 536,
+    "aggregatedRank": 539,
     "countryRank": 30
   },
   {
@@ -11546,7 +11633,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 537,
+    "aggregatedRank": 540,
     "countryRank": 12
   },
   {
@@ -11565,7 +11652,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 538,
+    "aggregatedRank": 541,
     "countryRank": 1
   },
   {
@@ -11584,7 +11671,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 539,
+    "aggregatedRank": 542,
     "countryRank": 55
   },
   {
@@ -11603,27 +11690,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 540,
+    "aggregatedRank": 543,
     "countryRank": 4
-  },
-  {
-    "name": "University of W�rzburg",
-    "country": "Germany",
-    "aggregatedScore": 783.34375,
-    "originalRankings": {
-      "qs": {
-        "rank": 428
-      },
-      "the": {
-        "rank": 163
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 541,
-    "countryRank": 29
   },
   {
     "name": "University of Science & Technology Beijing",
@@ -11641,7 +11709,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 542,
+    "aggregatedRank": 544,
     "countryRank": 48
   },
   {
@@ -11660,7 +11728,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 543,
+    "aggregatedRank": 545,
     "countryRank": 13
   },
   {
@@ -11679,7 +11747,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 544,
+    "aggregatedRank": 546,
     "countryRank": 49
   },
   {
@@ -11698,7 +11766,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 545,
+    "aggregatedRank": 547,
     "countryRank": 1
   },
   {
@@ -11717,7 +11785,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 546,
+    "aggregatedRank": 548,
     "countryRank": 50
   },
   {
@@ -11736,7 +11804,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 547,
+    "aggregatedRank": 549,
     "countryRank": 51
   },
   {
@@ -11755,7 +11823,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 548,
+    "aggregatedRank": 550,
     "countryRank": 31
   },
   {
@@ -11774,7 +11842,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 549,
+    "aggregatedRank": 551,
     "countryRank": 52
   },
   {
@@ -11793,7 +11861,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 550,
+    "aggregatedRank": 552,
     "countryRank": 114
   },
   {
@@ -11812,7 +11880,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 551,
+    "aggregatedRank": 553,
     "countryRank": 4
   },
   {
@@ -11831,7 +11899,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 552,
+    "aggregatedRank": 554,
     "countryRank": 53
   },
   {
@@ -11850,7 +11918,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 553,
+    "aggregatedRank": 555,
     "countryRank": 5
   },
   {
@@ -11869,7 +11937,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 554,
+    "aggregatedRank": 556,
     "countryRank": 14
   },
   {
@@ -11888,7 +11956,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 555,
+    "aggregatedRank": 557,
     "countryRank": 54
   },
   {
@@ -11907,7 +11975,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 556,
+    "aggregatedRank": 558,
     "countryRank": 3
   },
   {
@@ -11926,7 +11994,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 557,
+    "aggregatedRank": 559,
     "countryRank": 4
   },
   {
@@ -11945,7 +12013,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 558,
+    "aggregatedRank": 560,
     "countryRank": 6
   },
   {
@@ -11964,7 +12032,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 559,
+    "aggregatedRank": 561,
     "countryRank": 55
   },
   {
@@ -11983,7 +12051,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 560,
+    "aggregatedRank": 562,
     "countryRank": 30
   },
   {
@@ -12002,7 +12070,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 561,
+    "aggregatedRank": 563,
     "countryRank": 31
   },
   {
@@ -12021,7 +12089,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 562,
+    "aggregatedRank": 564,
     "countryRank": 14
   },
   {
@@ -12040,7 +12108,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 563,
+    "aggregatedRank": 565,
     "countryRank": 8
   },
   {
@@ -12059,27 +12127,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 564,
-    "countryRank": 2
-  },
-  {
-    "name": "University of Li�ge",
-    "country": "Belgium",
-    "aggregatedScore": 749.21875,
-    "originalRankings": {
-      "qs": {
-        "rank": 396
-      },
-      "the": {
-        "rank": 251
-      },
-      "arwu": {
-        "rank": 301
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 565,
-    "countryRank": 7
+    "aggregatedRank": 566,
+    "countryRank": 3
   },
   {
     "name": "University of Montpellier",
@@ -12097,7 +12146,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 566,
+    "aggregatedRank": 567,
     "countryRank": 9
   },
   {
@@ -12116,7 +12165,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 567,
+    "aggregatedRank": 568,
     "countryRank": 9
   },
   {
@@ -12135,7 +12184,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 568,
+    "aggregatedRank": 569,
     "countryRank": 5
   },
   {
@@ -12154,7 +12203,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 569,
+    "aggregatedRank": 570,
     "countryRank": 32
   },
   {
@@ -12173,7 +12222,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 570,
+    "aggregatedRank": 571,
     "countryRank": 56
   },
   {
@@ -12192,7 +12241,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 571,
+    "aggregatedRank": 572,
     "countryRank": 7
   },
   {
@@ -12211,7 +12260,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 572,
+    "aggregatedRank": 573,
     "countryRank": 4
   },
   {
@@ -12230,7 +12279,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 573,
+    "aggregatedRank": 574,
     "countryRank": 115
   },
   {
@@ -12249,7 +12298,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 574,
+    "aggregatedRank": 575,
     "countryRank": 15
   },
   {
@@ -12268,7 +12317,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 575,
+    "aggregatedRank": 576,
     "countryRank": 32
   },
   {
@@ -12287,7 +12336,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 576,
+    "aggregatedRank": 577,
     "countryRank": 7
   },
   {
@@ -12306,7 +12355,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 577,
+    "aggregatedRank": 578,
     "countryRank": 116
   },
   {
@@ -12325,7 +12374,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 578,
+    "aggregatedRank": 579,
     "countryRank": 57
   },
   {
@@ -12344,7 +12393,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 579,
+    "aggregatedRank": 580,
     "countryRank": 58
   },
   {
@@ -12363,7 +12412,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 580,
+    "aggregatedRank": 581,
     "countryRank": 117
   },
   {
@@ -12382,7 +12431,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 581,
+    "aggregatedRank": 582,
     "countryRank": 118
   },
   {
@@ -12401,7 +12450,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 582,
+    "aggregatedRank": 583,
     "countryRank": 1
   },
   {
@@ -12420,7 +12469,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 583,
+    "aggregatedRank": 584,
     "countryRank": 59
   },
   {
@@ -12439,7 +12488,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 584,
+    "aggregatedRank": 585,
     "countryRank": 119
   },
   {
@@ -12458,7 +12507,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 585,
+    "aggregatedRank": 586,
     "countryRank": 56
   },
   {
@@ -12477,7 +12526,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 586,
+    "aggregatedRank": 587,
     "countryRank": 10
   },
   {
@@ -12496,7 +12545,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 587,
+    "aggregatedRank": 588,
     "countryRank": 3
   },
   {
@@ -12515,7 +12564,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 588,
+    "aggregatedRank": 589,
     "countryRank": 60
   },
   {
@@ -12534,7 +12583,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 589,
+    "aggregatedRank": 590,
     "countryRank": 61
   },
   {
@@ -12553,7 +12602,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 590,
+    "aggregatedRank": 591,
     "countryRank": 62
   },
   {
@@ -12572,7 +12621,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 591,
+    "aggregatedRank": 592,
     "countryRank": 30
   },
   {
@@ -12591,7 +12640,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 592,
+    "aggregatedRank": 593,
     "countryRank": 4
   },
   {
@@ -12610,7 +12659,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 593,
+    "aggregatedRank": 594,
     "countryRank": 22
   },
   {
@@ -12629,7 +12678,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 594,
+    "aggregatedRank": 595,
     "countryRank": 11
   },
   {
@@ -12648,7 +12697,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 595,
+    "aggregatedRank": 596,
     "countryRank": 31
   },
   {
@@ -12667,7 +12716,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 596,
+    "aggregatedRank": 597,
     "countryRank": 33
   },
   {
@@ -12686,7 +12735,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 597,
+    "aggregatedRank": 598,
     "countryRank": 63
   },
   {
@@ -12705,7 +12754,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 598,
+    "aggregatedRank": 599,
     "countryRank": 4
   },
   {
@@ -12724,7 +12773,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 599,
+    "aggregatedRank": 600,
     "countryRank": 64
   },
   {
@@ -12743,7 +12792,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 600,
+    "aggregatedRank": 601,
     "countryRank": 11
   },
   {
@@ -12762,7 +12811,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 601,
+    "aggregatedRank": 602,
     "countryRank": 32
   },
   {
@@ -12781,7 +12830,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 602,
+    "aggregatedRank": 603,
     "countryRank": 5
   },
   {
@@ -12800,7 +12849,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 603,
+    "aggregatedRank": 604,
     "countryRank": 33
   },
   {
@@ -12819,7 +12868,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 604,
+    "aggregatedRank": 605,
     "countryRank": 6
   },
   {
@@ -12838,7 +12887,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 605,
+    "aggregatedRank": 606,
     "countryRank": 4
   },
   {
@@ -12857,7 +12906,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 606,
+    "aggregatedRank": 607,
     "countryRank": 12
   },
   {
@@ -12876,7 +12925,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 607,
+    "aggregatedRank": 608,
     "countryRank": 7
   },
   {
@@ -12895,7 +12944,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 608,
+    "aggregatedRank": 609,
     "countryRank": 65
   },
   {
@@ -12914,7 +12963,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 609,
+    "aggregatedRank": 610,
     "countryRank": 120
   },
   {
@@ -12933,7 +12982,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 610,
+    "aggregatedRank": 611,
     "countryRank": 7
   },
   {
@@ -12952,7 +13001,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 611,
+    "aggregatedRank": 612,
     "countryRank": 66
   },
   {
@@ -12971,7 +13020,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 612,
+    "aggregatedRank": 613,
     "countryRank": 67
   },
   {
@@ -12990,7 +13039,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 613,
+    "aggregatedRank": 614,
     "countryRank": 68
   },
   {
@@ -13009,7 +13058,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 614,
+    "aggregatedRank": 615,
     "countryRank": 121
   },
   {
@@ -13028,7 +13077,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 615,
+    "aggregatedRank": 616,
     "countryRank": 69
   },
   {
@@ -13047,7 +13096,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 616,
+    "aggregatedRank": 617,
     "countryRank": 34
   },
   {
@@ -13066,11 +13115,11 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 617,
+    "aggregatedRank": 618,
     "countryRank": 122
   },
   {
-    "name": "University of D�sseldorf",
+    "name": "University of Düsseldorf",
     "country": "Germany",
     "aggregatedScore": 671.5625,
     "originalRankings": {
@@ -13085,7 +13134,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 618,
+    "aggregatedRank": 619,
     "countryRank": 35
   },
   {
@@ -13104,7 +13153,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 619,
+    "aggregatedRank": 620,
     "countryRank": 9
   },
   {
@@ -13123,7 +13172,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 620,
+    "aggregatedRank": 621,
     "countryRank": 7
   },
   {
@@ -13142,7 +13191,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 621,
+    "aggregatedRank": 622,
     "countryRank": 8
   },
   {
@@ -13161,7 +13210,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 622,
+    "aggregatedRank": 623,
     "countryRank": 123
   },
   {
@@ -13180,7 +13229,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 623,
+    "aggregatedRank": 624,
     "countryRank": 124
   },
   {
@@ -13199,7 +13248,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 624,
+    "aggregatedRank": 625,
     "countryRank": 36
   },
   {
@@ -13218,7 +13267,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 625,
+    "aggregatedRank": 626,
     "countryRank": 6
   },
   {
@@ -13237,7 +13286,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 626,
+    "aggregatedRank": 627,
     "countryRank": 10
   },
   {
@@ -13256,7 +13305,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 627,
+    "aggregatedRank": 628,
     "countryRank": 70
   },
   {
@@ -13275,7 +13324,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 628,
+    "aggregatedRank": 629,
     "countryRank": 57
   },
   {
@@ -13294,7 +13343,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 629,
+    "aggregatedRank": 630,
     "countryRank": 71
   },
   {
@@ -13313,7 +13362,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 630,
+    "aggregatedRank": 631,
     "countryRank": 72
   },
   {
@@ -13332,7 +13381,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 631,
+    "aggregatedRank": 632,
     "countryRank": 4
   },
   {
@@ -13351,7 +13400,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 632,
+    "aggregatedRank": 633,
     "countryRank": 11
   },
   {
@@ -13370,7 +13419,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 633,
+    "aggregatedRank": 634,
     "countryRank": 1
   },
   {
@@ -13389,7 +13438,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 634,
+    "aggregatedRank": 635,
     "countryRank": 34
   },
   {
@@ -13408,7 +13457,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 635,
+    "aggregatedRank": 636,
     "countryRank": 2
   },
   {
@@ -13427,7 +13476,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 636,
+    "aggregatedRank": 637,
     "countryRank": 8
   },
   {
@@ -13446,7 +13495,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 637,
+    "aggregatedRank": 638,
     "countryRank": 73
   },
   {
@@ -13465,7 +13514,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 638,
+    "aggregatedRank": 639,
     "countryRank": 74
   },
   {
@@ -13484,7 +13533,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 639,
+    "aggregatedRank": 640,
     "countryRank": 5
   },
   {
@@ -13503,7 +13552,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 640,
+    "aggregatedRank": 641,
     "countryRank": 1
   },
   {
@@ -13522,7 +13571,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 641,
+    "aggregatedRank": 642,
     "countryRank": 3
   },
   {
@@ -13541,7 +13590,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 642,
+    "aggregatedRank": 643,
     "countryRank": 37
   },
   {
@@ -13560,7 +13609,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 643,
+    "aggregatedRank": 644,
     "countryRank": 75
   },
   {
@@ -13579,7 +13628,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 644,
+    "aggregatedRank": 645,
     "countryRank": 9
   },
   {
@@ -13598,7 +13647,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 645,
+    "aggregatedRank": 646,
     "countryRank": 125
   },
   {
@@ -13617,7 +13666,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 646,
+    "aggregatedRank": 647,
     "countryRank": 38
   },
   {
@@ -13636,7 +13685,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 647,
+    "aggregatedRank": 648,
     "countryRank": 58
   },
   {
@@ -13655,7 +13704,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 648,
+    "aggregatedRank": 649,
     "countryRank": 11
   },
   {
@@ -13674,7 +13723,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 649,
+    "aggregatedRank": 650,
     "countryRank": 23
   },
   {
@@ -13693,7 +13742,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 650,
+    "aggregatedRank": 651,
     "countryRank": 3
   },
   {
@@ -13712,7 +13761,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 651,
+    "aggregatedRank": 652,
     "countryRank": 12
   },
   {
@@ -13731,7 +13780,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 652,
+    "aggregatedRank": 653,
     "countryRank": 126
   },
   {
@@ -13750,7 +13799,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 653,
+    "aggregatedRank": 654,
     "countryRank": 127
   },
   {
@@ -13769,7 +13818,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 654,
+    "aggregatedRank": 655,
     "countryRank": 15
   },
   {
@@ -13788,7 +13837,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 655,
+    "aggregatedRank": 656,
     "countryRank": 128
   },
   {
@@ -13807,7 +13856,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 656,
+    "aggregatedRank": 657,
     "countryRank": 59
   },
   {
@@ -13826,7 +13875,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 657,
+    "aggregatedRank": 658,
     "countryRank": 5
   },
   {
@@ -13845,7 +13894,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 658,
+    "aggregatedRank": 659,
     "countryRank": 16
   },
   {
@@ -13864,7 +13913,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 659,
+    "aggregatedRank": 660,
     "countryRank": 7
   },
   {
@@ -13883,7 +13932,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 660,
+    "aggregatedRank": 661,
     "countryRank": 6
   },
   {
@@ -13902,7 +13951,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 661,
+    "aggregatedRank": 662,
     "countryRank": 15
   },
   {
@@ -13921,7 +13970,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 662,
+    "aggregatedRank": 663,
     "countryRank": 13
   },
   {
@@ -13940,7 +13989,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 663,
+    "aggregatedRank": 664,
     "countryRank": 35
   },
   {
@@ -13959,7 +14008,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 664,
+    "aggregatedRank": 665,
     "countryRank": 10
   },
   {
@@ -13978,8 +14027,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 665,
-    "countryRank": 3
+    "aggregatedRank": 666,
+    "countryRank": 4
   },
   {
     "name": "University of Lille",
@@ -13997,7 +14046,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 666,
+    "aggregatedRank": 667,
     "countryRank": 14
   },
   {
@@ -14016,7 +14065,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 667,
+    "aggregatedRank": 668,
     "countryRank": 76
   },
   {
@@ -14035,7 +14084,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 668,
+    "aggregatedRank": 669,
     "countryRank": 12
   },
   {
@@ -14054,7 +14103,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 669,
+    "aggregatedRank": 670,
     "countryRank": 17
   },
   {
@@ -14073,7 +14122,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 670,
+    "aggregatedRank": 671,
     "countryRank": 13
   },
   {
@@ -14092,7 +14141,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 671,
+    "aggregatedRank": 672,
     "countryRank": 14
   },
   {
@@ -14111,7 +14160,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 672,
+    "aggregatedRank": 673,
     "countryRank": 8
   },
   {
@@ -14130,7 +14179,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 673,
+    "aggregatedRank": 674,
     "countryRank": 36
   },
   {
@@ -14149,7 +14198,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 674,
+    "aggregatedRank": 675,
     "countryRank": 6
   },
   {
@@ -14168,7 +14217,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 675,
+    "aggregatedRank": 676,
     "countryRank": 5
   },
   {
@@ -14187,7 +14236,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 676,
+    "aggregatedRank": 677,
     "countryRank": 10
   },
   {
@@ -14206,7 +14255,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 677,
+    "aggregatedRank": 678,
     "countryRank": 3
   },
   {
@@ -14225,7 +14274,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 678,
+    "aggregatedRank": 679,
     "countryRank": 9
   },
   {
@@ -14244,7 +14293,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 679,
+    "aggregatedRank": 680,
     "countryRank": 5
   },
   {
@@ -14260,7 +14309,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 680,
+    "aggregatedRank": 681,
     "countryRank": 15
   },
   {
@@ -14279,7 +14328,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 681,
+    "aggregatedRank": 682,
     "countryRank": 16
   },
   {
@@ -14298,7 +14347,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 682,
+    "aggregatedRank": 683,
     "countryRank": 6
   },
   {
@@ -14317,7 +14366,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 683,
+    "aggregatedRank": 684,
     "countryRank": 16
   },
   {
@@ -14336,7 +14385,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 684,
+    "aggregatedRank": 685,
     "countryRank": 1
   },
   {
@@ -14355,11 +14404,11 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 685,
+    "aggregatedRank": 686,
     "countryRank": 77
   },
   {
-    "name": "University of C�te d'Azur",
+    "name": "University of Côte d'Azur",
     "country": "France",
     "aggregatedScore": 577.5,
     "originalRankings": {
@@ -14374,7 +14423,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 686,
+    "aggregatedRank": 687,
     "countryRank": 17
   },
   {
@@ -14393,7 +14442,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 687,
+    "aggregatedRank": 688,
     "countryRank": 11
   },
   {
@@ -14412,7 +14461,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 688,
+    "aggregatedRank": 689,
     "countryRank": 15
   },
   {
@@ -14431,7 +14480,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 689,
+    "aggregatedRank": 690,
     "countryRank": 5
   },
   {
@@ -14450,7 +14499,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 690,
+    "aggregatedRank": 691,
     "countryRank": 2
   },
   {
@@ -14469,7 +14518,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 691,
+    "aggregatedRank": 692,
     "countryRank": 78
   },
   {
@@ -14488,7 +14537,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 692,
+    "aggregatedRank": 693,
     "countryRank": 16
   },
   {
@@ -14507,7 +14556,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 693,
+    "aggregatedRank": 694,
     "countryRank": 79
   },
   {
@@ -14523,7 +14572,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 694,
+    "aggregatedRank": 695,
     "countryRank": 9
   },
   {
@@ -14542,7 +14591,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 695,
+    "aggregatedRank": 696,
     "countryRank": 129
   },
   {
@@ -14561,7 +14610,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 696,
+    "aggregatedRank": 697,
     "countryRank": 39
   },
   {
@@ -14580,27 +14629,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 697,
-    "countryRank": 37
-  },
-  {
-    "name": "Institut National des Sciences Appliqu�es de Toulouse",
-    "country": "France",
-    "aggregatedScore": 561.3125,
-    "originalRankings": {
-      "qs": {
-        "rank": 405
-      },
-      "the": {
-        "rank": 601
-      },
-      "arwu": {
-        "rank": 801
-      }
-    },
-    "appearances": 3,
     "aggregatedRank": 698,
-    "countryRank": 18
+    "countryRank": 37
   },
   {
     "name": "Graz University of Technology",
@@ -14790,25 +14820,6 @@
     "countryRank": 60
   },
   {
-    "name": "E�tv�s Lorand University",
-    "country": "Hungary",
-    "aggregatedScore": 548.40625,
-    "originalRankings": {
-      "qs": {
-        "rank": 564
-      },
-      "the": {
-        "rank": 801
-      },
-      "arwu": {
-        "rank": 501
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 709,
-    "countryRank": 4
-  },
-  {
     "name": "Polytechnic University of Bari",
     "country": "Italy",
     "aggregatedScore": 544.90625,
@@ -14824,7 +14835,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 710,
+    "aggregatedRank": 709,
     "countryRank": 38
   },
   {
@@ -14843,7 +14854,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 711,
+    "aggregatedRank": 710,
     "countryRank": 41
   },
   {
@@ -14862,7 +14873,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 712,
+    "aggregatedRank": 711,
     "countryRank": 1
   },
   {
@@ -14878,7 +14889,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 713,
+    "aggregatedRank": 712,
     "countryRank": 131
   },
   {
@@ -14894,7 +14905,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 714,
+    "aggregatedRank": 713,
     "countryRank": 132
   },
   {
@@ -14913,7 +14924,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 715,
+    "aggregatedRank": 714,
     "countryRank": 61
   },
   {
@@ -14932,8 +14943,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 716,
-    "countryRank": 19
+    "aggregatedRank": 715,
+    "countryRank": 18
   },
   {
     "name": "Oklahoma State University",
@@ -14951,7 +14962,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 717,
+    "aggregatedRank": 716,
     "countryRank": 133
   },
   {
@@ -14967,7 +14978,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 718,
+    "aggregatedRank": 717,
     "countryRank": 62
   },
   {
@@ -14983,7 +14994,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 719,
+    "aggregatedRank": 718,
     "countryRank": 1
   },
   {
@@ -15002,7 +15013,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 720,
+    "aggregatedRank": 719,
     "countryRank": 42
   },
   {
@@ -15018,7 +15029,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 721,
+    "aggregatedRank": 720,
     "countryRank": 6
   },
   {
@@ -15037,7 +15048,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 722,
+    "aggregatedRank": 721,
     "countryRank": 6
   },
   {
@@ -15056,7 +15067,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 723,
+    "aggregatedRank": 722,
     "countryRank": 4
   },
   {
@@ -15075,7 +15086,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 724,
+    "aggregatedRank": 723,
     "countryRank": 17
   },
   {
@@ -15091,7 +15102,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 725,
+    "aggregatedRank": 724,
     "countryRank": 134
   },
   {
@@ -15110,7 +15121,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 726,
+    "aggregatedRank": 725,
     "countryRank": 7
   },
   {
@@ -15126,7 +15137,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 727,
+    "aggregatedRank": 726,
     "countryRank": 135
   },
   {
@@ -15142,7 +15153,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 728,
+    "aggregatedRank": 727,
     "countryRank": 136
   },
   {
@@ -15161,7 +15172,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 729,
+    "aggregatedRank": 728,
     "countryRank": 39
   },
   {
@@ -15177,7 +15188,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 730,
+    "aggregatedRank": 729,
     "countryRank": 137
   },
   {
@@ -15196,7 +15207,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 731,
+    "aggregatedRank": 730,
     "countryRank": 18
   },
   {
@@ -15215,7 +15226,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 732,
+    "aggregatedRank": 731,
     "countryRank": 19
   },
   {
@@ -15234,7 +15245,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 733,
+    "aggregatedRank": 732,
     "countryRank": 18
   },
   {
@@ -15250,7 +15261,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 734,
+    "aggregatedRank": 733,
     "countryRank": 1
   },
   {
@@ -15266,7 +15277,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 735,
+    "aggregatedRank": 734,
     "countryRank": 13
   },
   {
@@ -15285,7 +15296,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 736,
+    "aggregatedRank": 735,
     "countryRank": 19
   },
   {
@@ -15301,7 +15312,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 737,
+    "aggregatedRank": 736,
     "countryRank": 10
   },
   {
@@ -15317,7 +15328,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 738,
+    "aggregatedRank": 737,
     "countryRank": 138
   },
   {
@@ -15336,7 +15347,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 739,
+    "aggregatedRank": 738,
     "countryRank": 139
   },
   {
@@ -15355,7 +15366,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 740,
+    "aggregatedRank": 739,
     "countryRank": 16
   },
   {
@@ -15371,7 +15382,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 741,
+    "aggregatedRank": 740,
     "countryRank": 7
   },
   {
@@ -15387,7 +15398,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 742,
+    "aggregatedRank": 741,
     "countryRank": 7
   },
   {
@@ -15403,7 +15414,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 743,
+    "aggregatedRank": 742,
     "countryRank": 8
   },
   {
@@ -15422,7 +15433,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 744,
+    "aggregatedRank": 743,
     "countryRank": 5
   },
   {
@@ -15438,7 +15449,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 745,
+    "aggregatedRank": 744,
     "countryRank": 6
   },
   {
@@ -15457,7 +15468,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 746,
+    "aggregatedRank": 745,
     "countryRank": 7
   },
   {
@@ -15473,11 +15484,11 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 747,
+    "aggregatedRank": 746,
     "countryRank": 14
   },
   {
-    "name": "University of Alcal� de Henares",
+    "name": "University of Alcalá de Henares",
     "country": "Spain",
     "aggregatedScore": 492.1875,
     "originalRankings": {
@@ -15492,7 +15503,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 748,
+    "aggregatedRank": 747,
     "countryRank": 20
   },
   {
@@ -15508,7 +15519,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 749,
+    "aggregatedRank": 748,
     "countryRank": 63
   },
   {
@@ -15524,7 +15535,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 750,
+    "aggregatedRank": 749,
     "countryRank": 13
   },
   {
@@ -15540,7 +15551,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 751,
+    "aggregatedRank": 750,
     "countryRank": 1
   },
   {
@@ -15556,7 +15567,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 752,
+    "aggregatedRank": 751,
     "countryRank": 11
   },
   {
@@ -15575,7 +15586,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 753,
+    "aggregatedRank": 752,
     "countryRank": 140
   },
   {
@@ -15591,7 +15602,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 754,
+    "aggregatedRank": 753,
     "countryRank": 8
   },
   {
@@ -15607,7 +15618,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 755,
+    "aggregatedRank": 754,
     "countryRank": 20
   },
   {
@@ -15626,7 +15637,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 756,
+    "aggregatedRank": 755,
     "countryRank": 21
   },
   {
@@ -15645,7 +15656,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 757,
+    "aggregatedRank": 756,
     "countryRank": 141
   },
   {
@@ -15661,7 +15672,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 758,
+    "aggregatedRank": 757,
     "countryRank": 6
   },
   {
@@ -15677,7 +15688,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 759,
+    "aggregatedRank": 758,
     "countryRank": 18
   },
   {
@@ -15693,7 +15704,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 760,
+    "aggregatedRank": 759,
     "countryRank": 64
   },
   {
@@ -15709,8 +15720,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 761,
-    "countryRank": 20
+    "aggregatedRank": 760,
+    "countryRank": 19
   },
   {
     "name": "Baylor College of Medicine",
@@ -15725,7 +15736,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 762,
+    "aggregatedRank": 761,
     "countryRank": 142
   },
   {
@@ -15741,7 +15752,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 763,
+    "aggregatedRank": 762,
     "countryRank": 7
   },
   {
@@ -15760,7 +15771,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 764,
+    "aggregatedRank": 763,
     "countryRank": 22
   },
   {
@@ -15776,7 +15787,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 765,
+    "aggregatedRank": 764,
     "countryRank": 19
   },
   {
@@ -15795,7 +15806,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 766,
+    "aggregatedRank": 765,
     "countryRank": 7
   },
   {
@@ -15811,7 +15822,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 767,
+    "aggregatedRank": 766,
     "countryRank": 81
   },
   {
@@ -15830,7 +15841,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 768,
+    "aggregatedRank": 767,
     "countryRank": 23
   },
   {
@@ -15849,7 +15860,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 769,
+    "aggregatedRank": 768,
     "countryRank": 143
   },
   {
@@ -15865,7 +15876,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 770,
+    "aggregatedRank": 769,
     "countryRank": 24
   },
   {
@@ -15884,7 +15895,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 771,
+    "aggregatedRank": 770,
     "countryRank": 10
   },
   {
@@ -15900,7 +15911,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 772,
+    "aggregatedRank": 771,
     "countryRank": 15
   },
   {
@@ -15916,7 +15927,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 773,
+    "aggregatedRank": 772,
     "countryRank": 1
   },
   {
@@ -15932,7 +15943,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 774,
+    "aggregatedRank": 773,
     "countryRank": 2
   },
   {
@@ -15948,7 +15959,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 775,
+    "aggregatedRank": 774,
     "countryRank": 12
   },
   {
@@ -15967,7 +15978,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 776,
+    "aggregatedRank": 775,
     "countryRank": 8
   },
   {
@@ -15986,7 +15997,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 777,
+    "aggregatedRank": 776,
     "countryRank": 25
   },
   {
@@ -16002,7 +16013,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 778,
+    "aggregatedRank": 777,
     "countryRank": 8
   },
   {
@@ -16018,7 +16029,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 779,
+    "aggregatedRank": 778,
     "countryRank": 40
   },
   {
@@ -16034,7 +16045,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 780,
+    "aggregatedRank": 779,
     "countryRank": 1
   },
   {
@@ -16050,7 +16061,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 781,
+    "aggregatedRank": 780,
     "countryRank": 1
   },
   {
@@ -16066,7 +16077,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 782,
+    "aggregatedRank": 781,
     "countryRank": 65
   },
   {
@@ -16085,7 +16096,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 783,
+    "aggregatedRank": 782,
     "countryRank": 5
   },
   {
@@ -16101,7 +16112,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 784,
+    "aggregatedRank": 783,
     "countryRank": 144
   },
   {
@@ -16117,7 +16128,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 785,
+    "aggregatedRank": 784,
     "countryRank": 7
   },
   {
@@ -16133,8 +16144,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 786,
-    "countryRank": 21
+    "aggregatedRank": 785,
+    "countryRank": 20
   },
   {
     "name": "Al Ain University",
@@ -16149,7 +16160,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 787,
+    "aggregatedRank": 786,
     "countryRank": 8
   },
   {
@@ -16165,7 +16176,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 788,
+    "aggregatedRank": 787,
     "countryRank": 8
   },
   {
@@ -16184,7 +16195,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 789,
+    "aggregatedRank": 788,
     "countryRank": 2
   },
   {
@@ -16200,7 +16211,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 790,
+    "aggregatedRank": 789,
     "countryRank": 9
   },
   {
@@ -16216,7 +16227,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 791,
+    "aggregatedRank": 790,
     "countryRank": 16
   },
   {
@@ -16232,7 +16243,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 792,
+    "aggregatedRank": 791,
     "countryRank": 1
   },
   {
@@ -16248,7 +16259,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 793,
+    "aggregatedRank": 792,
     "countryRank": 33
   },
   {
@@ -16264,7 +16275,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 794,
+    "aggregatedRank": 793,
     "countryRank": 17
   },
   {
@@ -16280,7 +16291,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 795,
+    "aggregatedRank": 794,
     "countryRank": 145
   },
   {
@@ -16296,7 +16307,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 796,
+    "aggregatedRank": 795,
     "countryRank": 66
   },
   {
@@ -16312,8 +16323,24 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 797,
+    "aggregatedRank": 796,
     "countryRank": 146
+  },
+  {
+    "name": "Institut National des Sciences Appliquées de Lyon",
+    "country": "France",
+    "aggregatedScore": 424.875,
+    "originalRankings": {
+      "qs": {
+        "rank": 405
+      },
+      "the": {
+        "rank": 601
+      }
+    },
+    "appearances": 2,
+    "aggregatedRank": 797,
+    "countryRank": 21
   },
   {
     "name": "ShanghaiTech University",
@@ -16482,7 +16509,7 @@
     "countryRank": 34
   },
   {
-    "name": "University Panth�on-Sorbonne (Paris I)",
+    "name": "University Panthéon-Sorbonne (Paris I)",
     "country": "France",
     "aggregatedScore": 410.25,
     "originalRankings": {
@@ -16968,7 +16995,7 @@
     "countryRank": 20
   },
   {
-    "name": "University of C�rdoba",
+    "name": "University of Córdoba",
     "country": "Spain",
     "aggregatedScore": 376.25,
     "originalRankings": {
@@ -18094,22 +18121,6 @@
     "countryRank": 101
   },
   {
-    "name": "Universite Paris-Est-Creteil-Val-de-Marne (UPEC)",
-    "country": "France",
-    "aggregatedScore": 304.40625,
-    "originalRankings": {
-      "arwu": {
-        "rank": 701
-      },
-      "usnews": {
-        "rank": 568
-      }
-    },
-    "appearances": 2,
-    "aggregatedRank": 908,
-    "countryRank": 23
-  },
-  {
     "name": "Shahid Beheshti University",
     "country": "Iran",
     "aggregatedScore": 303.75,
@@ -18122,7 +18133,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 909,
+    "aggregatedRank": 908,
     "countryRank": 14
   },
   {
@@ -18138,7 +18149,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 910,
+    "aggregatedRank": 909,
     "countryRank": 11
   },
   {
@@ -18154,8 +18165,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 911,
-    "countryRank": 24
+    "aggregatedRank": 910,
+    "countryRank": 23
   },
   {
     "name": "University of Tennessee Health Science Center",
@@ -18170,7 +18181,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 912,
+    "aggregatedRank": 911,
     "countryRank": 164
   },
   {
@@ -18186,7 +18197,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 913,
+    "aggregatedRank": 912,
     "countryRank": 44
   },
   {
@@ -18202,7 +18213,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 914,
+    "aggregatedRank": 913,
     "countryRank": 165
   },
   {
@@ -18218,7 +18229,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 915,
+    "aggregatedRank": 914,
     "countryRank": 102
   },
   {
@@ -18234,7 +18245,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 916,
+    "aggregatedRank": 915,
     "countryRank": 1
   },
   {
@@ -18250,7 +18261,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 917,
+    "aggregatedRank": 916,
     "countryRank": 45
   },
   {
@@ -18266,7 +18277,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 918,
+    "aggregatedRank": 917,
     "countryRank": 6
   },
   {
@@ -18282,7 +18293,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 919,
+    "aggregatedRank": 918,
     "countryRank": 103
   },
   {
@@ -18298,7 +18309,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 920,
+    "aggregatedRank": 919,
     "countryRank": 2
   },
   {
@@ -18314,7 +18325,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 921,
+    "aggregatedRank": 920,
     "countryRank": 7
   },
   {
@@ -18330,7 +18341,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 922,
+    "aggregatedRank": 921,
     "countryRank": 81
   },
   {
@@ -18346,7 +18357,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 923,
+    "aggregatedRank": 922,
     "countryRank": 82
   },
   {
@@ -18362,7 +18373,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 924,
+    "aggregatedRank": 923,
     "countryRank": 166
   },
   {
@@ -18378,7 +18389,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 925,
+    "aggregatedRank": 924,
     "countryRank": 104
   },
   {
@@ -18394,7 +18405,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 926,
+    "aggregatedRank": 925,
     "countryRank": 15
   },
   {
@@ -18410,7 +18421,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 927,
+    "aggregatedRank": 926,
     "countryRank": 2
   },
   {
@@ -18426,7 +18437,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 928,
+    "aggregatedRank": 927,
     "countryRank": 105
   },
   {
@@ -18442,7 +18453,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 929,
+    "aggregatedRank": 928,
     "countryRank": 16
   },
   {
@@ -18458,7 +18469,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 930,
+    "aggregatedRank": 929,
     "countryRank": 4
   },
   {
@@ -18474,7 +18485,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 931,
+    "aggregatedRank": 930,
     "countryRank": 27
   },
   {
@@ -18490,7 +18501,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 932,
+    "aggregatedRank": 931,
     "countryRank": 167
   },
   {
@@ -18506,7 +18517,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 933,
+    "aggregatedRank": 932,
     "countryRank": 168
   },
   {
@@ -18522,7 +18533,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 934,
+    "aggregatedRank": 933,
     "countryRank": 106
   },
   {
@@ -18538,8 +18549,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 935,
-    "countryRank": 25
+    "aggregatedRank": 934,
+    "countryRank": 24
   },
   {
     "name": "Fujian Normal University",
@@ -18554,7 +18565,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 936,
+    "aggregatedRank": 935,
     "countryRank": 107
   },
   {
@@ -18570,7 +18581,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 937,
+    "aggregatedRank": 936,
     "countryRank": 10
   },
   {
@@ -18586,7 +18597,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 938,
+    "aggregatedRank": 937,
     "countryRank": 169
   },
   {
@@ -18602,7 +18613,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 939,
+    "aggregatedRank": 938,
     "countryRank": 108
   },
   {
@@ -18618,7 +18629,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 940,
+    "aggregatedRank": 939,
     "countryRank": 170
   },
   {
@@ -18634,7 +18645,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 941,
+    "aggregatedRank": 940,
     "countryRank": 109
   },
   {
@@ -18650,7 +18661,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 942,
+    "aggregatedRank": 941,
     "countryRank": 7
   },
   {
@@ -18666,21 +18677,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 943,
+    "aggregatedRank": 942,
     "countryRank": 110
-  },
-  {
-    "name": "Universite Paris Cite",
-    "country": "France",
-    "aggregatedScore": 272.578125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 47
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 944,
-    "countryRank": 26
   },
   {
     "name": "University of Chinese Academy of Sciences, CAS",
@@ -18692,47 +18690,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 945,
+    "aggregatedRank": 943,
     "countryRank": 111
-  },
-  {
-    "name": "University of Munich",
-    "country": "Germany",
-    "aggregatedScore": 271.015625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 57
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 946,
-    "countryRank": 46
-  },
-  {
-    "name": "Universite Paris Saclay",
-    "country": "France",
-    "aggregatedScore": 267.734375,
-    "originalRankings": {
-      "usnews": {
-        "rank": 78
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 947,
-    "countryRank": 27
-  },
-  {
-    "name": "Technical University of Munich",
-    "country": "Germany",
-    "aggregatedScore": 267.578125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 79
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 948,
-    "countryRank": 47
   },
   {
     "name": "Vrije Universiteit Amsterdam",
@@ -18744,7 +18703,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 949,
+    "aggregatedRank": 944,
     "countryRank": 14
   },
   {
@@ -18757,7 +18716,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 950,
+    "aggregatedRank": 945,
     "countryRank": 112
   },
   {
@@ -18773,7 +18732,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 951,
+    "aggregatedRank": 946,
     "countryRank": 43
   },
   {
@@ -18789,7 +18748,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 952,
+    "aggregatedRank": 947,
     "countryRank": 83
   },
   {
@@ -18805,7 +18764,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 953,
+    "aggregatedRank": 948,
     "countryRank": 36
   },
   {
@@ -18821,7 +18780,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 954,
+    "aggregatedRank": 949,
     "countryRank": 113
   },
   {
@@ -18837,7 +18796,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 955,
+    "aggregatedRank": 950,
     "countryRank": 171
   },
   {
@@ -18850,7 +18809,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 956,
+    "aggregatedRank": 951,
     "countryRank": 9
   },
   {
@@ -18863,7 +18822,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 957,
+    "aggregatedRank": 952,
     "countryRank": 15
   },
   {
@@ -18879,7 +18838,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 958,
+    "aggregatedRank": 953,
     "countryRank": 172
   },
   {
@@ -18895,7 +18854,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 959,
+    "aggregatedRank": 954,
     "countryRank": 114
   },
   {
@@ -18908,7 +18867,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 960,
+    "aggregatedRank": 955,
     "countryRank": 115
   },
   {
@@ -18924,7 +18883,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 961,
+    "aggregatedRank": 956,
     "countryRank": 116
   },
   {
@@ -18937,7 +18896,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 962,
+    "aggregatedRank": 957,
     "countryRank": 12
   },
   {
@@ -18950,7 +18909,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 963,
+    "aggregatedRank": 958,
     "countryRank": 84
   },
   {
@@ -18963,7 +18922,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 964,
+    "aggregatedRank": 959,
     "countryRank": 173
   },
   {
@@ -18976,7 +18935,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 965,
+    "aggregatedRank": 960,
     "countryRank": 16
   },
   {
@@ -18992,21 +18951,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 966,
-    "countryRank": 48
-  },
-  {
-    "name": "University of Gottingen",
-    "country": "Germany",
-    "aggregatedScore": 251.484375,
-    "originalRankings": {
-      "usnews": {
-        "rank": 182
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 967,
-    "countryRank": 49
+    "aggregatedRank": 961,
+    "countryRank": 46
   },
   {
     "name": "Suez Canal University",
@@ -19021,7 +18967,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 968,
+    "aggregatedRank": 962,
     "countryRank": 11
   },
   {
@@ -19034,7 +18980,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 969,
+    "aggregatedRank": 963,
     "countryRank": 174
   },
   {
@@ -19047,7 +18993,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 970,
+    "aggregatedRank": 964,
     "countryRank": 12
   },
   {
@@ -19063,7 +19009,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 971,
+    "aggregatedRank": 965,
     "countryRank": 117
   },
   {
@@ -19076,7 +19022,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 972,
+    "aggregatedRank": 966,
     "countryRank": 28
   },
   {
@@ -19092,7 +19038,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 973,
+    "aggregatedRank": 967,
     "countryRank": 18
   },
   {
@@ -19105,7 +19051,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 974,
+    "aggregatedRank": 968,
     "countryRank": 37
   },
   {
@@ -19118,8 +19064,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 975,
-    "countryRank": 50
+    "aggregatedRank": 969,
+    "countryRank": 47
   },
   {
     "name": "Universite Catholique Louvain",
@@ -19131,7 +19077,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 976,
+    "aggregatedRank": 970,
     "countryRank": 10
   },
   {
@@ -19147,7 +19093,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 977,
+    "aggregatedRank": 971,
     "countryRank": 118
   },
   {
@@ -19160,7 +19106,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 978,
+    "aggregatedRank": 972,
     "countryRank": 119
   },
   {
@@ -19176,7 +19122,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 979,
+    "aggregatedRank": 973,
     "countryRank": 175
   },
   {
@@ -19192,7 +19138,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 980,
+    "aggregatedRank": 974,
     "countryRank": 176
   },
   {
@@ -19208,7 +19154,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 981,
+    "aggregatedRank": 975,
     "countryRank": 27
   },
   {
@@ -19224,7 +19170,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 982,
+    "aggregatedRank": 976,
     "countryRank": 120
   },
   {
@@ -19240,7 +19186,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 983,
+    "aggregatedRank": 977,
     "countryRank": 23
   },
   {
@@ -19256,7 +19202,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 984,
+    "aggregatedRank": 978,
     "countryRank": 24
   },
   {
@@ -19272,7 +19218,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 985,
+    "aggregatedRank": 979,
     "countryRank": 177
   },
   {
@@ -19285,7 +19231,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 986,
+    "aggregatedRank": 980,
     "countryRank": 1
   },
   {
@@ -19298,8 +19244,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 987,
-    "countryRank": 51
+    "aggregatedRank": 981,
+    "countryRank": 48
   },
   {
     "name": "Shanghai University of Finance & Economics",
@@ -19314,7 +19260,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 988,
+    "aggregatedRank": 982,
     "countryRank": 121
   },
   {
@@ -19327,21 +19273,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 989,
+    "aggregatedRank": 983,
     "countryRank": 1
-  },
-  {
-    "name": "University of Wurzburg",
-    "country": "Germany",
-    "aggregatedScore": 245.390625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 221
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 990,
-    "countryRank": 52
   },
   {
     "name": "Johannes Gutenberg University of Mainz",
@@ -19353,21 +19286,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 991,
-    "countryRank": 53
-  },
-  {
-    "name": "University of Munster",
-    "country": "Germany",
-    "aggregatedScore": 244.296875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 228
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 992,
-    "countryRank": 54
+    "aggregatedRank": 984,
+    "countryRank": 49
   },
   {
     "name": "Universite de Montpellier",
@@ -19379,8 +19299,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 993,
-    "countryRank": 28
+    "aggregatedRank": 985,
+    "countryRank": 25
   },
   {
     "name": "Universidade de Lisboa",
@@ -19392,7 +19312,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 994,
+    "aggregatedRank": 986,
     "countryRank": 1
   },
   {
@@ -19405,7 +19325,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 995,
+    "aggregatedRank": 987,
     "countryRank": 38
   },
   {
@@ -19418,21 +19338,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 996,
+    "aggregatedRank": 988,
     "countryRank": 44
-  },
-  {
-    "name": "Universite Libre de Bruxelles",
-    "country": "Belgium",
-    "aggregatedScore": 240.546875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 252
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 997,
-    "countryRank": 11
   },
   {
     "name": "Cranfield University",
@@ -19447,7 +19354,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 998,
+    "aggregatedRank": 989,
     "countryRank": 85
   },
   {
@@ -19460,11 +19367,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 999,
+    "aggregatedRank": 990,
     "countryRank": 39
   },
   {
-    "name": "Charit� - University Medicine Berlin",
+    "name": "Charité - University Medicine Berlin",
     "country": "Germany",
     "aggregatedScore": 238.234375,
     "originalRankings": {
@@ -19473,8 +19380,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1000,
-    "countryRank": 55
+    "aggregatedRank": 991,
+    "countryRank": 50
   },
   {
     "name": "Universidade do Porto",
@@ -19486,7 +19393,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1001,
+    "aggregatedRank": 992,
     "countryRank": 1
   },
   {
@@ -19502,7 +19409,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1002,
+    "aggregatedRank": 993,
     "countryRank": 178
   },
   {
@@ -19515,7 +19422,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1003,
+    "aggregatedRank": 994,
     "countryRank": 122
   },
   {
@@ -19528,8 +19435,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1004,
-    "countryRank": 56
+    "aggregatedRank": 995,
+    "countryRank": 51
   },
   {
     "name": "Sichuan Agricultural University",
@@ -19544,7 +19451,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1005,
+    "aggregatedRank": 996,
     "countryRank": 123
   },
   {
@@ -19557,7 +19464,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1006,
+    "aggregatedRank": 997,
     "countryRank": 124
   },
   {
@@ -19570,8 +19477,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1007,
-    "countryRank": 29
+    "aggregatedRank": 998,
+    "countryRank": 26
   },
   {
     "name": "Leipzig University",
@@ -19583,8 +19490,24 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1008,
-    "countryRank": 57
+    "aggregatedRank": 999,
+    "countryRank": 52
+  },
+  {
+    "name": "University of Quebec Montreal",
+    "country": "Canada",
+    "aggregatedScore": 233.34375,
+    "originalRankings": {
+      "arwu": {
+        "rank": 801
+      },
+      "usnews": {
+        "rank": 847
+      }
+    },
+    "appearances": 2,
+    "aggregatedRank": 1000,
+    "countryRank": 29
   },
   {
     "name": "Qatar University",
@@ -19596,7 +19519,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1009,
+    "aggregatedRank": 1001,
     "countryRank": 1
   },
   {
@@ -19609,8 +19532,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1010,
-    "countryRank": 30
+    "aggregatedRank": 1002,
+    "countryRank": 27
   },
   {
     "name": "Harbin Medical University",
@@ -19625,7 +19548,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1011,
+    "aggregatedRank": 1003,
     "countryRank": 125
   },
   {
@@ -19638,7 +19561,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1012,
+    "aggregatedRank": 1004,
     "countryRank": 19
   },
   {
@@ -19651,7 +19574,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1013,
+    "aggregatedRank": 1005,
     "countryRank": 86
   },
   {
@@ -19667,7 +19590,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1014,
+    "aggregatedRank": 1006,
     "countryRank": 126
   },
   {
@@ -19680,7 +19603,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1015,
+    "aggregatedRank": 1007,
     "countryRank": 1
   },
   {
@@ -19696,7 +19619,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1016,
+    "aggregatedRank": 1008,
     "countryRank": 127
   },
   {
@@ -19709,7 +19632,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1017,
+    "aggregatedRank": 1009,
     "countryRank": 1
   },
   {
@@ -19722,7 +19645,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1018,
+    "aggregatedRank": 1010,
     "countryRank": 45
   },
   {
@@ -19738,7 +19661,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1019,
+    "aggregatedRank": 1011,
     "countryRank": 12
   },
   {
@@ -19754,8 +19677,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1020,
-    "countryRank": 58
+    "aggregatedRank": 1012,
+    "countryRank": 53
   },
   {
     "name": "Juntendo University",
@@ -19770,7 +19693,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1021,
+    "aggregatedRank": 1013,
     "countryRank": 20
   },
   {
@@ -19786,7 +19709,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1022,
+    "aggregatedRank": 1014,
     "countryRank": 25
   },
   {
@@ -19802,7 +19725,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1023,
+    "aggregatedRank": 1015,
     "countryRank": 26
   },
   {
@@ -19818,7 +19741,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1024,
+    "aggregatedRank": 1016,
     "countryRank": 46
   },
   {
@@ -19831,8 +19754,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1025,
-    "countryRank": 31
+    "aggregatedRank": 1017,
+    "countryRank": 28
   },
   {
     "name": "Universite Claude Bernard Lyon 1",
@@ -19844,8 +19767,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1026,
-    "countryRank": 32
+    "aggregatedRank": 1018,
+    "countryRank": 29
   },
   {
     "name": "Jinan University",
@@ -19857,7 +19780,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1027,
+    "aggregatedRank": 1019,
     "countryRank": 128
   },
   {
@@ -19870,8 +19793,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1028,
-    "countryRank": 33
+    "aggregatedRank": 1020,
+    "countryRank": 30
   },
   {
     "name": "Universite Cote d'Azur",
@@ -19883,8 +19806,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1029,
-    "countryRank": 34
+    "aggregatedRank": 1021,
+    "countryRank": 31
   },
   {
     "name": "University of Ibadan",
@@ -19896,21 +19819,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1030,
+    "aggregatedRank": 1022,
     "countryRank": 1
-  },
-  {
-    "name": "University of Liege",
-    "country": "Belgium",
-    "aggregatedScore": 223.671875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 360
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1031,
-    "countryRank": 12
   },
   {
     "name": "Skolkovo Institute of Science & Technology",
@@ -19925,7 +19835,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1032,
+    "aggregatedRank": 1023,
     "countryRank": 18
   },
   {
@@ -19941,8 +19851,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1033,
-    "countryRank": 35
+    "aggregatedRank": 1024,
+    "countryRank": 32
   },
   {
     "name": "Ruhr University Bochum",
@@ -19954,8 +19864,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1034,
-    "countryRank": 59
+    "aggregatedRank": 1025,
+    "countryRank": 54
   },
   {
     "name": "Institute of Science Tokyo",
@@ -19967,7 +19877,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1035,
+    "aggregatedRank": 1026,
     "countryRank": 21
   },
   {
@@ -19980,7 +19890,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1036,
+    "aggregatedRank": 1027,
     "countryRank": 47
   },
   {
@@ -19993,7 +19903,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1037,
+    "aggregatedRank": 1028,
     "countryRank": 13
   },
   {
@@ -20006,7 +19916,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1038,
+    "aggregatedRank": 1029,
     "countryRank": 1
   },
   {
@@ -20019,8 +19929,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1039,
-    "countryRank": 60
+    "aggregatedRank": 1030,
+    "countryRank": 55
   },
   {
     "name": "Central China Normal University",
@@ -20032,7 +19942,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1040,
+    "aggregatedRank": 1031,
     "countryRank": 129
   },
   {
@@ -20045,8 +19955,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1041,
-    "countryRank": 61
+    "aggregatedRank": 1032,
+    "countryRank": 56
   },
   {
     "name": "University of Victoria",
@@ -20058,8 +19968,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1042,
-    "countryRank": 29
+    "aggregatedRank": 1033,
+    "countryRank": 30
   },
   {
     "name": "Hassan II University of Casablanca",
@@ -20074,7 +19984,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1043,
+    "aggregatedRank": 1034,
     "countryRank": 2
   },
   {
@@ -20087,7 +19997,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1044,
+    "aggregatedRank": 1035,
     "countryRank": 2
   },
   {
@@ -20100,7 +20010,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1045,
+    "aggregatedRank": 1036,
     "countryRank": 1
   },
   {
@@ -20113,7 +20023,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1046,
+    "aggregatedRank": 1037,
     "countryRank": 87
   },
   {
@@ -20129,7 +20039,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1047,
+    "aggregatedRank": 1038,
     "countryRank": 130
   },
   {
@@ -20145,7 +20055,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1048,
+    "aggregatedRank": 1039,
     "countryRank": 6
   },
   {
@@ -20158,8 +20068,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1049,
-    "countryRank": 62
+    "aggregatedRank": 1040,
+    "countryRank": 57
   },
   {
     "name": "Technical University of Madrid",
@@ -20174,7 +20084,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1050,
+    "aggregatedRank": 1041,
     "countryRank": 27
   },
   {
@@ -20187,7 +20097,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1051,
+    "aggregatedRank": 1042,
     "countryRank": 1
   },
   {
@@ -20200,7 +20110,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1052,
+    "aggregatedRank": 1043,
     "countryRank": 8
   },
   {
@@ -20213,7 +20123,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1053,
+    "aggregatedRank": 1044,
     "countryRank": 1
   },
   {
@@ -20226,8 +20136,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1054,
-    "countryRank": 63
+    "aggregatedRank": 1045,
+    "countryRank": 58
   },
   {
     "name": "University of Oviedo",
@@ -20242,7 +20152,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1055,
+    "aggregatedRank": 1046,
     "countryRank": 28
   },
   {
@@ -20255,7 +20165,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1056,
+    "aggregatedRank": 1047,
     "countryRank": 48
   },
   {
@@ -20268,7 +20178,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1057,
+    "aggregatedRank": 1048,
     "countryRank": 14
   },
   {
@@ -20284,7 +20194,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1058,
+    "aggregatedRank": 1049,
     "countryRank": 179
   },
   {
@@ -20297,8 +20207,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1059,
-    "countryRank": 36
+    "aggregatedRank": 1050,
+    "countryRank": 33
   },
   {
     "name": "University of Massachusetts Worcester",
@@ -20310,7 +20220,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1060,
+    "aggregatedRank": 1051,
     "countryRank": 180
   },
   {
@@ -20326,7 +20236,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1061,
+    "aggregatedRank": 1052,
     "countryRank": 131
   },
   {
@@ -20342,7 +20252,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1062,
+    "aggregatedRank": 1053,
     "countryRank": 132
   },
   {
@@ -20358,8 +20268,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1063,
-    "countryRank": 37
+    "aggregatedRank": 1054,
+    "countryRank": 34
   },
   {
     "name": "University of Campania Luigi Vanvitelli",
@@ -20374,7 +20284,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1064,
+    "aggregatedRank": 1055,
     "countryRank": 49
   },
   {
@@ -20390,7 +20300,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1065,
+    "aggregatedRank": 1056,
     "countryRank": 181
   },
   {
@@ -20406,7 +20316,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1066,
+    "aggregatedRank": 1057,
     "countryRank": 182
   },
   {
@@ -20422,7 +20332,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1067,
+    "aggregatedRank": 1058,
     "countryRank": 29
   },
   {
@@ -20435,8 +20345,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1068,
-    "countryRank": 38
+    "aggregatedRank": 1059,
+    "countryRank": 35
   },
   {
     "name": "Universitat Politecnica de Catalunya",
@@ -20448,7 +20358,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1069,
+    "aggregatedRank": 1060,
     "countryRank": 30
   },
   {
@@ -20464,7 +20374,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1070,
+    "aggregatedRank": 1061,
     "countryRank": 133
   },
   {
@@ -20477,7 +20387,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1071,
+    "aggregatedRank": 1062,
     "countryRank": 134
   },
   {
@@ -20490,7 +20400,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1072,
+    "aggregatedRank": 1063,
     "countryRank": 9
   },
   {
@@ -20503,7 +20413,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1073,
+    "aggregatedRank": 1064,
     "countryRank": 10
   },
   {
@@ -20516,7 +20426,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1074,
+    "aggregatedRank": 1065,
     "countryRank": 183
   },
   {
@@ -20532,7 +20442,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1075,
+    "aggregatedRank": 1066,
     "countryRank": 135
   },
   {
@@ -20545,7 +20455,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1076,
+    "aggregatedRank": 1067,
     "countryRank": 136
   },
   {
@@ -20558,7 +20468,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1077,
+    "aggregatedRank": 1068,
     "countryRank": 1
   },
   {
@@ -20571,7 +20481,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1078,
+    "aggregatedRank": 1069,
     "countryRank": 2
   },
   {
@@ -20584,7 +20494,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1079,
+    "aggregatedRank": 1070,
     "countryRank": 137
   },
   {
@@ -20597,7 +20507,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1080,
+    "aggregatedRank": 1071,
     "countryRank": 31
   },
   {
@@ -20610,20 +20520,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1081,
-    "countryRank": 1
-  },
-  {
-    "name": "Eotvos Lorand University",
-    "country": "Hungary|budapest",
-    "aggregatedScore": 202.578125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 495
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1082,
+    "aggregatedRank": 1072,
     "countryRank": 1
   },
   {
@@ -20636,7 +20533,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1083,
+    "aggregatedRank": 1073,
     "countryRank": 138
   },
   {
@@ -20649,7 +20546,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1084,
+    "aggregatedRank": 1074,
     "countryRank": 139
   },
   {
@@ -20662,7 +20559,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1085,
+    "aggregatedRank": 1075,
     "countryRank": 184
   },
   {
@@ -20675,8 +20572,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1086,
-    "countryRank": 39
+    "aggregatedRank": 1076,
+    "countryRank": 36
   },
   {
     "name": "International School for Advanced Studies (SISSA)",
@@ -20688,7 +20585,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1087,
+    "aggregatedRank": 1077,
     "countryRank": 50
   },
   {
@@ -20701,7 +20598,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1088,
+    "aggregatedRank": 1078,
     "countryRank": 1
   },
   {
@@ -20717,8 +20614,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1089,
-    "countryRank": 64
+    "aggregatedRank": 1079,
+    "countryRank": 59
   },
   {
     "name": "University of Tsukuba",
@@ -20730,7 +20627,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1090,
+    "aggregatedRank": 1080,
     "countryRank": 88
   },
   {
@@ -20743,7 +20640,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1091,
+    "aggregatedRank": 1081,
     "countryRank": 32
   },
   {
@@ -20756,8 +20653,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1092,
-    "countryRank": 30
+    "aggregatedRank": 1082,
+    "countryRank": 31
   },
   {
     "name": "University of Seville",
@@ -20769,7 +20666,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1093,
+    "aggregatedRank": 1083,
     "countryRank": 33
   },
   {
@@ -20782,7 +20679,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1094,
+    "aggregatedRank": 1084,
     "countryRank": 10
   },
   {
@@ -20795,8 +20692,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1095,
-    "countryRank": 40
+    "aggregatedRank": 1085,
+    "countryRank": 37
   },
   {
     "name": "Brunel University London",
@@ -20808,7 +20705,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1096,
+    "aggregatedRank": 1086,
     "countryRank": 89
   },
   {
@@ -20821,7 +20718,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1097,
+    "aggregatedRank": 1087,
     "countryRank": 51
   },
   {
@@ -20834,7 +20731,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1098,
+    "aggregatedRank": 1088,
     "countryRank": 1
   },
   {
@@ -20847,7 +20744,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1099,
+    "aggregatedRank": 1089,
     "countryRank": 1
   },
   {
@@ -20863,7 +20760,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1100,
+    "aggregatedRank": 1090,
     "countryRank": 1
   },
   {
@@ -20876,7 +20773,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1101,
+    "aggregatedRank": 1091,
     "countryRank": 10
   },
   {
@@ -20889,7 +20786,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1102,
+    "aggregatedRank": 1092,
     "countryRank": 185
   },
   {
@@ -20902,7 +20799,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1103,
+    "aggregatedRank": 1093,
     "countryRank": 52
   },
   {
@@ -20915,8 +20812,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1104,
-    "countryRank": 65
+    "aggregatedRank": 1094,
+    "countryRank": 60
   },
   {
     "name": "Benha University",
@@ -20928,7 +20825,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1105,
+    "aggregatedRank": 1095,
     "countryRank": 1
   },
   {
@@ -20941,7 +20838,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1106,
+    "aggregatedRank": 1096,
     "countryRank": 53
   },
   {
@@ -20954,7 +20851,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1107,
+    "aggregatedRank": 1097,
     "countryRank": 11
   },
   {
@@ -20967,7 +20864,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1108,
+    "aggregatedRank": 1098,
     "countryRank": 11
   },
   {
@@ -20983,7 +20880,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1109,
+    "aggregatedRank": 1099,
     "countryRank": 7
   },
   {
@@ -20996,7 +20893,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1110,
+    "aggregatedRank": 1100,
     "countryRank": 140
   },
   {
@@ -21009,8 +20906,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1111,
-    "countryRank": 66
+    "aggregatedRank": 1101,
+    "countryRank": 61
   },
   {
     "name": "Southern Medical University - China",
@@ -21022,7 +20919,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1112,
+    "aggregatedRank": 1102,
     "countryRank": 141
   },
   {
@@ -21035,7 +20932,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1113,
+    "aggregatedRank": 1103,
     "countryRank": 2
   },
   {
@@ -21048,8 +20945,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1114,
-    "countryRank": 67
+    "aggregatedRank": 1104,
+    "countryRank": 62
   },
   {
     "name": "Texas Tech University",
@@ -21061,11 +20958,24 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1115,
+    "aggregatedRank": 1105,
     "countryRank": 186
   },
   {
-    "name": "University of Ja�n",
+    "name": "Universite Paris-Est-Creteil-Val-de-Marne (UPEC)",
+    "country": "France",
+    "aggregatedScore": 191.171875,
+    "originalRankings": {
+      "usnews": {
+        "rank": 568
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 1106,
+    "countryRank": 38
+  },
+  {
+    "name": "University of Jaén",
     "country": "Spain",
     "aggregatedScore": 190.63125000000002,
     "originalRankings": {
@@ -21077,7 +20987,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1116,
+    "aggregatedRank": 1107,
     "countryRank": 34
   },
   {
@@ -21093,7 +21003,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1117,
+    "aggregatedRank": 1108,
     "countryRank": 12
   },
   {
@@ -21109,7 +21019,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1118,
+    "aggregatedRank": 1109,
     "countryRank": 13
   },
   {
@@ -21122,7 +21032,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1119,
+    "aggregatedRank": 1110,
     "countryRank": 1
   },
   {
@@ -21135,7 +21045,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1120,
+    "aggregatedRank": 1111,
     "countryRank": 11
   },
   {
@@ -21148,11 +21058,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1121,
+    "aggregatedRank": 1112,
     "countryRank": 28
   },
   {
-    "name": "Federal University of Toulouse Midi-Pyr�n�es",
+    "name": "Federal University of Toulouse Midi-Pyrénées",
     "country": "France",
     "aggregatedScore": 190.109375,
     "originalRankings": {
@@ -21161,8 +21071,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1122,
-    "countryRank": 41
+    "aggregatedRank": 1113,
+    "countryRank": 39
   },
   {
     "name": "Federation University Australia",
@@ -21174,7 +21084,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1123,
+    "aggregatedRank": 1114,
     "countryRank": 40
   },
   {
@@ -21187,8 +21097,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1124,
-    "countryRank": 68
+    "aggregatedRank": 1115,
+    "countryRank": 63
   },
   {
     "name": "UiT The Arctic University of Tromso",
@@ -21200,7 +21110,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1125,
+    "aggregatedRank": 1116,
     "countryRank": 8
   },
   {
@@ -21213,7 +21123,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1126,
+    "aggregatedRank": 1117,
     "countryRank": 1
   },
   {
@@ -21226,7 +21136,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1127,
+    "aggregatedRank": 1118,
     "countryRank": 1
   },
   {
@@ -21239,8 +21149,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1128,
-    "countryRank": 42
+    "aggregatedRank": 1119,
+    "countryRank": 40
   },
   {
     "name": "North West University - South Africa",
@@ -21252,7 +21162,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1129,
+    "aggregatedRank": 1120,
     "countryRank": 1
   },
   {
@@ -21265,7 +21175,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1130,
+    "aggregatedRank": 1121,
     "countryRank": 15
   },
   {
@@ -21281,8 +21191,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1131,
-    "countryRank": 69
+    "aggregatedRank": 1122,
+    "countryRank": 64
   },
   {
     "name": "Government College University Faisalabad",
@@ -21294,7 +21204,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1132,
+    "aggregatedRank": 1123,
     "countryRank": 1
   },
   {
@@ -21307,7 +21217,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1133,
+    "aggregatedRank": 1124,
     "countryRank": 1
   },
   {
@@ -21320,7 +21230,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1134,
+    "aggregatedRank": 1125,
     "countryRank": 90
   },
   {
@@ -21333,7 +21243,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1135,
+    "aggregatedRank": 1126,
     "countryRank": 1
   },
   {
@@ -21346,7 +21256,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1136,
+    "aggregatedRank": 1127,
     "countryRank": 142
   },
   {
@@ -21359,8 +21269,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1137,
-    "countryRank": 70
+    "aggregatedRank": 1128,
+    "countryRank": 65
   },
   {
     "name": "University of Kent",
@@ -21372,7 +21282,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1138,
+    "aggregatedRank": 1129,
     "countryRank": 91
   },
   {
@@ -21385,7 +21295,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1139,
+    "aggregatedRank": 1130,
     "countryRank": 187
   },
   {
@@ -21398,7 +21308,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1140,
+    "aggregatedRank": 1131,
     "countryRank": 1
   },
   {
@@ -21411,7 +21321,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1141,
+    "aggregatedRank": 1132,
     "countryRank": 54
   },
   {
@@ -21424,7 +21334,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1142,
+    "aggregatedRank": 1133,
     "countryRank": 29
   },
   {
@@ -21437,7 +21347,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1143,
+    "aggregatedRank": 1134,
     "countryRank": 12
   },
   {
@@ -21450,7 +21360,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1144,
+    "aggregatedRank": 1135,
     "countryRank": 188
   },
   {
@@ -21463,7 +21373,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1145,
+    "aggregatedRank": 1136,
     "countryRank": 1
   },
   {
@@ -21476,7 +21386,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1146,
+    "aggregatedRank": 1137,
     "countryRank": 1
   },
   {
@@ -21489,7 +21399,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1147,
+    "aggregatedRank": 1138,
     "countryRank": 1
   },
   {
@@ -21502,7 +21412,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1148,
+    "aggregatedRank": 1139,
     "countryRank": 1
   },
   {
@@ -21515,7 +21425,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1149,
+    "aggregatedRank": 1140,
     "countryRank": 143
   },
   {
@@ -21528,7 +21438,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1150,
+    "aggregatedRank": 1141,
     "countryRank": 189
   },
   {
@@ -21541,7 +21451,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1151,
+    "aggregatedRank": 1142,
     "countryRank": 3
   },
   {
@@ -21554,7 +21464,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1152,
+    "aggregatedRank": 1143,
     "countryRank": 1
   },
   {
@@ -21567,8 +21477,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1153,
-    "countryRank": 43
+    "aggregatedRank": 1144,
+    "countryRank": 41
   },
   {
     "name": "BOKU University",
@@ -21580,7 +21490,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1154,
+    "aggregatedRank": 1145,
     "countryRank": 16
   },
   {
@@ -21593,7 +21503,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1155,
+    "aggregatedRank": 1146,
     "countryRank": 30
   },
   {
@@ -21606,7 +21516,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1156,
+    "aggregatedRank": 1147,
     "countryRank": 31
   },
   {
@@ -21619,7 +21529,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1157,
+    "aggregatedRank": 1148,
     "countryRank": 35
   },
   {
@@ -21632,7 +21542,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1158,
+    "aggregatedRank": 1149,
     "countryRank": 1
   },
   {
@@ -21645,7 +21555,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1159,
+    "aggregatedRank": 1150,
     "countryRank": 12
   },
   {
@@ -21658,8 +21568,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1160,
-    "countryRank": 71
+    "aggregatedRank": 1151,
+    "countryRank": 66
   },
   {
     "name": "University of Passau",
@@ -21671,8 +21581,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1161,
-    "countryRank": 72
+    "aggregatedRank": 1152,
+    "countryRank": 67
   },
   {
     "name": "University of Siegen",
@@ -21684,8 +21594,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1162,
-    "countryRank": 73
+    "aggregatedRank": 1153,
+    "countryRank": 68
   },
   {
     "name": "Roskilde University",
@@ -21697,7 +21607,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1163,
+    "aggregatedRank": 1154,
     "countryRank": 7
   },
   {
@@ -21710,8 +21620,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1164,
-    "countryRank": 44
+    "aggregatedRank": 1155,
+    "countryRank": 42
   },
   {
     "name": "National Yunlin University of Science and Technology",
@@ -21723,7 +21633,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1165,
+    "aggregatedRank": 1156,
     "countryRank": 13
   },
   {
@@ -21736,7 +21646,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1166,
+    "aggregatedRank": 1157,
     "countryRank": 190
   },
   {
@@ -21749,8 +21659,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1167,
-    "countryRank": 74
+    "aggregatedRank": 1158,
+    "countryRank": 69
   },
   {
     "name": "Babol Noshirvani University of Technology",
@@ -21762,7 +21672,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1168,
+    "aggregatedRank": 1159,
     "countryRank": 17
   },
   {
@@ -21775,7 +21685,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1169,
+    "aggregatedRank": 1160,
     "countryRank": 3
   },
   {
@@ -21788,7 +21698,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1170,
+    "aggregatedRank": 1161,
     "countryRank": 3
   },
   {
@@ -21801,8 +21711,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1171,
-    "countryRank": 75
+    "aggregatedRank": 1162,
+    "countryRank": 70
   },
   {
     "name": "Egypt-Japan University of Science and Technology",
@@ -21814,7 +21724,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1172,
+    "aggregatedRank": 1163,
     "countryRank": 12
   },
   {
@@ -21827,8 +21737,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1173,
-    "countryRank": 45
+    "aggregatedRank": 1164,
+    "countryRank": 43
   },
   {
     "name": "Nazarbayev University",
@@ -21840,7 +21750,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1174,
+    "aggregatedRank": 1165,
     "countryRank": 1
   },
   {
@@ -21853,7 +21763,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1175,
+    "aggregatedRank": 1166,
     "countryRank": 1
   },
   {
@@ -21866,7 +21776,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1176,
+    "aggregatedRank": 1167,
     "countryRank": 36
   },
   {
@@ -21879,7 +21789,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1177,
+    "aggregatedRank": 1168,
     "countryRank": 37
   },
   {
@@ -21895,7 +21805,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1178,
+    "aggregatedRank": 1169,
     "countryRank": 144
   },
   {
@@ -21908,7 +21818,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1179,
+    "aggregatedRank": 1170,
     "countryRank": 191
   },
   {
@@ -21924,7 +21834,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1180,
+    "aggregatedRank": 1171,
     "countryRank": 192
   },
   {
@@ -21937,7 +21847,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1181,
+    "aggregatedRank": 1172,
     "countryRank": 32
   },
   {
@@ -21950,7 +21860,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1182,
+    "aggregatedRank": 1173,
     "countryRank": 9
   },
   {
@@ -21963,7 +21873,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1183,
+    "aggregatedRank": 1174,
     "countryRank": 1
   },
   {
@@ -21976,7 +21886,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1184,
+    "aggregatedRank": 1175,
     "countryRank": 12
   },
   {
@@ -21989,7 +21899,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1185,
+    "aggregatedRank": 1176,
     "countryRank": 1
   },
   {
@@ -22002,7 +21912,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1186,
+    "aggregatedRank": 1177,
     "countryRank": 1
   },
   {
@@ -22015,7 +21925,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1187,
+    "aggregatedRank": 1178,
     "countryRank": 2
   },
   {
@@ -22028,7 +21938,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1188,
+    "aggregatedRank": 1179,
     "countryRank": 145
   },
   {
@@ -22041,7 +21951,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1189,
+    "aggregatedRank": 1180,
     "countryRank": 55
   },
   {
@@ -22054,7 +21964,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1190,
+    "aggregatedRank": 1181,
     "countryRank": 1
   },
   {
@@ -22067,7 +21977,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1191,
+    "aggregatedRank": 1182,
     "countryRank": 1
   },
   {
@@ -22080,7 +21990,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1192,
+    "aggregatedRank": 1183,
     "countryRank": 56
   },
   {
@@ -22093,7 +22003,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1193,
+    "aggregatedRank": 1184,
     "countryRank": 13
   },
   {
@@ -22106,7 +22016,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1194,
+    "aggregatedRank": 1185,
     "countryRank": 1
   },
   {
@@ -22119,7 +22029,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1195,
+    "aggregatedRank": 1186,
     "countryRank": 193
   },
   {
@@ -22132,8 +22042,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1196,
-    "countryRank": 31
+    "aggregatedRank": 1187,
+    "countryRank": 32
   },
   {
     "name": "Dortmund University of Technology",
@@ -22145,8 +22055,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1197,
-    "countryRank": 76
+    "aggregatedRank": 1188,
+    "countryRank": 71
   },
   {
     "name": "University Djillali Liabes Sidi Bel Abbes",
@@ -22158,7 +22068,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1198,
+    "aggregatedRank": 1189,
     "countryRank": 1
   },
   {
@@ -22171,7 +22081,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1199,
+    "aggregatedRank": 1190,
     "countryRank": 1
   },
   {
@@ -22184,7 +22094,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1200,
+    "aggregatedRank": 1191,
     "countryRank": 2
   },
   {
@@ -22197,7 +22107,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1201,
+    "aggregatedRank": 1192,
     "countryRank": 1
   },
   {
@@ -22210,8 +22120,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1202,
-    "countryRank": 46
+    "aggregatedRank": 1193,
+    "countryRank": 44
   },
   {
     "name": "Ecole Nationale des Travaux Publics de l'Etat",
@@ -22223,8 +22133,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1203,
-    "countryRank": 47
+    "aggregatedRank": 1194,
+    "countryRank": 45
   },
   {
     "name": "Harokopio University",
@@ -22236,7 +22146,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1204,
+    "aggregatedRank": 1195,
     "countryRank": 7
   },
   {
@@ -22249,7 +22159,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1205,
+    "aggregatedRank": 1196,
     "countryRank": 18
   },
   {
@@ -22262,7 +22172,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1206,
+    "aggregatedRank": 1197,
     "countryRank": 19
   },
   {
@@ -22275,7 +22185,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1207,
+    "aggregatedRank": 1198,
     "countryRank": 20
   },
   {
@@ -22288,7 +22198,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1208,
+    "aggregatedRank": 1199,
     "countryRank": 21
   },
   {
@@ -22301,7 +22211,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1209,
+    "aggregatedRank": 1200,
     "countryRank": 22
   },
   {
@@ -22314,7 +22224,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1210,
+    "aggregatedRank": 1201,
     "countryRank": 57
   },
   {
@@ -22327,7 +22237,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1211,
+    "aggregatedRank": 1202,
     "countryRank": 58
   },
   {
@@ -22340,7 +22250,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1212,
+    "aggregatedRank": 1203,
     "countryRank": 22
   },
   {
@@ -22353,7 +22263,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1213,
+    "aggregatedRank": 1204,
     "countryRank": 14
   },
   {
@@ -22366,7 +22276,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1214,
+    "aggregatedRank": 1205,
     "countryRank": 8
   },
   {
@@ -22379,11 +22289,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1215,
+    "aggregatedRank": 1206,
     "countryRank": 19
   },
   {
-    "name": "J�nk�ping University College",
+    "name": "Jönköping University College",
     "country": "Sweden",
     "aggregatedScore": 158.859375,
     "originalRankings": {
@@ -22392,7 +22302,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1216,
+    "aggregatedRank": 1207,
     "countryRank": 14
   },
   {
@@ -22405,7 +22315,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1217,
+    "aggregatedRank": 1208,
     "countryRank": 92
   },
   {
@@ -22418,7 +22328,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1218,
+    "aggregatedRank": 1209,
     "countryRank": 93
   },
   {
@@ -22431,7 +22341,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1219,
+    "aggregatedRank": 1210,
     "countryRank": 194
   },
   {
@@ -22444,7 +22354,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1220,
+    "aggregatedRank": 1211,
     "countryRank": 195
   },
   {
@@ -22457,7 +22367,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1221,
+    "aggregatedRank": 1212,
     "countryRank": 4
   },
   {
@@ -22470,7 +22380,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1222,
+    "aggregatedRank": 1213,
     "countryRank": 33
   },
   {
@@ -22483,11 +22393,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1223,
+    "aggregatedRank": 1214,
     "countryRank": 94
   },
   {
-    "name": "�cole des Mines de Saint-�tienne",
+    "name": "École des Mines de Saint-Étienne",
     "country": "France",
     "aggregatedScore": 158.859375,
     "originalRankings": {
@@ -22496,8 +22406,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1224,
-    "countryRank": 48
+    "aggregatedRank": 1215,
+    "countryRank": 46
   },
   {
     "name": "University of Insubria",
@@ -22509,7 +22419,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1225,
+    "aggregatedRank": 1216,
     "countryRank": 59
   },
   {
@@ -22522,7 +22432,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1226,
+    "aggregatedRank": 1217,
     "countryRank": 38
   },
   {
@@ -22535,7 +22445,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1227,
+    "aggregatedRank": 1218,
     "countryRank": 34
   },
   {
@@ -22548,7 +22458,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1228,
+    "aggregatedRank": 1219,
     "countryRank": 60
   },
   {
@@ -22561,7 +22471,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1229,
+    "aggregatedRank": 1220,
     "countryRank": 95
   },
   {
@@ -22574,11 +22484,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1230,
+    "aggregatedRank": 1221,
     "countryRank": 13
   },
   {
-    "name": "�buda University",
+    "name": "Óbuda University",
     "country": "Hungary",
     "aggregatedScore": 158.859375,
     "originalRankings": {
@@ -22587,7 +22497,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1231,
+    "aggregatedRank": 1222,
     "countryRank": 5
   },
   {
@@ -22600,7 +22510,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1232,
+    "aggregatedRank": 1223,
     "countryRank": 23
   },
   {
@@ -22613,7 +22523,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1233,
+    "aggregatedRank": 1224,
     "countryRank": 24
   },
   {
@@ -22626,7 +22536,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1234,
+    "aggregatedRank": 1225,
     "countryRank": 25
   },
   {
@@ -22639,7 +22549,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1235,
+    "aggregatedRank": 1226,
     "countryRank": 20
   },
   {
@@ -22652,7 +22562,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1236,
+    "aggregatedRank": 1227,
     "countryRank": 15
   },
   {
@@ -22665,7 +22575,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1237,
+    "aggregatedRank": 1228,
     "countryRank": 16
   },
   {
@@ -22678,7 +22588,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1238,
+    "aggregatedRank": 1229,
     "countryRank": 35
   },
   {
@@ -22691,7 +22601,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1239,
+    "aggregatedRank": 1230,
     "countryRank": 36
   },
   {
@@ -22704,7 +22614,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1240,
+    "aggregatedRank": 1231,
     "countryRank": 37
   },
   {
@@ -22717,7 +22627,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1241,
+    "aggregatedRank": 1232,
     "countryRank": 21
   },
   {
@@ -22730,7 +22640,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1242,
+    "aggregatedRank": 1233,
     "countryRank": 17
   },
   {
@@ -22743,7 +22653,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1243,
+    "aggregatedRank": 1234,
     "countryRank": 38
   },
   {
@@ -22756,7 +22666,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1244,
+    "aggregatedRank": 1235,
     "countryRank": 39
   },
   {
@@ -22769,7 +22679,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1245,
+    "aggregatedRank": 1236,
     "countryRank": 39
   },
   {
@@ -22782,7 +22692,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1246,
+    "aggregatedRank": 1237,
     "countryRank": 1
   },
   {
@@ -22795,7 +22705,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1247,
+    "aggregatedRank": 1238,
     "countryRank": 1
   },
   {
@@ -22808,7 +22718,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1248,
+    "aggregatedRank": 1239,
     "countryRank": 96
   },
   {
@@ -22821,7 +22731,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1249,
+    "aggregatedRank": 1240,
     "countryRank": 146
   },
   {
@@ -22834,7 +22744,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1250,
+    "aggregatedRank": 1241,
     "countryRank": 13
   },
   {
@@ -22847,7 +22757,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1251,
+    "aggregatedRank": 1242,
     "countryRank": 40
   },
   {
@@ -22860,7 +22770,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1252,
+    "aggregatedRank": 1243,
     "countryRank": 8
   },
   {
@@ -22873,7 +22783,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1253,
+    "aggregatedRank": 1244,
     "countryRank": 40
   },
   {
@@ -22886,7 +22796,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1254,
+    "aggregatedRank": 1245,
     "countryRank": 1
   },
   {
@@ -22899,7 +22809,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1255,
+    "aggregatedRank": 1246,
     "countryRank": 196
   },
   {
@@ -22915,7 +22825,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1256,
+    "aggregatedRank": 1247,
     "countryRank": 5
   },
   {
@@ -22931,8 +22841,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1257,
-    "countryRank": 49
+    "aggregatedRank": 1248,
+    "countryRank": 47
   },
   {
     "name": "Mohammed V University in Rabat",
@@ -22944,7 +22854,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1258,
+    "aggregatedRank": 1249,
     "countryRank": 14
   },
   {
@@ -22957,7 +22867,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1259,
+    "aggregatedRank": 1250,
     "countryRank": 3
   },
   {
@@ -22970,7 +22880,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1260,
+    "aggregatedRank": 1251,
     "countryRank": 197
   },
   {
@@ -22983,7 +22893,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1261,
+    "aggregatedRank": 1252,
     "countryRank": 1
   },
   {
@@ -22996,7 +22906,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1262,
+    "aggregatedRank": 1253,
     "countryRank": 1
   },
   {
@@ -23009,7 +22919,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1263,
+    "aggregatedRank": 1254,
     "countryRank": 10
   },
   {
@@ -23022,7 +22932,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1264,
+    "aggregatedRank": 1255,
     "countryRank": 198
   },
   {
@@ -23035,7 +22945,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1265,
+    "aggregatedRank": 1256,
     "countryRank": 199
   },
   {
@@ -23048,7 +22958,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1266,
+    "aggregatedRank": 1257,
     "countryRank": 200
   },
   {
@@ -23061,7 +22971,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1267,
+    "aggregatedRank": 1258,
     "countryRank": 201
   },
   {
@@ -23074,7 +22984,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1268,
+    "aggregatedRank": 1259,
     "countryRank": 1
   },
   {
@@ -23087,7 +22997,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1269,
+    "aggregatedRank": 1260,
     "countryRank": 41
   },
   {
@@ -23100,7 +23010,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1270,
+    "aggregatedRank": 1261,
     "countryRank": 1
   },
   {
@@ -23113,7 +23023,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1271,
+    "aggregatedRank": 1262,
     "countryRank": 202
   },
   {
@@ -23126,7 +23036,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1272,
+    "aggregatedRank": 1263,
     "countryRank": 147
   },
   {
@@ -23139,21 +23049,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1273,
+    "aggregatedRank": 1264,
     "countryRank": 1
-  },
-  {
-    "name": "University of Quebec Montreal",
-    "country": "Canada",
-    "aggregatedScore": 147.578125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 847
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1274,
-    "countryRank": 32
   },
   {
     "name": "Kwame Nkrumah University Science & Technology",
@@ -23165,7 +23062,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1275,
+    "aggregatedRank": 1265,
     "countryRank": 1
   },
   {
@@ -23178,8 +23075,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1276,
-    "countryRank": 77
+    "aggregatedRank": 1266,
+    "countryRank": 72
   },
   {
     "name": "University of Ioannina",
@@ -23191,7 +23088,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1277,
+    "aggregatedRank": 1267,
     "countryRank": 1
   },
   {
@@ -23204,7 +23101,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1278,
+    "aggregatedRank": 1268,
     "countryRank": 14
   },
   {
@@ -23217,7 +23114,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1279,
+    "aggregatedRank": 1269,
     "countryRank": 148
   },
   {
@@ -23230,7 +23127,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1280,
+    "aggregatedRank": 1270,
     "countryRank": 42
   },
   {
@@ -23243,7 +23140,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1281,
+    "aggregatedRank": 1271,
     "countryRank": 1
   },
   {
@@ -23259,7 +23156,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1282,
+    "aggregatedRank": 1272,
     "countryRank": 6
   },
   {
@@ -23272,7 +23169,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1283,
+    "aggregatedRank": 1273,
     "countryRank": 1
   },
   {
@@ -23285,7 +23182,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1284,
+    "aggregatedRank": 1274,
     "countryRank": 97
   },
   {
@@ -23298,7 +23195,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1285,
+    "aggregatedRank": 1275,
     "countryRank": 149
   },
   {
@@ -23311,7 +23208,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1286,
+    "aggregatedRank": 1276,
     "countryRank": 1
   },
   {
@@ -23324,7 +23221,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1287,
+    "aggregatedRank": 1277,
     "countryRank": 61
   },
   {
@@ -23337,7 +23234,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1288,
+    "aggregatedRank": 1278,
     "countryRank": 150
   },
   {
@@ -23350,7 +23247,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1289,
+    "aggregatedRank": 1279,
     "countryRank": 98
   },
   {
@@ -23363,7 +23260,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1290,
+    "aggregatedRank": 1280,
     "countryRank": 41
   },
   {
@@ -23376,7 +23273,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1291,
+    "aggregatedRank": 1281,
     "countryRank": 1
   },
   {
@@ -23389,11 +23286,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1292,
+    "aggregatedRank": 1282,
     "countryRank": 28
   },
   {
-    "name": "University of Concepci�n",
+    "name": "University of Concepción",
     "country": "Chile",
     "aggregatedScore": 138.52499999999998,
     "originalRankings": {
@@ -23405,7 +23302,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1293,
+    "aggregatedRank": 1283,
     "countryRank": 3
   },
   {
@@ -23418,7 +23315,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1294,
+    "aggregatedRank": 1284,
     "countryRank": 203
   },
   {
@@ -23431,7 +23328,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1295,
+    "aggregatedRank": 1285,
     "countryRank": 151
   },
   {
@@ -23444,7 +23341,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1296,
+    "aggregatedRank": 1286,
     "countryRank": 204
   },
   {
@@ -23457,7 +23354,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1297,
+    "aggregatedRank": 1287,
     "countryRank": 205
   },
   {
@@ -23470,8 +23367,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1298,
-    "countryRank": 78
+    "aggregatedRank": 1288,
+    "countryRank": 73
   },
   {
     "name": "Tribhuvan University",
@@ -23483,7 +23380,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1299,
+    "aggregatedRank": 1289,
     "countryRank": 1
   },
   {
@@ -23496,7 +23393,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1300,
+    "aggregatedRank": 1290,
     "countryRank": 41
   },
   {
@@ -23509,7 +23406,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1301,
+    "aggregatedRank": 1291,
     "countryRank": 1
   },
   {
@@ -23522,7 +23419,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1302,
+    "aggregatedRank": 1292,
     "countryRank": 1
   },
   {
@@ -23535,7 +23432,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1303,
+    "aggregatedRank": 1293,
     "countryRank": 1
   },
   {
@@ -23551,7 +23448,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1304,
+    "aggregatedRank": 1294,
     "countryRank": 23
   },
   {
@@ -23564,7 +23461,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1305,
+    "aggregatedRank": 1295,
     "countryRank": 11
   },
   {
@@ -23577,7 +23474,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1306,
+    "aggregatedRank": 1296,
     "countryRank": 1
   },
   {
@@ -23590,7 +23487,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1307,
+    "aggregatedRank": 1297,
     "countryRank": 43
   },
   {
@@ -23603,7 +23500,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1308,
+    "aggregatedRank": 1298,
     "countryRank": 1
   },
   {
@@ -23616,7 +23513,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1309,
+    "aggregatedRank": 1299,
     "countryRank": 1
   },
   {
@@ -23629,7 +23526,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1310,
+    "aggregatedRank": 1300,
     "countryRank": 44
   },
   {
@@ -23642,8 +23539,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1311,
-    "countryRank": 13
+    "aggregatedRank": 1301,
+    "countryRank": 11
   },
   {
     "name": "Carlos III University of Madrid",
@@ -23655,7 +23552,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1312,
+    "aggregatedRank": 1302,
     "countryRank": 45
   },
   {
@@ -23668,7 +23565,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1313,
+    "aggregatedRank": 1303,
     "countryRank": 2
   },
   {
@@ -23681,8 +23578,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1314,
-    "countryRank": 50
+    "aggregatedRank": 1304,
+    "countryRank": 48
   },
   {
     "name": "University of Split",
@@ -23694,7 +23591,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1315,
+    "aggregatedRank": 1305,
     "countryRank": 1
   },
   {
@@ -23707,7 +23604,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1316,
+    "aggregatedRank": 1306,
     "countryRank": 152
   },
   {
@@ -23720,7 +23617,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1317,
+    "aggregatedRank": 1307,
     "countryRank": 1
   },
   {
@@ -23733,7 +23630,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1318,
+    "aggregatedRank": 1308,
     "countryRank": 42
   },
   {
@@ -23746,8 +23643,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1319,
-    "countryRank": 51
+    "aggregatedRank": 1309,
+    "countryRank": 49
   },
   {
     "name": "Transilvania University of Brasov",
@@ -23759,7 +23656,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1320,
+    "aggregatedRank": 1310,
     "countryRank": 1
   },
   {
@@ -23772,7 +23669,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1321,
+    "aggregatedRank": 1311,
     "countryRank": 1
   },
   {
@@ -23785,7 +23682,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1322,
+    "aggregatedRank": 1312,
     "countryRank": 15
   },
   {
@@ -23798,7 +23695,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1323,
+    "aggregatedRank": 1313,
     "countryRank": 17
   },
   {
@@ -23811,7 +23708,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1324,
+    "aggregatedRank": 1314,
     "countryRank": 24
   },
   {
@@ -23824,7 +23721,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1325,
+    "aggregatedRank": 1315,
     "countryRank": 1
   },
   {
@@ -23837,7 +23734,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1326,
+    "aggregatedRank": 1316,
     "countryRank": 1
   },
   {
@@ -23850,7 +23747,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1327,
+    "aggregatedRank": 1317,
     "countryRank": 26
   },
   {
@@ -23863,7 +23760,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1328,
+    "aggregatedRank": 1318,
     "countryRank": 27
   },
   {
@@ -23876,7 +23773,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1329,
+    "aggregatedRank": 1319,
     "countryRank": 18
   },
   {
@@ -23889,7 +23786,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1330,
+    "aggregatedRank": 1320,
     "countryRank": 18
   },
   {
@@ -23902,7 +23799,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1331,
+    "aggregatedRank": 1321,
     "countryRank": 3
   },
   {
@@ -23915,7 +23812,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1332,
+    "aggregatedRank": 1322,
     "countryRank": 4
   },
   {
@@ -23928,7 +23825,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1333,
+    "aggregatedRank": 1323,
     "countryRank": 33
   },
   {
@@ -23941,7 +23838,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1334,
+    "aggregatedRank": 1324,
     "countryRank": 34
   },
   {
@@ -23954,7 +23851,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1335,
+    "aggregatedRank": 1325,
     "countryRank": 46
   },
   {
@@ -23967,11 +23864,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1336,
+    "aggregatedRank": 1326,
     "countryRank": 1
   },
   {
-    "name": "Arts et M�tiers",
+    "name": "Arts et Métiers",
     "country": "France",
     "aggregatedScore": 127.609375,
     "originalRankings": {
@@ -23980,8 +23877,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1337,
-    "countryRank": 52
+    "aggregatedRank": 1327,
+    "countryRank": 50
   },
   {
     "name": "National Veterinary School of Alfort",
@@ -23993,8 +23890,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1338,
-    "countryRank": 53
+    "aggregatedRank": 1328,
+    "countryRank": 51
   },
   {
     "name": "University of Western Brittany",
@@ -24006,8 +23903,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1339,
-    "countryRank": 54
+    "aggregatedRank": 1329,
+    "countryRank": 52
   },
   {
     "name": "Alagappa University",
@@ -24019,7 +23916,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1340,
+    "aggregatedRank": 1330,
     "countryRank": 43
   },
   {
@@ -24032,7 +23929,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1341,
+    "aggregatedRank": 1331,
     "countryRank": 44
   },
   {
@@ -24045,7 +23942,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1342,
+    "aggregatedRank": 1332,
     "countryRank": 45
   },
   {
@@ -24058,7 +23955,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1343,
+    "aggregatedRank": 1333,
     "countryRank": 46
   },
   {
@@ -24071,7 +23968,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1344,
+    "aggregatedRank": 1334,
     "countryRank": 28
   },
   {
@@ -24084,7 +23981,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1345,
+    "aggregatedRank": 1335,
     "countryRank": 29
   },
   {
@@ -24097,7 +23994,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1346,
+    "aggregatedRank": 1336,
     "countryRank": 30
   },
   {
@@ -24110,7 +24007,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1347,
+    "aggregatedRank": 1337,
     "countryRank": 31
   },
   {
@@ -24123,7 +24020,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1348,
+    "aggregatedRank": 1338,
     "countryRank": 32
   },
   {
@@ -24136,7 +24033,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1349,
+    "aggregatedRank": 1339,
     "countryRank": 33
   },
   {
@@ -24149,7 +24046,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1350,
+    "aggregatedRank": 1340,
     "countryRank": 34
   },
   {
@@ -24162,7 +24059,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1351,
+    "aggregatedRank": 1341,
     "countryRank": 35
   },
   {
@@ -24175,11 +24072,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1352,
+    "aggregatedRank": 1342,
     "countryRank": 36
   },
   {
-    "name": "Reykjav�k University",
+    "name": "Reykjavík University",
     "country": "Iceland",
     "aggregatedScore": 127.609375,
     "originalRankings": {
@@ -24188,7 +24085,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1353,
+    "aggregatedRank": 1343,
     "countryRank": 2
   },
   {
@@ -24201,7 +24098,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1354,
+    "aggregatedRank": 1344,
     "countryRank": 62
   },
   {
@@ -24214,7 +24111,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1355,
+    "aggregatedRank": 1345,
     "countryRank": 63
   },
   {
@@ -24227,7 +24124,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1356,
+    "aggregatedRank": 1346,
     "countryRank": 64
   },
   {
@@ -24240,7 +24137,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1357,
+    "aggregatedRank": 1347,
     "countryRank": 5
   },
   {
@@ -24253,7 +24150,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1358,
+    "aggregatedRank": 1348,
     "countryRank": 25
   },
   {
@@ -24266,7 +24163,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1359,
+    "aggregatedRank": 1349,
     "countryRank": 26
   },
   {
@@ -24279,7 +24176,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1360,
+    "aggregatedRank": 1350,
     "countryRank": 29
   },
   {
@@ -24292,7 +24189,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1361,
+    "aggregatedRank": 1351,
     "countryRank": 1
   },
   {
@@ -24305,7 +24202,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1362,
+    "aggregatedRank": 1352,
     "countryRank": 19
   },
   {
@@ -24318,7 +24215,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1363,
+    "aggregatedRank": 1353,
     "countryRank": 20
   },
   {
@@ -24331,7 +24228,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1364,
+    "aggregatedRank": 1354,
     "countryRank": 21
   },
   {
@@ -24344,7 +24241,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1365,
+    "aggregatedRank": 1355,
     "countryRank": 22
   },
   {
@@ -24357,7 +24254,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1366,
+    "aggregatedRank": 1356,
     "countryRank": 4
   },
   {
@@ -24370,7 +24267,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1367,
+    "aggregatedRank": 1357,
     "countryRank": 22
   },
   {
@@ -24383,7 +24280,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1368,
+    "aggregatedRank": 1358,
     "countryRank": 12
   },
   {
@@ -24396,7 +24293,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1369,
+    "aggregatedRank": 1359,
     "countryRank": 13
   },
   {
@@ -24409,7 +24306,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1370,
+    "aggregatedRank": 1360,
     "countryRank": 15
   },
   {
@@ -24422,7 +24319,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1371,
+    "aggregatedRank": 1361,
     "countryRank": 1
   },
   {
@@ -24435,7 +24332,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1372,
+    "aggregatedRank": 1362,
     "countryRank": 99
   },
   {
@@ -24448,7 +24345,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1373,
+    "aggregatedRank": 1363,
     "countryRank": 100
   },
   {
@@ -24461,7 +24358,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1374,
+    "aggregatedRank": 1364,
     "countryRank": 101
   },
   {
@@ -24474,7 +24371,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1375,
+    "aggregatedRank": 1365,
     "countryRank": 102
   },
   {
@@ -24487,7 +24384,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1376,
+    "aggregatedRank": 1366,
     "countryRank": 103
   },
   {
@@ -24500,7 +24397,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1377,
+    "aggregatedRank": 1367,
     "countryRank": 4
   },
   {
@@ -24513,7 +24410,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1378,
+    "aggregatedRank": 1368,
     "countryRank": 206
   },
   {
@@ -24526,7 +24423,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1379,
+    "aggregatedRank": 1369,
     "countryRank": 207
   },
   {
@@ -24539,7 +24436,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1380,
+    "aggregatedRank": 1370,
     "countryRank": 208
   },
   {
@@ -24552,7 +24449,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1381,
+    "aggregatedRank": 1371,
     "countryRank": 209
   },
   {
@@ -24565,7 +24462,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1382,
+    "aggregatedRank": 1372,
     "countryRank": 210
   },
   {
@@ -24578,7 +24475,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1383,
+    "aggregatedRank": 1373,
     "countryRank": 65
   },
   {
@@ -24591,7 +24488,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1384,
+    "aggregatedRank": 1374,
     "countryRank": 104
   },
   {
@@ -24604,7 +24501,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1385,
+    "aggregatedRank": 1375,
     "countryRank": 47
   },
   {
@@ -24617,7 +24514,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1386,
+    "aggregatedRank": 1376,
     "countryRank": 48
   },
   {
@@ -24630,7 +24527,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1387,
+    "aggregatedRank": 1377,
     "countryRank": 49
   },
   {
@@ -24643,7 +24540,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1388,
+    "aggregatedRank": 1378,
     "countryRank": 50
   },
   {
@@ -24656,7 +24553,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1389,
+    "aggregatedRank": 1379,
     "countryRank": 37
   },
   {
@@ -24669,7 +24566,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1390,
+    "aggregatedRank": 1380,
     "countryRank": 105
   },
   {
@@ -24682,7 +24579,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1391,
+    "aggregatedRank": 1381,
     "countryRank": 4
   },
   {
@@ -24695,7 +24592,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1392,
+    "aggregatedRank": 1382,
     "countryRank": 23
   },
   {
@@ -24708,7 +24605,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1393,
+    "aggregatedRank": 1383,
     "countryRank": 51
   },
   {
@@ -24721,7 +24618,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1394,
+    "aggregatedRank": 1384,
     "countryRank": 52
   },
   {
@@ -24734,7 +24631,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1395,
+    "aggregatedRank": 1385,
     "countryRank": 53
   },
   {
@@ -24747,7 +24644,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1396,
+    "aggregatedRank": 1386,
     "countryRank": 14
   },
   {
@@ -24760,7 +24657,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1397,
+    "aggregatedRank": 1387,
     "countryRank": 47
   },
   {
@@ -24773,7 +24670,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1398,
+    "aggregatedRank": 1388,
     "countryRank": 5
   },
   {
@@ -24786,7 +24683,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1399,
+    "aggregatedRank": 1389,
     "countryRank": 5
   },
   {
@@ -24799,7 +24696,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1400,
+    "aggregatedRank": 1390,
     "countryRank": 6
   },
   {
@@ -24812,7 +24709,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1401,
+    "aggregatedRank": 1391,
     "countryRank": 24
   },
   {
@@ -24825,7 +24722,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1402,
+    "aggregatedRank": 1392,
     "countryRank": 2
   },
   {
@@ -24838,7 +24735,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1403,
+    "aggregatedRank": 1393,
     "countryRank": 54
   },
   {
@@ -24851,7 +24748,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1404,
+    "aggregatedRank": 1394,
     "countryRank": 55
   },
   {
@@ -24864,7 +24761,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1405,
+    "aggregatedRank": 1395,
     "countryRank": 56
   },
   {
@@ -24877,7 +24774,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1406,
+    "aggregatedRank": 1396,
     "countryRank": 2
   },
   {
@@ -24890,7 +24787,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1407,
+    "aggregatedRank": 1397,
     "countryRank": 23
   },
   {
@@ -24903,8 +24800,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1408,
-    "countryRank": 14
+    "aggregatedRank": 1398,
+    "countryRank": 12
   },
   {
     "name": "Reichman University",
@@ -24916,7 +24813,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1409,
+    "aggregatedRank": 1399,
     "countryRank": 9
   },
   {
@@ -24929,7 +24826,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1410,
+    "aggregatedRank": 1400,
     "countryRank": 38
   },
   {
@@ -24942,7 +24839,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1411,
+    "aggregatedRank": 1401,
     "countryRank": 57
   },
   {
@@ -24955,7 +24852,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1412,
+    "aggregatedRank": 1402,
     "countryRank": 58
   },
   {
@@ -24968,8 +24865,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1413,
-    "countryRank": 79
+    "aggregatedRank": 1403,
+    "countryRank": 74
   },
   {
     "name": "Al-Farabi Kazakh National University",
@@ -24981,7 +24878,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1414,
+    "aggregatedRank": 1404,
     "countryRank": 2
   },
   {
@@ -24997,7 +24894,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1415,
+    "aggregatedRank": 1405,
     "countryRank": 48
   },
   {
@@ -25013,7 +24910,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1416,
+    "aggregatedRank": 1406,
     "countryRank": 4
   },
   {
@@ -25029,7 +24926,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1417,
+    "aggregatedRank": 1407,
     "countryRank": 27
   },
   {
@@ -25042,7 +24939,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1418,
+    "aggregatedRank": 1408,
     "countryRank": 2
   },
   {
@@ -25055,7 +24952,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1419,
+    "aggregatedRank": 1409,
     "countryRank": 2
   },
   {
@@ -25071,11 +24968,11 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1420,
+    "aggregatedRank": 1410,
     "countryRank": 5
   },
   {
-    "name": "University of Bras�lia",
+    "name": "University of Brasília",
     "country": "Brazil",
     "aggregatedScore": 116.02499999999999,
     "originalRankings": {
@@ -25087,7 +24984,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1421,
+    "aggregatedRank": 1411,
     "countryRank": 16
   },
   {
@@ -25103,7 +25000,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1422,
+    "aggregatedRank": 1412,
     "countryRank": 35
   },
   {
@@ -25116,7 +25013,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1423,
+    "aggregatedRank": 1413,
     "countryRank": 3
   },
   {
@@ -25132,7 +25029,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1424,
+    "aggregatedRank": 1414,
     "countryRank": 16
   },
   {
@@ -25145,7 +25042,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1425,
+    "aggregatedRank": 1415,
     "countryRank": 4
   },
   {
@@ -25161,7 +25058,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1426,
+    "aggregatedRank": 1416,
     "countryRank": 17
   },
   {
@@ -25177,7 +25074,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1427,
+    "aggregatedRank": 1417,
     "countryRank": 6
   },
   {
@@ -25190,7 +25087,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1428,
+    "aggregatedRank": 1418,
     "countryRank": 3
   },
   {
@@ -25206,7 +25103,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1429,
+    "aggregatedRank": 1419,
     "countryRank": 17
   },
   {
@@ -25222,11 +25119,11 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1430,
+    "aggregatedRank": 1420,
     "countryRank": 30
   },
   {
-    "name": "Pontifical Catholic University of Per�",
+    "name": "Pontifical Catholic University of Perú",
     "country": "Peru",
     "aggregatedScore": 95.4375,
     "originalRankings": {
@@ -25235,7 +25132,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1431,
+    "aggregatedRank": 1421,
     "countryRank": 1
   },
   {
@@ -25251,7 +25148,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1432,
+    "aggregatedRank": 1422,
     "countryRank": 1
   },
   {
@@ -25264,7 +25161,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1433,
+    "aggregatedRank": 1423,
     "countryRank": 3
   },
   {
@@ -25277,8 +25174,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1434,
-    "countryRank": 80
+    "aggregatedRank": 1424,
+    "countryRank": 75
   },
   {
     "name": "Belarusian State University",
@@ -25290,7 +25187,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1435,
+    "aggregatedRank": 1425,
     "countryRank": 1
   },
   {
@@ -25303,7 +25200,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1436,
+    "aggregatedRank": 1426,
     "countryRank": 4
   },
   {
@@ -25319,11 +25216,11 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1437,
+    "aggregatedRank": 1427,
     "countryRank": 2
   },
   {
-    "name": "Gda�sk University of Technology",
+    "name": "Gdañsk University of Technology",
     "country": "Poland",
     "aggregatedScore": 87.89999999999999,
     "originalRankings": {
@@ -25335,7 +25232,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1438,
+    "aggregatedRank": 1428,
     "countryRank": 6
   },
   {
@@ -25348,7 +25245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1439,
+    "aggregatedRank": 1429,
     "countryRank": 18
   },
   {
@@ -25361,7 +25258,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1440,
+    "aggregatedRank": 1430,
     "countryRank": 5
   },
   {
@@ -25374,7 +25271,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1441,
+    "aggregatedRank": 1431,
     "countryRank": 49
   },
   {
@@ -25387,7 +25284,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1442,
+    "aggregatedRank": 1432,
     "countryRank": 4
   },
   {
@@ -25403,7 +25300,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1443,
+    "aggregatedRank": 1433,
     "countryRank": 59
   },
   {
@@ -25419,7 +25316,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1444,
+    "aggregatedRank": 1434,
     "countryRank": 28
   },
   {
@@ -25435,7 +25332,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1445,
+    "aggregatedRank": 1435,
     "countryRank": 7
   },
   {
@@ -25448,7 +25345,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1446,
+    "aggregatedRank": 1436,
     "countryRank": 2
   },
   {
@@ -25461,7 +25358,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1447,
+    "aggregatedRank": 1437,
     "countryRank": 9
   },
   {
@@ -25474,7 +25371,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1448,
+    "aggregatedRank": 1438,
     "countryRank": 1
   },
   {
@@ -25487,7 +25384,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1449,
+    "aggregatedRank": 1439,
     "countryRank": 2
   },
   {
@@ -25500,7 +25397,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1450,
+    "aggregatedRank": 1440,
     "countryRank": 14
   },
   {
@@ -25513,7 +25410,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1451,
+    "aggregatedRank": 1441,
     "countryRank": 10
   },
   {
@@ -25526,11 +25423,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1452,
+    "aggregatedRank": 1442,
     "countryRank": 3
   },
   {
-    "name": "National University de C�rdoba",
+    "name": "National University de Córdoba",
     "country": "Argentina",
     "aggregatedScore": 69.14999999999999,
     "originalRankings": {
@@ -25542,7 +25439,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1453,
+    "aggregatedRank": 1443,
     "countryRank": 4
   },
   {
@@ -25558,7 +25455,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1454,
+    "aggregatedRank": 1444,
     "countryRank": 29
   },
   {
@@ -25571,7 +25468,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1455,
+    "aggregatedRank": 1445,
     "countryRank": 60
   },
   {
@@ -25584,7 +25481,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1456,
+    "aggregatedRank": 1446,
     "countryRank": 5
   },
   {
@@ -25597,7 +25494,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1457,
+    "aggregatedRank": 1447,
     "countryRank": 30
   },
   {
@@ -25610,7 +25507,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1458,
+    "aggregatedRank": 1448,
     "countryRank": 2
   },
   {
@@ -25623,7 +25520,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1459,
+    "aggregatedRank": 1449,
     "countryRank": 50
   },
   {
@@ -25636,7 +25533,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1460,
+    "aggregatedRank": 1450,
     "countryRank": 4
   },
   {
@@ -25649,7 +25546,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1461,
+    "aggregatedRank": 1451,
     "countryRank": 21
   },
   {
@@ -25662,11 +25559,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1462,
+    "aggregatedRank": 1452,
     "countryRank": 7
   },
   {
-    "name": "University Adolfo Ib��ez",
+    "name": "University Adolfo Ibáñez",
     "country": "Chile",
     "aggregatedScore": 61.53124999999999,
     "originalRankings": {
@@ -25675,7 +25572,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1463,
+    "aggregatedRank": 1453,
     "countryRank": 5
   },
   {
@@ -25688,7 +25585,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1464,
+    "aggregatedRank": 1454,
     "countryRank": 6
   },
   {
@@ -25701,7 +25598,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1465,
+    "aggregatedRank": 1455,
     "countryRank": 15
   },
   {
@@ -25717,7 +25614,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1466,
+    "aggregatedRank": 1456,
     "countryRank": 51
   },
   {
@@ -25733,7 +25630,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1467,
+    "aggregatedRank": 1457,
     "countryRank": 31
   },
   {
@@ -25749,7 +25646,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1468,
+    "aggregatedRank": 1458,
     "countryRank": 8
   },
   {
@@ -25762,7 +25659,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1469,
+    "aggregatedRank": 1459,
     "countryRank": 7
   },
   {
@@ -25775,7 +25672,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1470,
+    "aggregatedRank": 1460,
     "countryRank": 5
   },
   {
@@ -25788,7 +25685,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1471,
+    "aggregatedRank": 1461,
     "countryRank": 19
   },
   {
@@ -25801,7 +25698,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1472,
+    "aggregatedRank": 1462,
     "countryRank": 16
   },
   {
@@ -25814,7 +25711,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1473,
+    "aggregatedRank": 1463,
     "countryRank": 6
   },
   {
@@ -25827,7 +25724,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1474,
+    "aggregatedRank": 1464,
     "countryRank": 11
   },
   {
@@ -25840,7 +25737,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1475,
+    "aggregatedRank": 1465,
     "countryRank": 5
   },
   {
@@ -25853,7 +25750,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1476,
+    "aggregatedRank": 1466,
     "countryRank": 22
   },
   {
@@ -25866,7 +25763,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1477,
+    "aggregatedRank": 1467,
     "countryRank": 211
   },
   {
@@ -25879,7 +25776,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1478,
+    "aggregatedRank": 1468,
     "countryRank": 32
   },
   {
@@ -25892,7 +25789,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1479,
+    "aggregatedRank": 1469,
     "countryRank": 3
   },
   {
@@ -25908,7 +25805,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1480,
+    "aggregatedRank": 1470,
     "countryRank": 33
   },
   {
@@ -25924,7 +25821,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1481,
+    "aggregatedRank": 1471,
     "countryRank": 9
   },
   {
@@ -25937,7 +25834,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1482,
+    "aggregatedRank": 1472,
     "countryRank": 31
   },
   {
@@ -25950,7 +25847,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1483,
+    "aggregatedRank": 1473,
     "countryRank": 212
   },
   {
@@ -25963,7 +25860,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1484,
+    "aggregatedRank": 1474,
     "countryRank": 1
   },
   {
@@ -25976,7 +25873,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1485,
+    "aggregatedRank": 1475,
     "countryRank": 17
   },
   {
@@ -25989,7 +25886,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1486,
+    "aggregatedRank": 1476,
     "countryRank": 1
   },
   {
@@ -26002,7 +25899,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1487,
+    "aggregatedRank": 1477,
     "countryRank": 6
   },
   {
@@ -26015,7 +25912,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1488,
+    "aggregatedRank": 1478,
     "countryRank": 7
   },
   {
@@ -26028,7 +25925,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1489,
+    "aggregatedRank": 1479,
     "countryRank": 61
   },
   {
@@ -26041,7 +25938,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1490,
+    "aggregatedRank": 1480,
     "countryRank": 1
   },
   {
@@ -26054,7 +25951,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1491,
+    "aggregatedRank": 1481,
     "countryRank": 5
   },
   {
@@ -26067,7 +25964,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1492,
+    "aggregatedRank": 1482,
     "countryRank": 1
   },
   {
@@ -26080,7 +25977,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1493,
+    "aggregatedRank": 1483,
     "countryRank": 25
   },
   {
@@ -26096,7 +25993,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1494,
+    "aggregatedRank": 1484,
     "countryRank": 34
   },
   {
@@ -26112,7 +26009,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1495,
+    "aggregatedRank": 1485,
     "countryRank": 32
   },
   {
@@ -26125,11 +26022,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1496,
+    "aggregatedRank": 1486,
     "countryRank": 3
   },
   {
-    "name": "University of Franche-Comt�",
+    "name": "University of Franche-Comté",
     "country": "France",
     "aggregatedScore": 40.43749999999999,
     "originalRankings": {
@@ -26138,8 +26035,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1497,
-    "countryRank": 55
+    "aggregatedRank": 1487,
+    "countryRank": 53
   },
   {
     "name": "Lingnan University",
@@ -26151,7 +26048,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1498,
+    "aggregatedRank": 1488,
     "countryRank": 8
   },
   {
@@ -26164,7 +26061,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1499,
+    "aggregatedRank": 1489,
     "countryRank": 62
   },
   {
@@ -26177,7 +26074,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1500,
+    "aggregatedRank": 1490,
     "countryRank": 23
   },
   {
@@ -26190,7 +26087,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1501,
+    "aggregatedRank": 1491,
     "countryRank": 5
   },
   {
@@ -26203,7 +26100,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1502,
+    "aggregatedRank": 1492,
     "countryRank": 8
   },
   {
@@ -26216,7 +26113,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1503,
+    "aggregatedRank": 1493,
     "countryRank": 63
   },
   {
@@ -26229,7 +26126,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1504,
+    "aggregatedRank": 1494,
     "countryRank": 1
   },
   {
@@ -26242,7 +26139,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1505,
+    "aggregatedRank": 1495,
     "countryRank": 24
   },
   {
@@ -26255,7 +26152,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1506,
+    "aggregatedRank": 1496,
     "countryRank": 3
   },
   {
@@ -26268,7 +26165,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1507,
+    "aggregatedRank": 1497,
     "countryRank": 24
   },
   {
@@ -26281,7 +26178,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1508,
+    "aggregatedRank": 1498,
     "countryRank": 2
   },
   {
@@ -26294,7 +26191,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1509,
+    "aggregatedRank": 1499,
     "countryRank": 2
   },
   {
@@ -26307,7 +26204,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1510,
+    "aggregatedRank": 1500,
     "countryRank": 3
   },
   {
@@ -26320,11 +26217,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1511,
+    "aggregatedRank": 1501,
     "countryRank": 4
   },
   {
-    "name": "M�xico Autonomous Institute of Technology",
+    "name": "México Autonomous Institute of Technology",
     "country": "Mexico",
     "aggregatedScore": 34.18749999999999,
     "originalRankings": {
@@ -26333,7 +26230,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1512,
+    "aggregatedRank": 1502,
     "countryRank": 6
   },
   {
@@ -26346,7 +26243,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1513,
+    "aggregatedRank": 1503,
     "countryRank": 213
   },
   {
@@ -26359,7 +26256,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1514,
+    "aggregatedRank": 1504,
     "countryRank": 7
   },
   {
@@ -26372,7 +26269,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1515,
+    "aggregatedRank": 1505,
     "countryRank": 4
   },
   {
@@ -26385,7 +26282,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1516,
+    "aggregatedRank": 1506,
     "countryRank": 7
   },
   {
@@ -26398,7 +26295,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1517,
+    "aggregatedRank": 1507,
     "countryRank": 6
   },
   {
@@ -26411,7 +26308,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1518,
+    "aggregatedRank": 1508,
     "countryRank": 7
   },
   {
@@ -26424,7 +26321,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1519,
+    "aggregatedRank": 1509,
     "countryRank": 2
   },
   {
@@ -26437,7 +26334,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1520,
+    "aggregatedRank": 1510,
     "countryRank": 6
   },
   {
@@ -26450,7 +26347,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1521,
+    "aggregatedRank": 1511,
     "countryRank": 2
   },
   {
@@ -26463,7 +26360,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1522,
+    "aggregatedRank": 1512,
     "countryRank": 214
   },
   {
@@ -26476,11 +26373,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1523,
+    "aggregatedRank": 1513,
     "countryRank": 13
   },
   {
-    "name": "University of Antioqu�a",
+    "name": "University of Antioquía",
     "country": "Colombia",
     "aggregatedScore": 27.937499999999993,
     "originalRankings": {
@@ -26489,7 +26386,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1524,
+    "aggregatedRank": 1514,
     "countryRank": 5
   },
   {
@@ -26502,7 +26399,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1525,
+    "aggregatedRank": 1515,
     "countryRank": 1
   },
   {
@@ -26515,7 +26412,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1526,
+    "aggregatedRank": 1516,
     "countryRank": 6
   },
   {
@@ -26528,7 +26425,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1527,
+    "aggregatedRank": 1517,
     "countryRank": 2
   },
   {
@@ -26541,7 +26438,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1528,
+    "aggregatedRank": 1518,
     "countryRank": 64
   },
   {
@@ -26554,11 +26451,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1529,
+    "aggregatedRank": 1519,
     "countryRank": 2
   },
   {
-    "name": "An�huac University",
+    "name": "Anáhuac University",
     "country": "Mexico",
     "aggregatedScore": 26.374999999999993,
     "originalRankings": {
@@ -26567,7 +26464,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1530,
+    "aggregatedRank": 1520,
     "countryRank": 8
   },
   {
@@ -26580,7 +26477,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1531,
+    "aggregatedRank": 1521,
     "countryRank": 18
   },
   {
@@ -26593,7 +26490,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1532,
+    "aggregatedRank": 1522,
     "countryRank": 4
   },
   {
@@ -26606,7 +26503,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1533,
+    "aggregatedRank": 1523,
     "countryRank": 9
   },
   {
@@ -26619,7 +26516,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1534,
+    "aggregatedRank": 1524,
     "countryRank": 9
   },
   {
@@ -26632,7 +26529,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1535,
+    "aggregatedRank": 1525,
     "countryRank": 1
   },
   {
@@ -26645,7 +26542,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1536,
+    "aggregatedRank": 1526,
     "countryRank": 2
   },
   {
@@ -26658,7 +26555,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1537,
+    "aggregatedRank": 1527,
     "countryRank": 25
   },
   {
@@ -26671,7 +26568,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1538,
+    "aggregatedRank": 1528,
     "countryRank": 8
   },
   {
@@ -26684,7 +26581,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1539,
+    "aggregatedRank": 1529,
     "countryRank": 1
   },
   {
@@ -26697,7 +26594,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1540,
+    "aggregatedRank": 1530,
     "countryRank": 12
   },
   {
@@ -26710,7 +26607,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1541,
+    "aggregatedRank": 1531,
     "countryRank": 8
   },
   {
@@ -26723,7 +26620,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1542,
+    "aggregatedRank": 1532,
     "countryRank": 1
   },
   {
@@ -26736,7 +26633,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1543,
+    "aggregatedRank": 1533,
     "countryRank": 3
   },
   {
@@ -26749,7 +26646,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1544,
+    "aggregatedRank": 1534,
     "countryRank": 9
   },
   {
@@ -26762,7 +26659,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1545,
+    "aggregatedRank": 1535,
     "countryRank": 5
   },
   {
@@ -26775,7 +26672,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1546,
+    "aggregatedRank": 1536,
     "countryRank": 4
   },
   {
@@ -26788,7 +26685,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1547,
+    "aggregatedRank": 1537,
     "countryRank": 10
   },
   {
@@ -26801,7 +26698,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1548,
+    "aggregatedRank": 1538,
     "countryRank": 11
   },
   {
@@ -26814,7 +26711,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1549,
+    "aggregatedRank": 1539,
     "countryRank": 2
   },
   {
@@ -26827,7 +26724,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1550,
+    "aggregatedRank": 1540,
     "countryRank": 3
   },
   {
@@ -26840,7 +26737,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1551,
+    "aggregatedRank": 1541,
     "countryRank": 215
   },
   {
@@ -26853,7 +26750,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1552,
+    "aggregatedRank": 1542,
     "countryRank": 216
   },
   {
@@ -26866,7 +26763,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1553,
+    "aggregatedRank": 1543,
     "countryRank": 5
   },
   {
@@ -26879,7 +26776,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1554,
+    "aggregatedRank": 1544,
     "countryRank": 9
   },
   {
@@ -26892,7 +26789,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1555,
+    "aggregatedRank": 1545,
     "countryRank": 12
   },
   {
@@ -26905,7 +26802,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1556,
+    "aggregatedRank": 1546,
     "countryRank": 217
   },
   {
@@ -26918,7 +26815,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1557,
+    "aggregatedRank": 1547,
     "countryRank": 218
   },
   {
@@ -26931,7 +26828,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1558,
+    "aggregatedRank": 1548,
     "countryRank": 153
   },
   {
@@ -26944,7 +26841,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1559,
+    "aggregatedRank": 1549,
     "countryRank": 1
   },
   {
@@ -26957,7 +26854,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1560,
+    "aggregatedRank": 1550,
     "countryRank": 6
   },
   {
@@ -26970,7 +26867,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1561,
+    "aggregatedRank": 1551,
     "countryRank": 7
   },
   {
@@ -26983,11 +26880,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1562,
+    "aggregatedRank": 1552,
     "countryRank": 2
   },
   {
-    "name": "University Panth�on-Assas (Paris II)",
+    "name": "University Panthéon-Assas (Paris II)",
     "country": "France",
     "aggregatedScore": 10.749999999999993,
     "originalRankings": {
@@ -26996,8 +26893,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1563,
-    "countryRank": 56
+    "aggregatedRank": 1553,
+    "countryRank": 54
   },
   {
     "name": "Georgian Technical University",
@@ -27009,7 +26906,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1564,
+    "aggregatedRank": 1554,
     "countryRank": 2
   },
   {
@@ -27022,7 +26919,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1565,
+    "aggregatedRank": 1555,
     "countryRank": 6
   },
   {
@@ -27035,7 +26932,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1566,
+    "aggregatedRank": 1556,
     "countryRank": 7
   },
   {
@@ -27048,7 +26945,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1567,
+    "aggregatedRank": 1557,
     "countryRank": 35
   },
   {
@@ -27061,7 +26958,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1568,
+    "aggregatedRank": 1558,
     "countryRank": 2
   },
   {
@@ -27074,7 +26971,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1569,
+    "aggregatedRank": 1559,
     "countryRank": 10
   },
   {
@@ -27087,7 +26984,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1570,
+    "aggregatedRank": 1560,
     "countryRank": 2
   },
   {
@@ -27100,7 +26997,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1571,
+    "aggregatedRank": 1561,
     "countryRank": 13
   },
   {
@@ -27113,7 +27010,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1572,
+    "aggregatedRank": 1562,
     "countryRank": 26
   },
   {
@@ -27126,7 +27023,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1573,
+    "aggregatedRank": 1563,
     "countryRank": 3
   },
   {
@@ -27139,7 +27036,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1574,
+    "aggregatedRank": 1564,
     "countryRank": 15
   },
   {
@@ -27152,7 +27049,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1575,
+    "aggregatedRank": 1565,
     "countryRank": 106
   },
   {
@@ -27165,7 +27062,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1576,
+    "aggregatedRank": 1566,
     "countryRank": 4
   },
   {
@@ -27178,7 +27075,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1577,
+    "aggregatedRank": 1567,
     "countryRank": 14
   },
   {
@@ -27191,7 +27088,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1578,
+    "aggregatedRank": 1568,
     "countryRank": 6
   },
   {
@@ -27204,7 +27101,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1579,
+    "aggregatedRank": 1569,
     "countryRank": 8
   },
   {
@@ -27217,7 +27114,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1580,
+    "aggregatedRank": 1570,
     "countryRank": 11
   },
   {
@@ -27230,7 +27127,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1581,
+    "aggregatedRank": 1571,
     "countryRank": 27
   },
   {
@@ -27243,7 +27140,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1582,
+    "aggregatedRank": 1572,
     "countryRank": 7
   },
   {
@@ -27256,7 +27153,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1583,
+    "aggregatedRank": 1573,
     "countryRank": 8
   },
   {
@@ -27269,7 +27166,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1584,
+    "aggregatedRank": 1574,
     "countryRank": 9
   },
   {
@@ -27282,7 +27179,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1585,
+    "aggregatedRank": 1575,
     "countryRank": 10
   },
   {
@@ -27295,7 +27192,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1586,
+    "aggregatedRank": 1576,
     "countryRank": 1
   },
   {
@@ -27308,11 +27205,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1587,
+    "aggregatedRank": 1577,
     "countryRank": 4
   },
   {
-    "name": "Federico Santa Mar�a Technical University",
+    "name": "Federico Santa María Technical University",
     "country": "Chile",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
@@ -27321,7 +27218,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1588,
+    "aggregatedRank": 1578,
     "countryRank": 7
   },
   {
@@ -27334,7 +27231,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1589,
+    "aggregatedRank": 1579,
     "countryRank": 8
   },
   {
@@ -27347,7 +27244,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1590,
+    "aggregatedRank": 1580,
     "countryRank": 9
   },
   {
@@ -27360,7 +27257,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1591,
+    "aggregatedRank": 1581,
     "countryRank": 9
   },
   {
@@ -27373,11 +27270,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1592,
+    "aggregatedRank": 1582,
     "countryRank": 3
   },
   {
-    "name": "University of Le�n",
+    "name": "University of León",
     "country": "Spain",
     "aggregatedScore": 2.937499999999993,
     "originalRankings": {
@@ -27386,7 +27283,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1593,
+    "aggregatedRank": 1583,
     "countryRank": 52
   },
   {
@@ -27399,8 +27296,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1594,
-    "countryRank": 57
+    "aggregatedRank": 1584,
+    "countryRank": 55
   },
   {
     "name": "Athens University of Economics and Business",
@@ -27412,7 +27309,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1595,
+    "aggregatedRank": 1585,
     "countryRank": 8
   },
   {
@@ -27425,7 +27322,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1596,
+    "aggregatedRank": 1586,
     "countryRank": 10
   },
   {
@@ -27438,7 +27335,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1597,
+    "aggregatedRank": 1587,
     "countryRank": 8
   },
   {
@@ -27451,7 +27348,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1598,
+    "aggregatedRank": 1588,
     "countryRank": 36
   },
   {
@@ -27464,7 +27361,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1599,
+    "aggregatedRank": 1589,
     "countryRank": 37
   },
   {
@@ -27477,7 +27374,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1600,
+    "aggregatedRank": 1590,
     "countryRank": 1
   },
   {
@@ -27490,7 +27387,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1601,
+    "aggregatedRank": 1591,
     "countryRank": 10
   },
   {
@@ -27503,7 +27400,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1602,
+    "aggregatedRank": 1592,
     "countryRank": 7
   },
   {
@@ -27516,7 +27413,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1603,
+    "aggregatedRank": 1593,
     "countryRank": 8
   },
   {
@@ -27529,7 +27426,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1604,
+    "aggregatedRank": 1594,
     "countryRank": 10
   },
   {
@@ -27542,7 +27439,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1605,
+    "aggregatedRank": 1595,
     "countryRank": 28
   },
   {
@@ -27555,7 +27452,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1606,
+    "aggregatedRank": 1596,
     "countryRank": 3
   },
   {
@@ -27568,7 +27465,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1607,
+    "aggregatedRank": 1597,
     "countryRank": 65
   },
   {
@@ -27581,7 +27478,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1608,
+    "aggregatedRank": 1598,
     "countryRank": 12
   },
   {
@@ -27594,7 +27491,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1609,
+    "aggregatedRank": 1599,
     "countryRank": 154
   },
   {
@@ -27607,7 +27504,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1610,
+    "aggregatedRank": 1600,
     "countryRank": 155
   },
   {
@@ -27620,8 +27517,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1611,
-    "countryRank": 81
+    "aggregatedRank": 1601,
+    "countryRank": 76
   },
   {
     "name": "The Graduate Center - CUNY",
@@ -27633,7 +27530,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1612,
+    "aggregatedRank": 1602,
     "countryRank": 219
   },
   {
@@ -27646,7 +27543,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1613,
+    "aggregatedRank": 1603,
     "countryRank": 156
   },
   {
@@ -27659,7 +27556,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1614,
+    "aggregatedRank": 1604,
     "countryRank": 157
   },
   {
@@ -27672,7 +27569,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1615,
+    "aggregatedRank": 1605,
     "countryRank": 158
   },
   {
@@ -27685,7 +27582,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1616,
+    "aggregatedRank": 1606,
     "countryRank": 159
   },
   {
@@ -27698,7 +27595,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1617,
+    "aggregatedRank": 1607,
     "countryRank": 160
   },
   {
@@ -27711,7 +27608,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1618,
+    "aggregatedRank": 1608,
     "countryRank": 161
   },
   {
@@ -27724,7 +27621,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1619,
+    "aggregatedRank": 1609,
     "countryRank": 162
   },
   {
@@ -27737,7 +27634,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1620,
+    "aggregatedRank": 1610,
     "countryRank": 163
   },
   {
@@ -27750,7 +27647,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1621,
+    "aggregatedRank": 1611,
     "countryRank": 164
   },
   {
@@ -27763,7 +27660,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1622,
+    "aggregatedRank": 1612,
     "countryRank": 53
   },
   {
@@ -27776,7 +27673,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1623,
+    "aggregatedRank": 1613,
     "countryRank": 12
   },
   {
@@ -27789,7 +27686,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1624,
+    "aggregatedRank": 1614,
     "countryRank": 220
   },
   {
@@ -27802,7 +27699,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1625,
+    "aggregatedRank": 1615,
     "countryRank": 165
   },
   {
@@ -27815,7 +27712,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1626,
+    "aggregatedRank": 1616,
     "countryRank": 166
   },
   {
@@ -27828,7 +27725,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1627,
+    "aggregatedRank": 1617,
     "countryRank": 167
   },
   {
@@ -27841,7 +27738,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1628,
+    "aggregatedRank": 1618,
     "countryRank": 168
   },
   {
@@ -27854,7 +27751,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1629,
+    "aggregatedRank": 1619,
     "countryRank": 169
   },
   {
@@ -27867,7 +27764,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1630,
+    "aggregatedRank": 1620,
     "countryRank": 170
   },
   {
@@ -27880,7 +27777,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1631,
+    "aggregatedRank": 1621,
     "countryRank": 171
   },
   {
@@ -27893,7 +27790,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1632,
+    "aggregatedRank": 1622,
     "countryRank": 172
   },
   {
@@ -27906,7 +27803,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1633,
+    "aggregatedRank": 1623,
     "countryRank": 173
   },
   {
@@ -27919,7 +27816,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1634,
+    "aggregatedRank": 1624,
     "countryRank": 174
   },
   {
@@ -27932,7 +27829,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1635,
+    "aggregatedRank": 1625,
     "countryRank": 175
   },
   {
@@ -27945,7 +27842,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1636,
+    "aggregatedRank": 1626,
     "countryRank": 176
   },
   {
@@ -27958,7 +27855,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1637,
+    "aggregatedRank": 1627,
     "countryRank": 38
   },
   {
@@ -27971,7 +27868,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1638,
+    "aggregatedRank": 1628,
     "countryRank": 221
   },
   {
@@ -27984,7 +27881,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1639,
+    "aggregatedRank": 1629,
     "countryRank": 19
   },
   {
@@ -27997,7 +27894,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1640,
+    "aggregatedRank": 1630,
     "countryRank": 177
   },
   {
@@ -28010,7 +27907,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1641,
+    "aggregatedRank": 1631,
     "countryRank": 178
   },
   {
@@ -28023,7 +27920,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1642,
+    "aggregatedRank": 1632,
     "countryRank": 5
   },
   {
@@ -28036,7 +27933,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1643,
+    "aggregatedRank": 1633,
     "countryRank": 179
   },
   {
@@ -28049,7 +27946,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1644,
+    "aggregatedRank": 1634,
     "countryRank": 180
   },
   {
@@ -28062,7 +27959,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1645,
+    "aggregatedRank": 1635,
     "countryRank": 181
   },
   {
@@ -28075,7 +27972,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1646,
+    "aggregatedRank": 1636,
     "countryRank": 16
   },
   {
@@ -28088,11 +27985,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1647,
+    "aggregatedRank": 1637,
     "countryRank": 18
   },
   {
-    "name": "Federal University of Paran�",
+    "name": "Federal University of Paraná",
     "country": "Brazil",
     "aggregatedScore": -44.453125,
     "originalRankings": {
@@ -28101,7 +27998,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1648,
+    "aggregatedRank": 1638,
     "countryRank": 19
   },
   {
@@ -28114,7 +28011,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1649,
+    "aggregatedRank": 1639,
     "countryRank": 182
   },
   {
@@ -28127,7 +28024,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1650,
+    "aggregatedRank": 1640,
     "countryRank": 183
   },
   {
@@ -28140,7 +28037,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1651,
+    "aggregatedRank": 1641,
     "countryRank": 184
   },
   {
@@ -28153,7 +28050,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1652,
+    "aggregatedRank": 1642,
     "countryRank": 185
   },
   {
@@ -28166,8 +28063,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1653,
-    "countryRank": 82
+    "aggregatedRank": 1643,
+    "countryRank": 77
   },
   {
     "name": "University of Magdeburg",
@@ -28179,8 +28076,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1654,
-    "countryRank": 83
+    "aggregatedRank": 1644,
+    "countryRank": 78
   },
   {
     "name": "University of Augsburg",
@@ -28192,8 +28089,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1655,
-    "countryRank": 84
+    "aggregatedRank": 1645,
+    "countryRank": 79
   },
   {
     "name": "University of Extremadura",
@@ -28205,11 +28102,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1656,
+    "aggregatedRank": 1646,
     "countryRank": 54
   },
   {
-    "name": "University of M�laga",
+    "name": "University of Málaga",
     "country": "Spain",
     "aggregatedScore": -44.453125,
     "originalRankings": {
@@ -28218,7 +28115,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1657,
+    "aggregatedRank": 1647,
     "countryRank": 55
   },
   {
@@ -28231,7 +28128,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1658,
+    "aggregatedRank": 1648,
     "countryRank": 39
   },
   {
@@ -28244,7 +28141,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1659,
+    "aggregatedRank": 1649,
     "countryRank": 40
   },
   {
@@ -28257,7 +28154,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1660,
+    "aggregatedRank": 1650,
     "countryRank": 33
   },
   {
@@ -28270,7 +28167,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1661,
+    "aggregatedRank": 1651,
     "countryRank": 15
   },
   {
@@ -28283,8 +28180,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1662,
+    "aggregatedRank": 1652,
     "countryRank": 222
+  },
+  {
+    "name": "University Paris-Est Créteil Val de Marne",
+    "country": "France",
+    "aggregatedScore": -44.453125,
+    "originalRankings": {
+      "arwu": {
+        "rank": 701
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 1653,
+    "countryRank": 56
   },
   {
     "name": "Army Medical University",
@@ -28296,7 +28206,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1663,
+    "aggregatedRank": 1654,
     "countryRank": 186
   },
   {
@@ -28309,7 +28219,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1664,
+    "aggregatedRank": 1655,
     "countryRank": 187
   },
   {
@@ -28322,7 +28232,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1665,
+    "aggregatedRank": 1656,
     "countryRank": 188
   },
   {
@@ -28335,7 +28245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1666,
+    "aggregatedRank": 1657,
     "countryRank": 66
   },
   {
@@ -28348,11 +28258,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1667,
+    "aggregatedRank": 1658,
     "countryRank": 189
   },
   {
-    "name": "Federal University of S�o Carlos",
+    "name": "Federal University of São Carlos",
     "country": "Brazil",
     "aggregatedScore": -60.078125,
     "originalRankings": {
@@ -28361,11 +28271,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1668,
+    "aggregatedRank": 1659,
     "countryRank": 20
   },
   {
-    "name": "Federal University of Vi�osa",
+    "name": "Federal University of Viçosa",
     "country": "Brazil",
     "aggregatedScore": -60.078125,
     "originalRankings": {
@@ -28374,21 +28284,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1669,
+    "aggregatedRank": 1660,
     "countryRank": 21
-  },
-  {
-    "name": "University of Qu�bec at Montreal",
-    "country": "Canada",
-    "aggregatedScore": -60.078125,
-    "originalRankings": {
-      "arwu": {
-        "rank": 801
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1670,
-    "countryRank": 36
   },
   {
     "name": "Capital Normal University",
@@ -28400,7 +28297,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1671,
+    "aggregatedRank": 1661,
     "countryRank": 190
   },
   {
@@ -28413,7 +28310,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1672,
+    "aggregatedRank": 1662,
     "countryRank": 191
   },
   {
@@ -28426,7 +28323,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1673,
+    "aggregatedRank": 1663,
     "countryRank": 192
   },
   {
@@ -28439,7 +28336,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1674,
+    "aggregatedRank": 1664,
     "countryRank": 193
   },
   {
@@ -28452,7 +28349,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1675,
+    "aggregatedRank": 1665,
     "countryRank": 194
   },
   {
@@ -28465,7 +28362,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1676,
+    "aggregatedRank": 1666,
     "countryRank": 195
   },
   {
@@ -28478,7 +28375,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1677,
+    "aggregatedRank": 1667,
     "countryRank": 196
   },
   {
@@ -28491,7 +28388,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1678,
+    "aggregatedRank": 1668,
     "countryRank": 197
   },
   {
@@ -28504,8 +28401,21 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1679,
-    "countryRank": 85
+    "aggregatedRank": 1669,
+    "countryRank": 80
+  },
+  {
+    "name": "Institut National des Sciences Appliquées de Toulouse",
+    "country": "France",
+    "aggregatedScore": -60.078125,
+    "originalRankings": {
+      "arwu": {
+        "rank": 801
+      }
+    },
+    "appearances": 1,
+    "aggregatedRank": 1670,
+    "countryRank": 57
   },
   {
     "name": "University of Burgundy",
@@ -28517,7 +28427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1680,
+    "aggregatedRank": 1671,
     "countryRank": 58
   },
   {
@@ -28530,7 +28440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1681,
+    "aggregatedRank": 1672,
     "countryRank": 34
   },
   {
@@ -28543,7 +28453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1682,
+    "aggregatedRank": 1673,
     "countryRank": 198
   },
   {
@@ -28556,7 +28466,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1683,
+    "aggregatedRank": 1674,
     "countryRank": 199
   },
   {
@@ -28569,7 +28479,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1684,
+    "aggregatedRank": 1675,
     "countryRank": 200
   },
   {
@@ -28582,7 +28492,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1685,
+    "aggregatedRank": 1676,
     "countryRank": 201
   },
   {
@@ -28595,7 +28505,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1686,
+    "aggregatedRank": 1677,
     "countryRank": 202
   },
   {
@@ -28608,7 +28518,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1687,
+    "aggregatedRank": 1678,
     "countryRank": 203
   },
   {
@@ -28621,7 +28531,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1688,
+    "aggregatedRank": 1679,
     "countryRank": 17
   },
   {
@@ -28634,7 +28544,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1689,
+    "aggregatedRank": 1680,
     "countryRank": 223
   },
   {
@@ -28647,11 +28557,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1690,
+    "aggregatedRank": 1681,
     "countryRank": 22
   },
   {
-    "name": "Federal University of Goi�s",
+    "name": "Federal University of Goiás",
     "country": "Brazil",
     "aggregatedScore": -75.703125,
     "originalRankings": {
@@ -28660,7 +28570,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1691,
+    "aggregatedRank": 1682,
     "countryRank": 23
   },
   {
@@ -28673,7 +28583,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1692,
+    "aggregatedRank": 1683,
     "countryRank": 24
   },
   {
@@ -28686,11 +28596,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1693,
+    "aggregatedRank": 1684,
     "countryRank": 25
   },
   {
-    "name": "Federal University of Cear�",
+    "name": "Federal University of Ceará",
     "country": "Brazil",
     "aggregatedScore": -75.703125,
     "originalRankings": {
@@ -28699,7 +28609,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1694,
+    "aggregatedRank": 1685,
     "countryRank": 26
   },
   {
@@ -28712,11 +28622,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1695,
-    "countryRank": 37
+    "aggregatedRank": 1686,
+    "countryRank": 36
   },
   {
-    "name": "National University Andr�s Bello",
+    "name": "National University Andrés Bello",
     "country": "Chile",
     "aggregatedScore": -75.703125,
     "originalRankings": {
@@ -28725,7 +28635,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1696,
+    "aggregatedRank": 1687,
     "countryRank": 9
   },
   {
@@ -28738,7 +28648,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1697,
+    "aggregatedRank": 1688,
     "countryRank": 204
   },
   {
@@ -28751,7 +28661,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1698,
+    "aggregatedRank": 1689,
     "countryRank": 205
   },
   {
@@ -28764,7 +28674,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1699,
+    "aggregatedRank": 1690,
     "countryRank": 206
   },
   {
@@ -28777,7 +28687,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1700,
+    "aggregatedRank": 1691,
     "countryRank": 207
   },
   {
@@ -28790,7 +28700,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1701,
+    "aggregatedRank": 1692,
     "countryRank": 208
   },
   {
@@ -28803,7 +28713,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1702,
+    "aggregatedRank": 1693,
     "countryRank": 209
   },
   {
@@ -28816,7 +28726,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1703,
+    "aggregatedRank": 1694,
     "countryRank": 210
   },
   {
@@ -28829,7 +28739,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1704,
+    "aggregatedRank": 1695,
     "countryRank": 211
   },
   {
@@ -28842,7 +28752,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1705,
+    "aggregatedRank": 1696,
     "countryRank": 212
   },
   {
@@ -28855,11 +28765,11 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1706,
+    "aggregatedRank": 1697,
     "countryRank": 56
   },
   {
-    "name": "University of C�diz",
+    "name": "University of Cádiz",
     "country": "Spain",
     "aggregatedScore": -75.703125,
     "originalRankings": {
@@ -28868,7 +28778,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1707,
+    "aggregatedRank": 1698,
     "countryRank": 57
   },
   {
@@ -28881,7 +28791,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1708,
+    "aggregatedRank": 1699,
     "countryRank": 59
   },
   {
@@ -28894,7 +28804,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1709,
+    "aggregatedRank": 1700,
     "countryRank": 41
   },
   {
@@ -28907,7 +28817,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1710,
+    "aggregatedRank": 1701,
     "countryRank": 35
   },
   {
@@ -28920,7 +28830,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1711,
+    "aggregatedRank": 1702,
     "countryRank": 18
   },
   {
@@ -28933,7 +28843,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1712,
+    "aggregatedRank": 1703,
     "countryRank": 19
   },
   {
@@ -28946,7 +28856,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1713,
+    "aggregatedRank": 1704,
     "countryRank": 224
   },
   {
@@ -28959,7 +28869,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1714,
+    "aggregatedRank": 1705,
     "countryRank": 225
   },
   {
@@ -28972,7 +28882,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1715,
+    "aggregatedRank": 1706,
     "countryRank": 226
   },
   {
@@ -28985,7 +28895,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1716,
+    "aggregatedRank": 1707,
     "countryRank": 227
   },
   {
@@ -28998,7 +28908,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1717,
+    "aggregatedRank": 1708,
     "countryRank": 213
   },
   {
@@ -29011,7 +28921,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1718,
+    "aggregatedRank": 1709,
     "countryRank": 2
   },
   {
@@ -29024,7 +28934,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1719,
+    "aggregatedRank": 1710,
     "countryRank": 228
   },
   {
@@ -29037,7 +28947,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1720,
+    "aggregatedRank": 1711,
     "countryRank": 214
   },
   {
@@ -29050,7 +28960,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1721,
+    "aggregatedRank": 1712,
     "countryRank": 215
   },
   {
@@ -29063,7 +28973,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1722,
+    "aggregatedRank": 1713,
     "countryRank": 16
   },
   {
@@ -29076,7 +28986,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1723,
+    "aggregatedRank": 1714,
     "countryRank": 216
   },
   {
@@ -29089,7 +28999,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1724,
+    "aggregatedRank": 1715,
     "countryRank": 217
   },
   {
@@ -29102,7 +29012,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1725,
+    "aggregatedRank": 1716,
     "countryRank": 218
   },
   {
@@ -29115,7 +29025,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1726,
+    "aggregatedRank": 1717,
     "countryRank": 219
   },
   {
@@ -29128,7 +29038,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1727,
+    "aggregatedRank": 1718,
     "countryRank": 220
   },
   {
@@ -29141,7 +29051,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1728,
+    "aggregatedRank": 1719,
     "countryRank": 221
   },
   {
@@ -29154,7 +29064,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1729,
+    "aggregatedRank": 1720,
     "countryRank": 222
   }
 ]

--- a/scripts/arwu-scraper.js
+++ b/scripts/arwu-scraper.js
@@ -61,7 +61,7 @@ async function scrapeARWURankings(limit) {
 
         // --- Start of parsing logic with csv-parser ---
         await new Promise((resolve, reject) => {
-            fs.createReadStream(ARWU_FILE_PATH)
+            fs.createReadStream(ARWU_FILE_PATH, { encoding: 'latin1' })
                 .pipe(csv({
                     // Explicitly define headers as found in the CSV file (line 5)
                     headers: ['# World Rank', ' Institution', ' Country'], 

--- a/scripts/qs-scraper.js
+++ b/scripts/qs-scraper.js
@@ -37,7 +37,7 @@ async function downloadQSCSV() {
 function parseQSCSV(filePath) {
   return new Promise((resolve, reject) => {
     const results = [];
-    fs.createReadStream(filePath)
+    fs.createReadStream(filePath, { encoding: 'latin1' })
       .pipe(
         csv({
           headers: ['# World Rank', ' Institution', ' Country'],

--- a/scripts/scrape-rankings.js
+++ b/scripts/scrape-rankings.js
@@ -73,6 +73,8 @@ function canonicalizeName(name) {
     cleaned = cleaned.replace(/\s*-\s*/g, ' ');
     cleaned = cleaned.replace(/[.,]/g, '');
     cleaned = cleaned.replace(/\s+/g, ' ');
+    // Fix common encoding issues where 'ü' becomes 'u' is dropped entirely
+    cleaned = cleaned.replace(/Mnchen/g, 'Munchen');
     cleaned = cleaned.trim();
     return cleaned;
 }

--- a/scripts/the-scraper.js
+++ b/scripts/the-scraper.js
@@ -54,7 +54,7 @@ async function scrapeTHERankings() {
         console.log(`Reading THE rankings from local CSV file ${THE_FILE_PATH}...`);
 
         await new Promise((resolve, reject) => {
-            createReadStream(THE_FILE_PATH)
+            createReadStream(THE_FILE_PATH, { encoding: 'latin1' })
                 .pipe(csv({
                     // Explicitly define headers as found in the CSV file
                     headers: ['#    World Rank', 'Institution', 'Country', ''], 


### PR DESCRIPTION
## Summary
- parse QS/THE/ARWU CSV files using latin1 so accented characters decode correctly
- sanitize broken `Mnchen` encoding during canonicalization
- regenerate aggregated rankings with full matches for Munich universities

## Testing
- `npm install`
- `node scripts/scrape-rankings.js 200`

------
https://chatgpt.com/codex/tasks/task_e_68523a622dc08320a267016cfd0d2570