### PR TITLE
Add mappings for Spanish/Portuguese names

### DIFF
--- a/frontend/public/data/aggregated-rankings.json
+++ b/frontend/public/data/aggregated-rankings.json
@@ -4862,6 +4862,28 @@
     "countryRank": 5
   },
   {
+    "name": "Universidade de Lisboa",
+    "country": "Portugal",
+    "aggregatedScore": 1437.75,
+    "originalRankings": {
+      "qs": {
+        "rank": 260
+      },
+      "the": {
+        "rank": 401
+      },
+      "arwu": {
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 236
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 222,
+    "countryRank": 1
+  },
+  {
     "name": "Northwestern Polytechnical University",
     "country": "China",
     "aggregatedScore": 1435.75,
@@ -4880,7 +4902,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 222,
+    "aggregatedRank": 223,
     "countryRank": 24
   },
   {
@@ -4902,7 +4924,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 223,
+    "aggregatedRank": 224,
     "countryRank": 6
   },
   {
@@ -4924,7 +4946,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 224,
+    "aggregatedRank": 225,
     "countryRank": 10
   },
   {
@@ -4946,7 +4968,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 225,
+    "aggregatedRank": 226,
     "countryRank": 58
   },
   {
@@ -4968,7 +4990,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 226,
+    "aggregatedRank": 227,
     "countryRank": 59
   },
   {
@@ -4990,7 +5012,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 227,
+    "aggregatedRank": 228,
     "countryRank": 17
   },
   {
@@ -5012,7 +5034,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 228,
+    "aggregatedRank": 229,
     "countryRank": 60
   },
   {
@@ -5034,7 +5056,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 229,
+    "aggregatedRank": 230,
     "countryRank": 4
   },
   {
@@ -5056,7 +5078,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 230,
+    "aggregatedRank": 231,
     "countryRank": 7
   },
   {
@@ -5078,7 +5100,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 231,
+    "aggregatedRank": 232,
     "countryRank": 4
   },
   {
@@ -5100,7 +5122,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 232,
+    "aggregatedRank": 233,
     "countryRank": 4
   },
   {
@@ -5122,7 +5144,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 233,
+    "aggregatedRank": 234,
     "countryRank": 2
   },
   {
@@ -5144,7 +5166,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 234,
+    "aggregatedRank": 235,
     "countryRank": 7
   },
   {
@@ -5166,8 +5188,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 235,
+    "aggregatedRank": 236,
     "countryRank": 8
+  },
+  {
+    "name": "Universidade do Porto",
+    "country": "Portugal",
+    "aggregatedScore": 1424.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 278
+      },
+      "the": {
+        "rank": 401
+      },
+      "arwu": {
+        "rank": 201
+      },
+      "usnews": {
+        "rank": 271
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 237,
+    "countryRank": 2
   },
   {
     "name": "University of Reading",
@@ -5188,7 +5232,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 236,
+    "aggregatedRank": 238,
     "countryRank": 28
   },
   {
@@ -5210,7 +5254,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 237,
+    "aggregatedRank": 239,
     "countryRank": 6
   },
   {
@@ -5232,7 +5276,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 238,
+    "aggregatedRank": 240,
     "countryRank": 25
   },
   {
@@ -5254,7 +5298,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 239,
+    "aggregatedRank": 241,
     "countryRank": 26
   },
   {
@@ -5276,7 +5320,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 240,
+    "aggregatedRank": 242,
     "countryRank": 1
   },
   {
@@ -5298,7 +5342,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 241,
+    "aggregatedRank": 243,
     "countryRank": 61
   },
   {
@@ -5320,7 +5364,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 242,
+    "aggregatedRank": 244,
     "countryRank": 8
   },
   {
@@ -5342,7 +5386,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 243,
+    "aggregatedRank": 245,
     "countryRank": 29
   },
   {
@@ -5364,7 +5408,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 244,
+    "aggregatedRank": 246,
     "countryRank": 9
   },
   {
@@ -5386,7 +5430,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 245,
+    "aggregatedRank": 247,
     "countryRank": 7
   },
   {
@@ -5408,7 +5452,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 246,
+    "aggregatedRank": 248,
     "countryRank": 30
   },
   {
@@ -5430,7 +5474,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 247,
+    "aggregatedRank": 249,
     "countryRank": 62
   },
   {
@@ -5452,7 +5496,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 248,
+    "aggregatedRank": 250,
     "countryRank": 5
   },
   {
@@ -5474,7 +5518,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 249,
+    "aggregatedRank": 251,
     "countryRank": 63
   },
   {
@@ -5496,7 +5540,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 250,
+    "aggregatedRank": 252,
     "countryRank": 8
   },
   {
@@ -5518,7 +5562,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 251,
+    "aggregatedRank": 253,
     "countryRank": 64
   },
   {
@@ -5540,7 +5584,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 252,
+    "aggregatedRank": 254,
     "countryRank": 27
   },
   {
@@ -5562,7 +5606,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 253,
+    "aggregatedRank": 255,
     "countryRank": 2
   },
   {
@@ -5584,7 +5628,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 254,
+    "aggregatedRank": 256,
     "countryRank": 11
   },
   {
@@ -5606,7 +5650,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 255,
+    "aggregatedRank": 257,
     "countryRank": 65
   },
   {
@@ -5628,7 +5672,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 256,
+    "aggregatedRank": 258,
     "countryRank": 3
   },
   {
@@ -5650,7 +5694,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 257,
+    "aggregatedRank": 259,
     "countryRank": 10
   },
   {
@@ -5672,7 +5716,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 258,
+    "aggregatedRank": 260,
     "countryRank": 3
   },
   {
@@ -5694,7 +5738,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 259,
+    "aggregatedRank": 261,
     "countryRank": 5
   },
   {
@@ -5716,7 +5760,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 260,
+    "aggregatedRank": 262,
     "countryRank": 2
   },
   {
@@ -5738,7 +5782,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 261,
+    "aggregatedRank": 263,
     "countryRank": 31
   },
   {
@@ -5760,7 +5804,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 262,
+    "aggregatedRank": 264,
     "countryRank": 66
   },
   {
@@ -5782,7 +5826,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 263,
+    "aggregatedRank": 265,
     "countryRank": 5
   },
   {
@@ -5804,7 +5848,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 264,
+    "aggregatedRank": 266,
     "countryRank": 14
   },
   {
@@ -5826,7 +5870,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 265,
+    "aggregatedRank": 267,
     "countryRank": 28
   },
   {
@@ -5848,7 +5892,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 266,
+    "aggregatedRank": 268,
     "countryRank": 3
   },
   {
@@ -5870,7 +5914,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 267,
+    "aggregatedRank": 269,
     "countryRank": 9
   },
   {
@@ -5892,7 +5936,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 268,
+    "aggregatedRank": 270,
     "countryRank": 12
   },
   {
@@ -5914,7 +5958,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 269,
+    "aggregatedRank": 271,
     "countryRank": 2
   },
   {
@@ -5936,7 +5980,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 270,
+    "aggregatedRank": 272,
     "countryRank": 6
   },
   {
@@ -5958,7 +6002,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 271,
+    "aggregatedRank": 273,
     "countryRank": 8
   },
   {
@@ -5980,7 +6024,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 272,
+    "aggregatedRank": 274,
     "countryRank": 67
   },
   {
@@ -6002,7 +6046,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 273,
+    "aggregatedRank": 275,
     "countryRank": 68
   },
   {
@@ -6024,7 +6068,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 274,
+    "aggregatedRank": 276,
     "countryRank": 29
   },
   {
@@ -6046,7 +6090,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 275,
+    "aggregatedRank": 277,
     "countryRank": 3
   },
   {
@@ -6068,7 +6112,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 276,
+    "aggregatedRank": 278,
     "countryRank": 7
   },
   {
@@ -6090,7 +6134,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 277,
+    "aggregatedRank": 279,
     "countryRank": 4
   },
   {
@@ -6112,7 +6156,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 278,
+    "aggregatedRank": 280,
     "countryRank": 13
   },
   {
@@ -6134,7 +6178,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 279,
+    "aggregatedRank": 281,
     "countryRank": 3
   },
   {
@@ -6156,7 +6200,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 280,
+    "aggregatedRank": 282,
     "countryRank": 11
   },
   {
@@ -6178,7 +6222,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 281,
+    "aggregatedRank": 283,
     "countryRank": 69
   },
   {
@@ -6200,7 +6244,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 282,
+    "aggregatedRank": 284,
     "countryRank": 1
   },
   {
@@ -6222,7 +6266,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 283,
+    "aggregatedRank": 285,
     "countryRank": 15
   },
   {
@@ -6244,7 +6288,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 284,
+    "aggregatedRank": 286,
     "countryRank": 70
   },
   {
@@ -6266,7 +6310,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 285,
+    "aggregatedRank": 287,
     "countryRank": 18
   },
   {
@@ -6288,7 +6332,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 286,
+    "aggregatedRank": 288,
     "countryRank": 10
   },
   {
@@ -6310,7 +6354,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 287,
+    "aggregatedRank": 289,
     "countryRank": 19
   },
   {
@@ -6332,7 +6376,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 288,
+    "aggregatedRank": 290,
     "countryRank": 12
   },
   {
@@ -6354,7 +6398,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 289,
+    "aggregatedRank": 291,
     "countryRank": 71
   },
   {
@@ -6376,7 +6420,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 290,
+    "aggregatedRank": 292,
     "countryRank": 13
   },
   {
@@ -6398,7 +6442,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 291,
+    "aggregatedRank": 293,
     "countryRank": 72
   },
   {
@@ -6420,7 +6464,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 292,
+    "aggregatedRank": 294,
     "countryRank": 1
   },
   {
@@ -6442,7 +6486,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 293,
+    "aggregatedRank": 295,
     "countryRank": 1
   },
   {
@@ -6464,7 +6508,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 294,
+    "aggregatedRank": 296,
     "countryRank": 73
   },
   {
@@ -6486,7 +6530,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 295,
+    "aggregatedRank": 297,
     "countryRank": 2
   },
   {
@@ -6508,7 +6552,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 296,
+    "aggregatedRank": 298,
     "countryRank": 32
   },
   {
@@ -6530,7 +6574,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 297,
+    "aggregatedRank": 299,
     "countryRank": 74
   },
   {
@@ -6552,7 +6596,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 298,
+    "aggregatedRank": 300,
     "countryRank": 33
   },
   {
@@ -6574,7 +6618,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 299,
+    "aggregatedRank": 301,
     "countryRank": 16
   },
   {
@@ -6596,7 +6640,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 300,
+    "aggregatedRank": 302,
     "countryRank": 6
   },
   {
@@ -6618,7 +6662,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 301,
+    "aggregatedRank": 303,
     "countryRank": 34
   },
   {
@@ -6640,7 +6684,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 302,
+    "aggregatedRank": 304,
     "countryRank": 20
   },
   {
@@ -6662,7 +6706,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 303,
+    "aggregatedRank": 305,
     "countryRank": 1
   },
   {
@@ -6684,7 +6728,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 304,
+    "aggregatedRank": 306,
     "countryRank": 14
   },
   {
@@ -6706,7 +6750,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 305,
+    "aggregatedRank": 307,
     "countryRank": 30
   },
   {
@@ -6728,7 +6772,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 306,
+    "aggregatedRank": 308,
     "countryRank": 21
   },
   {
@@ -6750,7 +6794,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 307,
+    "aggregatedRank": 309,
     "countryRank": 1
   },
   {
@@ -6772,7 +6816,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 308,
+    "aggregatedRank": 310,
     "countryRank": 75
   },
   {
@@ -6794,7 +6838,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 309,
+    "aggregatedRank": 311,
     "countryRank": 7
   },
   {
@@ -6816,7 +6860,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 310,
+    "aggregatedRank": 312,
     "countryRank": 3
   },
   {
@@ -6838,7 +6882,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 311,
+    "aggregatedRank": 313,
     "countryRank": 1
   },
   {
@@ -6860,7 +6904,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 312,
+    "aggregatedRank": 314,
     "countryRank": 17
   },
   {
@@ -6882,7 +6926,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 313,
+    "aggregatedRank": 315,
     "countryRank": 18
   },
   {
@@ -6904,7 +6948,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 314,
+    "aggregatedRank": 316,
     "countryRank": 4
   },
   {
@@ -6926,7 +6970,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 315,
+    "aggregatedRank": 317,
     "countryRank": 14
   },
   {
@@ -6948,7 +6992,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 316,
+    "aggregatedRank": 318,
     "countryRank": 76
   },
   {
@@ -6970,7 +7014,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 317,
+    "aggregatedRank": 319,
     "countryRank": 2
   },
   {
@@ -6992,7 +7036,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 318,
+    "aggregatedRank": 320,
     "countryRank": 77
   },
   {
@@ -7014,7 +7058,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 319,
+    "aggregatedRank": 321,
     "countryRank": 78
   },
   {
@@ -7036,7 +7080,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 320,
+    "aggregatedRank": 322,
     "countryRank": 8
   },
   {
@@ -7058,7 +7102,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 321,
+    "aggregatedRank": 323,
     "countryRank": 1
   },
   {
@@ -7080,7 +7124,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 322,
+    "aggregatedRank": 324,
     "countryRank": 15
   },
   {
@@ -7102,7 +7146,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 323,
+    "aggregatedRank": 325,
     "countryRank": 79
   },
   {
@@ -7124,7 +7168,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 324,
+    "aggregatedRank": 326,
     "countryRank": 3
   },
   {
@@ -7146,7 +7190,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 325,
+    "aggregatedRank": 327,
     "countryRank": 7
   },
   {
@@ -7168,7 +7212,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 326,
+    "aggregatedRank": 328,
     "countryRank": 1
   },
   {
@@ -7190,7 +7234,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 327,
+    "aggregatedRank": 329,
     "countryRank": 16
   },
   {
@@ -7212,7 +7256,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 328,
+    "aggregatedRank": 330,
     "countryRank": 4
   },
   {
@@ -7234,7 +7278,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 329,
+    "aggregatedRank": 331,
     "countryRank": 2
   },
   {
@@ -7256,7 +7300,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 330,
+    "aggregatedRank": 332,
     "countryRank": 35
   },
   {
@@ -7278,7 +7322,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 331,
+    "aggregatedRank": 333,
     "countryRank": 80
   },
   {
@@ -7300,7 +7344,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 332,
+    "aggregatedRank": 334,
     "countryRank": 19
   },
   {
@@ -7322,7 +7366,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 333,
+    "aggregatedRank": 335,
     "countryRank": 81
   },
   {
@@ -7344,7 +7388,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 334,
+    "aggregatedRank": 336,
     "countryRank": 82
   },
   {
@@ -7366,7 +7410,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 335,
+    "aggregatedRank": 337,
     "countryRank": 2
   },
   {
@@ -7388,7 +7432,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 336,
+    "aggregatedRank": 338,
     "countryRank": 2
   },
   {
@@ -7410,7 +7454,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 337,
+    "aggregatedRank": 339,
     "countryRank": 4
   },
   {
@@ -7432,7 +7476,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 338,
+    "aggregatedRank": 340,
     "countryRank": 20
   },
   {
@@ -7454,7 +7498,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 339,
+    "aggregatedRank": 341,
     "countryRank": 22
   },
   {
@@ -7476,7 +7520,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 340,
+    "aggregatedRank": 342,
     "countryRank": 83
   },
   {
@@ -7498,7 +7542,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 341,
+    "aggregatedRank": 343,
     "countryRank": 84
   },
   {
@@ -7520,7 +7564,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 342,
+    "aggregatedRank": 344,
     "countryRank": 85
   },
   {
@@ -7542,7 +7586,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 343,
+    "aggregatedRank": 345,
     "countryRank": 86
   },
   {
@@ -7564,7 +7608,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 344,
+    "aggregatedRank": 346,
     "countryRank": 2
   },
   {
@@ -7586,7 +7630,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 345,
+    "aggregatedRank": 347,
     "countryRank": 17
   },
   {
@@ -7608,7 +7652,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 346,
+    "aggregatedRank": 348,
     "countryRank": 4
   },
   {
@@ -7630,7 +7674,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 347,
+    "aggregatedRank": 349,
     "countryRank": 23
   },
   {
@@ -7652,7 +7696,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 348,
+    "aggregatedRank": 350,
     "countryRank": 87
   },
   {
@@ -7674,7 +7718,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 349,
+    "aggregatedRank": 351,
     "countryRank": 1
   },
   {
@@ -7696,7 +7740,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 350,
+    "aggregatedRank": 352,
     "countryRank": 9
   },
   {
@@ -7718,7 +7762,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 351,
+    "aggregatedRank": 353,
     "countryRank": 36
   },
   {
@@ -7740,7 +7784,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 352,
+    "aggregatedRank": 354,
     "countryRank": 88
   },
   {
@@ -7762,8 +7806,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 353,
-    "countryRank": 1
+    "aggregatedRank": 355,
+    "countryRank": 3
   },
   {
     "name": "Drexel University",
@@ -7784,7 +7828,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 354,
+    "aggregatedRank": 356,
     "countryRank": 89
   },
   {
@@ -7806,7 +7850,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 355,
+    "aggregatedRank": 357,
     "countryRank": 1
   },
   {
@@ -7828,7 +7872,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 356,
+    "aggregatedRank": 358,
     "countryRank": 90
   },
   {
@@ -7850,7 +7894,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 357,
+    "aggregatedRank": 359,
     "countryRank": 91
   },
   {
@@ -7872,7 +7916,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 358,
+    "aggregatedRank": 360,
     "countryRank": 2
   },
   {
@@ -7894,7 +7938,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 359,
+    "aggregatedRank": 361,
     "countryRank": 21
   },
   {
@@ -7916,7 +7960,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 360,
+    "aggregatedRank": 362,
     "countryRank": 5
   },
   {
@@ -7938,7 +7982,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 361,
+    "aggregatedRank": 363,
     "countryRank": 5
   },
   {
@@ -7960,7 +8004,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 362,
+    "aggregatedRank": 364,
     "countryRank": 92
   },
   {
@@ -7979,7 +8023,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 363,
+    "aggregatedRank": 365,
     "countryRank": 22
   },
   {
@@ -7998,7 +8042,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 364,
+    "aggregatedRank": 366,
     "countryRank": 23
   },
   {
@@ -8020,7 +8064,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 365,
+    "aggregatedRank": 367,
     "countryRank": 24
   },
   {
@@ -8042,7 +8086,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 366,
+    "aggregatedRank": 368,
     "countryRank": 31
   },
   {
@@ -8064,7 +8108,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 367,
+    "aggregatedRank": 369,
     "countryRank": 32
   },
   {
@@ -8086,7 +8130,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 368,
+    "aggregatedRank": 370,
     "countryRank": 93
   },
   {
@@ -8108,7 +8152,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 369,
+    "aggregatedRank": 371,
     "countryRank": 7
   },
   {
@@ -8130,7 +8174,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 370,
+    "aggregatedRank": 372,
     "countryRank": 15
   },
   {
@@ -8152,7 +8196,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 371,
+    "aggregatedRank": 373,
     "countryRank": 1
   },
   {
@@ -8174,7 +8218,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 372,
+    "aggregatedRank": 374,
     "countryRank": 16
   },
   {
@@ -8196,7 +8240,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 373,
+    "aggregatedRank": 375,
     "countryRank": 11
   },
   {
@@ -8218,7 +8262,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 374,
+    "aggregatedRank": 376,
     "countryRank": 94
   },
   {
@@ -8240,8 +8284,30 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 375,
+    "aggregatedRank": 377,
     "countryRank": 5
+  },
+  {
+    "name": "Universidade Nova de Lisboa",
+    "country": "Portugal",
+    "aggregatedScore": 1173.5,
+    "originalRankings": {
+      "qs": {
+        "rank": 388
+      },
+      "the": {
+        "rank": 501
+      },
+      "arwu": {
+        "rank": 701
+      },
+      "usnews": {
+        "rank": 565
+      }
+    },
+    "appearances": 4,
+    "aggregatedRank": 378,
+    "countryRank": 4
   },
   {
     "name": "University of Waikato",
@@ -8262,7 +8328,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 376,
+    "aggregatedRank": 379,
     "countryRank": 4
   },
   {
@@ -8284,7 +8350,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 377,
+    "aggregatedRank": 380,
     "countryRank": 8
   },
   {
@@ -8306,7 +8372,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 378,
+    "aggregatedRank": 381,
     "countryRank": 2
   },
   {
@@ -8328,7 +8394,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 379,
+    "aggregatedRank": 382,
     "countryRank": 1
   },
   {
@@ -8350,7 +8416,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 380,
+    "aggregatedRank": 383,
     "countryRank": 12
   },
   {
@@ -8372,7 +8438,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 381,
+    "aggregatedRank": 384,
     "countryRank": 5
   },
   {
@@ -8394,7 +8460,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 382,
+    "aggregatedRank": 385,
     "countryRank": 6
   },
   {
@@ -8416,7 +8482,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 383,
+    "aggregatedRank": 386,
     "countryRank": 9
   },
   {
@@ -8438,7 +8504,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 384,
+    "aggregatedRank": 387,
     "countryRank": 2
   },
   {
@@ -8460,7 +8526,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 385,
+    "aggregatedRank": 388,
     "countryRank": 1
   },
   {
@@ -8482,7 +8548,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 386,
+    "aggregatedRank": 389,
     "countryRank": 1
   },
   {
@@ -8504,7 +8570,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 387,
+    "aggregatedRank": 390,
     "countryRank": 17
   },
   {
@@ -8526,7 +8592,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 388,
+    "aggregatedRank": 391,
     "countryRank": 1
   },
   {
@@ -8548,7 +8614,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 389,
+    "aggregatedRank": 392,
     "countryRank": 24
   },
   {
@@ -8570,7 +8636,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 390,
+    "aggregatedRank": 393,
     "countryRank": 95
   },
   {
@@ -8592,7 +8658,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 391,
+    "aggregatedRank": 394,
     "countryRank": 6
   },
   {
@@ -8614,7 +8680,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 392,
+    "aggregatedRank": 395,
     "countryRank": 10
   },
   {
@@ -8636,7 +8702,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 393,
+    "aggregatedRank": 396,
     "countryRank": 18
   },
   {
@@ -8658,7 +8724,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 394,
+    "aggregatedRank": 397,
     "countryRank": 96
   },
   {
@@ -8680,7 +8746,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 395,
+    "aggregatedRank": 398,
     "countryRank": 3
   },
   {
@@ -8702,7 +8768,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 396,
+    "aggregatedRank": 399,
     "countryRank": 6
   },
   {
@@ -8724,7 +8790,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 397,
+    "aggregatedRank": 400,
     "countryRank": 37
   },
   {
@@ -8746,8 +8812,8 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 398,
-    "countryRank": 2
+    "aggregatedRank": 401,
+    "countryRank": 5
   },
   {
     "name": "Wayne State University",
@@ -8768,7 +8834,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 399,
+    "aggregatedRank": 402,
     "countryRank": 97
   },
   {
@@ -8790,7 +8856,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 400,
+    "aggregatedRank": 403,
     "countryRank": 18
   },
   {
@@ -8812,7 +8878,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 401,
+    "aggregatedRank": 404,
     "countryRank": 1
   },
   {
@@ -8834,7 +8900,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 402,
+    "aggregatedRank": 405,
     "countryRank": 3
   },
   {
@@ -8856,7 +8922,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 403,
+    "aggregatedRank": 406,
     "countryRank": 38
   },
   {
@@ -8878,7 +8944,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 404,
+    "aggregatedRank": 407,
     "countryRank": 5
   },
   {
@@ -8900,7 +8966,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 405,
+    "aggregatedRank": 408,
     "countryRank": 98
   },
   {
@@ -8922,7 +8988,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 406,
+    "aggregatedRank": 409,
     "countryRank": 39
   },
   {
@@ -8944,7 +9010,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 407,
+    "aggregatedRank": 410,
     "countryRank": 1
   },
   {
@@ -8966,7 +9032,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 408,
+    "aggregatedRank": 411,
     "countryRank": 2
   },
   {
@@ -8988,7 +9054,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 409,
+    "aggregatedRank": 412,
     "countryRank": 40
   },
   {
@@ -9007,7 +9073,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 410,
+    "aggregatedRank": 413,
     "countryRank": 8
   },
   {
@@ -9029,7 +9095,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 411,
+    "aggregatedRank": 414,
     "countryRank": 99
   },
   {
@@ -9051,7 +9117,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 412,
+    "aggregatedRank": 415,
     "countryRank": 100
   },
   {
@@ -9073,7 +9139,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 413,
+    "aggregatedRank": 416,
     "countryRank": 41
   },
   {
@@ -9095,7 +9161,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 414,
+    "aggregatedRank": 417,
     "countryRank": 25
   },
   {
@@ -9117,7 +9183,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 415,
+    "aggregatedRank": 418,
     "countryRank": 2
   },
   {
@@ -9139,7 +9205,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 416,
+    "aggregatedRank": 419,
     "countryRank": 42
   },
   {
@@ -9161,7 +9227,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 417,
+    "aggregatedRank": 420,
     "countryRank": 3
   },
   {
@@ -9183,7 +9249,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 418,
+    "aggregatedRank": 421,
     "countryRank": 43
   },
   {
@@ -9205,7 +9271,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 419,
+    "aggregatedRank": 422,
     "countryRank": 44
   },
   {
@@ -9227,7 +9293,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 420,
+    "aggregatedRank": 423,
     "countryRank": 2
   },
   {
@@ -9249,7 +9315,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 421,
+    "aggregatedRank": 424,
     "countryRank": 4
   },
   {
@@ -9271,7 +9337,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 422,
+    "aggregatedRank": 425,
     "countryRank": 45
   },
   {
@@ -9293,7 +9359,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 423,
+    "aggregatedRank": 426,
     "countryRank": 46
   },
   {
@@ -9315,7 +9381,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 424,
+    "aggregatedRank": 427,
     "countryRank": 1
   },
   {
@@ -9337,7 +9403,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 425,
+    "aggregatedRank": 428,
     "countryRank": 13
   },
   {
@@ -9359,7 +9425,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 426,
+    "aggregatedRank": 429,
     "countryRank": 47
   },
   {
@@ -9381,7 +9447,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 427,
+    "aggregatedRank": 430,
     "countryRank": 2
   },
   {
@@ -9403,7 +9469,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 428,
+    "aggregatedRank": 431,
     "countryRank": 5
   },
   {
@@ -9425,7 +9491,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 429,
+    "aggregatedRank": 432,
     "countryRank": 6
   },
   {
@@ -9447,7 +9513,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 430,
+    "aggregatedRank": 433,
     "countryRank": 19
   },
   {
@@ -9469,7 +9535,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 431,
+    "aggregatedRank": 434,
     "countryRank": 9
   },
   {
@@ -9491,7 +9557,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 432,
+    "aggregatedRank": 435,
     "countryRank": 4
   },
   {
@@ -9513,7 +9579,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 433,
+    "aggregatedRank": 436,
     "countryRank": 101
   },
   {
@@ -9535,7 +9601,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 434,
+    "aggregatedRank": 437,
     "countryRank": 7
   },
   {
@@ -9557,7 +9623,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 435,
+    "aggregatedRank": 438,
     "countryRank": 20
   },
   {
@@ -9579,7 +9645,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 436,
+    "aggregatedRank": 439,
     "countryRank": 19
   },
   {
@@ -9601,7 +9667,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 437,
+    "aggregatedRank": 440,
     "countryRank": 3
   },
   {
@@ -9623,7 +9689,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 438,
+    "aggregatedRank": 441,
     "countryRank": 21
   },
   {
@@ -9645,7 +9711,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 439,
+    "aggregatedRank": 442,
     "countryRank": 102
   },
   {
@@ -9667,7 +9733,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 440,
+    "aggregatedRank": 443,
     "countryRank": 22
   },
   {
@@ -9689,7 +9755,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 441,
+    "aggregatedRank": 444,
     "countryRank": 23
   },
   {
@@ -9711,7 +9777,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 442,
+    "aggregatedRank": 445,
     "countryRank": 24
   },
   {
@@ -9733,7 +9799,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 443,
+    "aggregatedRank": 446,
     "countryRank": 6
   },
   {
@@ -9755,7 +9821,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 444,
+    "aggregatedRank": 447,
     "countryRank": 25
   },
   {
@@ -9777,7 +9843,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 445,
+    "aggregatedRank": 448,
     "countryRank": 3
   },
   {
@@ -9796,7 +9862,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 446,
+    "aggregatedRank": 449,
     "countryRank": 2
   },
   {
@@ -9818,7 +9884,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 447,
+    "aggregatedRank": 450,
     "countryRank": 103
   },
   {
@@ -9840,7 +9906,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 448,
+    "aggregatedRank": 451,
     "countryRank": 48
   },
   {
@@ -9862,7 +9928,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 449,
+    "aggregatedRank": 452,
     "countryRank": 104
   },
   {
@@ -9881,7 +9947,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 450,
+    "aggregatedRank": 453,
     "countryRank": 4
   },
   {
@@ -9903,7 +9969,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 451,
+    "aggregatedRank": 454,
     "countryRank": 3
   },
   {
@@ -9922,7 +9988,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 452,
+    "aggregatedRank": 455,
     "countryRank": 105
   },
   {
@@ -9944,7 +10010,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 453,
+    "aggregatedRank": 456,
     "countryRank": 14
   },
   {
@@ -9966,7 +10032,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 454,
+    "aggregatedRank": 457,
     "countryRank": 7
   },
   {
@@ -9988,7 +10054,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 455,
+    "aggregatedRank": 458,
     "countryRank": 106
   },
   {
@@ -10007,7 +10073,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 456,
+    "aggregatedRank": 459,
     "countryRank": 49
   },
   {
@@ -10026,7 +10092,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 457,
+    "aggregatedRank": 460,
     "countryRank": 1
   },
   {
@@ -10045,7 +10111,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 458,
+    "aggregatedRank": 461,
     "countryRank": 10
   },
   {
@@ -10067,7 +10133,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 459,
+    "aggregatedRank": 462,
     "countryRank": 3
   },
   {
@@ -10089,7 +10155,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 460,
+    "aggregatedRank": 463,
     "countryRank": 26
   },
   {
@@ -10108,7 +10174,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 461,
+    "aggregatedRank": 464,
     "countryRank": 8
   },
   {
@@ -10130,7 +10196,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 462,
+    "aggregatedRank": 465,
     "countryRank": 20
   },
   {
@@ -10149,7 +10215,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 463,
+    "aggregatedRank": 466,
     "countryRank": 25
   },
   {
@@ -10171,7 +10237,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 464,
+    "aggregatedRank": 467,
     "countryRank": 11
   },
   {
@@ -10193,7 +10259,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 465,
+    "aggregatedRank": 468,
     "countryRank": 4
   },
   {
@@ -10212,7 +10278,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 466,
+    "aggregatedRank": 469,
     "countryRank": 5
   },
   {
@@ -10231,7 +10297,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 467,
+    "aggregatedRank": 470,
     "countryRank": 8
   },
   {
@@ -10250,7 +10316,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 468,
+    "aggregatedRank": 471,
     "countryRank": 1
   },
   {
@@ -10269,7 +10335,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 469,
+    "aggregatedRank": 472,
     "countryRank": 8
   },
   {
@@ -10288,7 +10354,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 470,
+    "aggregatedRank": 473,
     "countryRank": 9
   },
   {
@@ -10307,7 +10373,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 471,
+    "aggregatedRank": 474,
     "countryRank": 10
   },
   {
@@ -10326,7 +10392,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 472,
+    "aggregatedRank": 475,
     "countryRank": 6
   },
   {
@@ -10348,7 +10414,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 473,
+    "aggregatedRank": 476,
     "countryRank": 27
   },
   {
@@ -10370,7 +10436,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 474,
+    "aggregatedRank": 477,
     "countryRank": 3
   },
   {
@@ -10392,7 +10458,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 475,
+    "aggregatedRank": 478,
     "countryRank": 50
   },
   {
@@ -10411,7 +10477,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 476,
+    "aggregatedRank": 479,
     "countryRank": 3
   },
   {
@@ -10430,7 +10496,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 477,
+    "aggregatedRank": 480,
     "countryRank": 4
   },
   {
@@ -10449,7 +10515,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 478,
+    "aggregatedRank": 481,
     "countryRank": 107
   },
   {
@@ -10471,7 +10537,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 479,
+    "aggregatedRank": 482,
     "countryRank": 10
   },
   {
@@ -10490,7 +10556,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 480,
+    "aggregatedRank": 483,
     "countryRank": 9
   },
   {
@@ -10509,7 +10575,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 481,
+    "aggregatedRank": 484,
     "countryRank": 5
   },
   {
@@ -10528,7 +10594,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 482,
+    "aggregatedRank": 485,
     "countryRank": 2
   },
   {
@@ -10547,7 +10613,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 483,
+    "aggregatedRank": 486,
     "countryRank": 108
   },
   {
@@ -10566,7 +10632,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 484,
+    "aggregatedRank": 487,
     "countryRank": 33
   },
   {
@@ -10585,7 +10651,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 485,
+    "aggregatedRank": 488,
     "countryRank": 109
   },
   {
@@ -10604,7 +10670,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 486,
+    "aggregatedRank": 489,
     "countryRank": 28
   },
   {
@@ -10623,7 +10689,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 487,
+    "aggregatedRank": 490,
     "countryRank": 12
   },
   {
@@ -10642,7 +10708,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 488,
+    "aggregatedRank": 491,
     "countryRank": 6
   },
   {
@@ -10661,7 +10727,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 489,
+    "aggregatedRank": 492,
     "countryRank": 21
   },
   {
@@ -10680,7 +10746,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 490,
+    "aggregatedRank": 493,
     "countryRank": 26
   },
   {
@@ -10699,7 +10765,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 491,
+    "aggregatedRank": 494,
     "countryRank": 27
   },
   {
@@ -10718,7 +10784,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 492,
+    "aggregatedRank": 495,
     "countryRank": 13
   },
   {
@@ -10740,7 +10806,7 @@
       }
     },
     "appearances": 4,
-    "aggregatedRank": 493,
+    "aggregatedRank": 496,
     "countryRank": 28
   },
   {
@@ -10759,7 +10825,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 494,
+    "aggregatedRank": 497,
     "countryRank": 34
   },
   {
@@ -10778,7 +10844,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 495,
+    "aggregatedRank": 498,
     "countryRank": 35
   },
   {
@@ -10797,7 +10863,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 496,
+    "aggregatedRank": 499,
     "countryRank": 26
   },
   {
@@ -10816,7 +10882,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 497,
+    "aggregatedRank": 500,
     "countryRank": 36
   },
   {
@@ -10835,7 +10901,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 498,
+    "aggregatedRank": 501,
     "countryRank": 51
   },
   {
@@ -10854,7 +10920,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 499,
+    "aggregatedRank": 502,
     "countryRank": 10
   },
   {
@@ -10873,7 +10939,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 500,
+    "aggregatedRank": 503,
     "countryRank": 37
   },
   {
@@ -10892,7 +10958,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 501,
+    "aggregatedRank": 504,
     "countryRank": 110
   },
   {
@@ -10911,7 +10977,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 502,
+    "aggregatedRank": 505,
     "countryRank": 29
   },
   {
@@ -10930,7 +10996,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 503,
+    "aggregatedRank": 506,
     "countryRank": 11
   },
   {
@@ -10949,7 +11015,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 504,
+    "aggregatedRank": 507,
     "countryRank": 9
   },
   {
@@ -10968,7 +11034,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 505,
+    "aggregatedRank": 508,
     "countryRank": 1
   },
   {
@@ -10987,7 +11053,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 506,
+    "aggregatedRank": 509,
     "countryRank": 12
   },
   {
@@ -11006,7 +11072,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 507,
+    "aggregatedRank": 510,
     "countryRank": 2
   },
   {
@@ -11025,7 +11091,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 508,
+    "aggregatedRank": 511,
     "countryRank": 7
   },
   {
@@ -11044,7 +11110,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 509,
+    "aggregatedRank": 512,
     "countryRank": 3
   },
   {
@@ -11063,7 +11129,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 510,
+    "aggregatedRank": 513,
     "countryRank": 1
   },
   {
@@ -11082,7 +11148,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 511,
+    "aggregatedRank": 514,
     "countryRank": 38
   },
   {
@@ -11101,7 +11167,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 512,
+    "aggregatedRank": 515,
     "countryRank": 39
   },
   {
@@ -11120,7 +11186,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 513,
+    "aggregatedRank": 516,
     "countryRank": 13
   },
   {
@@ -11139,7 +11205,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 514,
+    "aggregatedRank": 517,
     "countryRank": 7
   },
   {
@@ -11158,7 +11224,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 515,
+    "aggregatedRank": 518,
     "countryRank": 52
   },
   {
@@ -11177,7 +11243,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 516,
+    "aggregatedRank": 519,
     "countryRank": 2
   },
   {
@@ -11196,7 +11262,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 517,
+    "aggregatedRank": 520,
     "countryRank": 3
   },
   {
@@ -11215,7 +11281,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 518,
+    "aggregatedRank": 521,
     "countryRank": 53
   },
   {
@@ -11234,7 +11300,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 519,
+    "aggregatedRank": 522,
     "countryRank": 27
   },
   {
@@ -11253,7 +11319,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 520,
+    "aggregatedRank": 523,
     "countryRank": 40
   },
   {
@@ -11272,7 +11338,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 521,
+    "aggregatedRank": 524,
     "countryRank": 41
   },
   {
@@ -11291,7 +11357,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 522,
+    "aggregatedRank": 525,
     "countryRank": 7
   },
   {
@@ -11310,7 +11376,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 523,
+    "aggregatedRank": 526,
     "countryRank": 11
   },
   {
@@ -11329,7 +11395,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 524,
+    "aggregatedRank": 527,
     "countryRank": 5
   },
   {
@@ -11348,7 +11414,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 525,
+    "aggregatedRank": 528,
     "countryRank": 42
   },
   {
@@ -11367,7 +11433,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 526,
+    "aggregatedRank": 529,
     "countryRank": 28
   },
   {
@@ -11386,7 +11452,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 527,
+    "aggregatedRank": 530,
     "countryRank": 43
   },
   {
@@ -11405,7 +11471,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 528,
+    "aggregatedRank": 531,
     "countryRank": 29
   },
   {
@@ -11424,7 +11490,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 529,
+    "aggregatedRank": 532,
     "countryRank": 6
   },
   {
@@ -11443,7 +11509,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 530,
+    "aggregatedRank": 533,
     "countryRank": 29
   },
   {
@@ -11462,7 +11528,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 531,
+    "aggregatedRank": 534,
     "countryRank": 111
   },
   {
@@ -11481,7 +11547,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 532,
+    "aggregatedRank": 535,
     "countryRank": 112
   },
   {
@@ -11500,7 +11566,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 533,
+    "aggregatedRank": 536,
     "countryRank": 44
   },
   {
@@ -11519,7 +11585,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 534,
+    "aggregatedRank": 537,
     "countryRank": 45
   },
   {
@@ -11538,7 +11604,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 535,
+    "aggregatedRank": 538,
     "countryRank": 46
   },
   {
@@ -11557,7 +11623,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 536,
+    "aggregatedRank": 539,
     "countryRank": 47
   },
   {
@@ -11576,7 +11642,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 537,
+    "aggregatedRank": 540,
     "countryRank": 113
   },
   {
@@ -11595,7 +11661,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 538,
+    "aggregatedRank": 541,
     "countryRank": 54
   },
   {
@@ -11614,7 +11680,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 539,
+    "aggregatedRank": 542,
     "countryRank": 30
   },
   {
@@ -11633,7 +11699,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 540,
+    "aggregatedRank": 543,
     "countryRank": 12
   },
   {
@@ -11652,7 +11718,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 541,
+    "aggregatedRank": 544,
     "countryRank": 1
   },
   {
@@ -11671,7 +11737,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 542,
+    "aggregatedRank": 545,
     "countryRank": 55
   },
   {
@@ -11690,7 +11756,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 543,
+    "aggregatedRank": 546,
     "countryRank": 4
   },
   {
@@ -11709,7 +11775,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 544,
+    "aggregatedRank": 547,
     "countryRank": 48
   },
   {
@@ -11728,7 +11794,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 545,
+    "aggregatedRank": 548,
     "countryRank": 13
   },
   {
@@ -11747,7 +11813,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 546,
+    "aggregatedRank": 549,
     "countryRank": 49
   },
   {
@@ -11766,7 +11832,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 547,
+    "aggregatedRank": 550,
     "countryRank": 1
   },
   {
@@ -11785,7 +11851,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 548,
+    "aggregatedRank": 551,
     "countryRank": 50
   },
   {
@@ -11804,7 +11870,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 549,
+    "aggregatedRank": 552,
     "countryRank": 51
   },
   {
@@ -11823,7 +11889,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 550,
+    "aggregatedRank": 553,
     "countryRank": 31
   },
   {
@@ -11842,7 +11908,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 551,
+    "aggregatedRank": 554,
     "countryRank": 52
   },
   {
@@ -11861,7 +11927,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 552,
+    "aggregatedRank": 555,
     "countryRank": 114
   },
   {
@@ -11880,7 +11946,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 553,
+    "aggregatedRank": 556,
     "countryRank": 4
   },
   {
@@ -11899,7 +11965,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 554,
+    "aggregatedRank": 557,
     "countryRank": 53
   },
   {
@@ -11918,7 +11984,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 555,
+    "aggregatedRank": 558,
     "countryRank": 5
   },
   {
@@ -11937,7 +12003,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 556,
+    "aggregatedRank": 559,
     "countryRank": 14
   },
   {
@@ -11956,27 +12022,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 557,
+    "aggregatedRank": 560,
     "countryRank": 54
-  },
-  {
-    "name": "University of Porto",
-    "country": "Portugal",
-    "aggregatedScore": 764.09375,
-    "originalRankings": {
-      "qs": {
-        "rank": 278
-      },
-      "the": {
-        "rank": 401
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 558,
-    "countryRank": 3
   },
   {
     "name": "Future University in Egypt",
@@ -11994,7 +12041,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 559,
+    "aggregatedRank": 561,
     "countryRank": 4
   },
   {
@@ -12013,7 +12060,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 560,
+    "aggregatedRank": 562,
     "countryRank": 6
   },
   {
@@ -12032,7 +12079,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 561,
+    "aggregatedRank": 563,
     "countryRank": 55
   },
   {
@@ -12051,7 +12098,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 562,
+    "aggregatedRank": 564,
     "countryRank": 30
   },
   {
@@ -12070,7 +12117,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 563,
+    "aggregatedRank": 565,
     "countryRank": 31
   },
   {
@@ -12089,7 +12136,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 564,
+    "aggregatedRank": 566,
     "countryRank": 14
   },
   {
@@ -12108,7 +12155,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 565,
+    "aggregatedRank": 567,
     "countryRank": 8
   },
   {
@@ -12127,7 +12174,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 566,
+    "aggregatedRank": 568,
     "countryRank": 3
   },
   {
@@ -12146,7 +12193,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 567,
+    "aggregatedRank": 569,
     "countryRank": 9
   },
   {
@@ -12165,7 +12212,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 568,
+    "aggregatedRank": 570,
     "countryRank": 9
   },
   {
@@ -12184,7 +12231,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 569,
+    "aggregatedRank": 571,
     "countryRank": 5
   },
   {
@@ -12203,7 +12250,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 570,
+    "aggregatedRank": 572,
     "countryRank": 32
   },
   {
@@ -12222,7 +12269,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 571,
+    "aggregatedRank": 573,
     "countryRank": 56
   },
   {
@@ -12241,7 +12288,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 572,
+    "aggregatedRank": 574,
     "countryRank": 7
   },
   {
@@ -12260,7 +12307,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 573,
+    "aggregatedRank": 575,
     "countryRank": 4
   },
   {
@@ -12279,7 +12326,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 574,
+    "aggregatedRank": 576,
     "countryRank": 115
   },
   {
@@ -12298,7 +12345,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 575,
+    "aggregatedRank": 577,
     "countryRank": 15
   },
   {
@@ -12317,7 +12364,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 576,
+    "aggregatedRank": 578,
     "countryRank": 32
   },
   {
@@ -12336,7 +12383,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 577,
+    "aggregatedRank": 579,
     "countryRank": 7
   },
   {
@@ -12355,7 +12402,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 578,
+    "aggregatedRank": 580,
     "countryRank": 116
   },
   {
@@ -12374,7 +12421,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 579,
+    "aggregatedRank": 581,
     "countryRank": 57
   },
   {
@@ -12393,7 +12440,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 580,
+    "aggregatedRank": 582,
     "countryRank": 58
   },
   {
@@ -12412,7 +12459,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 581,
+    "aggregatedRank": 583,
     "countryRank": 117
   },
   {
@@ -12431,7 +12478,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 582,
+    "aggregatedRank": 584,
     "countryRank": 118
   },
   {
@@ -12450,7 +12497,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 583,
+    "aggregatedRank": 585,
     "countryRank": 1
   },
   {
@@ -12469,7 +12516,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 584,
+    "aggregatedRank": 586,
     "countryRank": 59
   },
   {
@@ -12488,7 +12535,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 585,
+    "aggregatedRank": 587,
     "countryRank": 119
   },
   {
@@ -12507,7 +12554,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 586,
+    "aggregatedRank": 588,
     "countryRank": 56
   },
   {
@@ -12526,7 +12573,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 587,
+    "aggregatedRank": 589,
     "countryRank": 10
   },
   {
@@ -12545,7 +12592,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 588,
+    "aggregatedRank": 590,
     "countryRank": 3
   },
   {
@@ -12564,7 +12611,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 589,
+    "aggregatedRank": 591,
     "countryRank": 60
   },
   {
@@ -12583,7 +12630,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 590,
+    "aggregatedRank": 592,
     "countryRank": 61
   },
   {
@@ -12602,7 +12649,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 591,
+    "aggregatedRank": 593,
     "countryRank": 62
   },
   {
@@ -12621,7 +12668,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 592,
+    "aggregatedRank": 594,
     "countryRank": 30
   },
   {
@@ -12640,7 +12687,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 593,
+    "aggregatedRank": 595,
     "countryRank": 4
   },
   {
@@ -12659,7 +12706,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 594,
+    "aggregatedRank": 596,
     "countryRank": 22
   },
   {
@@ -12678,7 +12725,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 595,
+    "aggregatedRank": 597,
     "countryRank": 11
   },
   {
@@ -12697,7 +12744,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 596,
+    "aggregatedRank": 598,
     "countryRank": 31
   },
   {
@@ -12716,7 +12763,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 597,
+    "aggregatedRank": 599,
     "countryRank": 33
   },
   {
@@ -12735,7 +12782,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 598,
+    "aggregatedRank": 600,
     "countryRank": 63
   },
   {
@@ -12754,7 +12801,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 599,
+    "aggregatedRank": 601,
     "countryRank": 4
   },
   {
@@ -12773,7 +12820,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 600,
+    "aggregatedRank": 602,
     "countryRank": 64
   },
   {
@@ -12792,7 +12839,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 601,
+    "aggregatedRank": 603,
     "countryRank": 11
   },
   {
@@ -12811,7 +12858,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 602,
+    "aggregatedRank": 604,
     "countryRank": 32
   },
   {
@@ -12830,7 +12877,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 603,
+    "aggregatedRank": 605,
     "countryRank": 5
   },
   {
@@ -12849,7 +12896,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 604,
+    "aggregatedRank": 606,
     "countryRank": 33
   },
   {
@@ -12868,7 +12915,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 605,
+    "aggregatedRank": 607,
     "countryRank": 6
   },
   {
@@ -12887,8 +12934,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 606,
-    "countryRank": 4
+    "aggregatedRank": 608,
+    "countryRank": 6
   },
   {
     "name": "Universite Clermont Auvergne (UCA)",
@@ -12906,7 +12953,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 607,
+    "aggregatedRank": 609,
     "countryRank": 12
   },
   {
@@ -12925,7 +12972,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 608,
+    "aggregatedRank": 610,
     "countryRank": 7
   },
   {
@@ -12944,7 +12991,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 609,
+    "aggregatedRank": 611,
     "countryRank": 65
   },
   {
@@ -12963,7 +13010,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 610,
+    "aggregatedRank": 612,
     "countryRank": 120
   },
   {
@@ -12982,7 +13029,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 611,
+    "aggregatedRank": 613,
     "countryRank": 7
   },
   {
@@ -13001,7 +13048,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 612,
+    "aggregatedRank": 614,
     "countryRank": 66
   },
   {
@@ -13020,7 +13067,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 613,
+    "aggregatedRank": 615,
     "countryRank": 67
   },
   {
@@ -13039,7 +13086,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 614,
+    "aggregatedRank": 616,
     "countryRank": 68
   },
   {
@@ -13058,7 +13105,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 615,
+    "aggregatedRank": 617,
     "countryRank": 121
   },
   {
@@ -13077,7 +13124,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 616,
+    "aggregatedRank": 618,
     "countryRank": 69
   },
   {
@@ -13096,7 +13143,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 617,
+    "aggregatedRank": 619,
     "countryRank": 34
   },
   {
@@ -13115,7 +13162,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 618,
+    "aggregatedRank": 620,
     "countryRank": 122
   },
   {
@@ -13134,7 +13181,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 619,
+    "aggregatedRank": 621,
     "countryRank": 35
   },
   {
@@ -13153,7 +13200,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 620,
+    "aggregatedRank": 622,
     "countryRank": 9
   },
   {
@@ -13172,7 +13219,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 621,
+    "aggregatedRank": 623,
     "countryRank": 7
   },
   {
@@ -13191,7 +13238,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 622,
+    "aggregatedRank": 624,
     "countryRank": 8
   },
   {
@@ -13210,7 +13257,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 623,
+    "aggregatedRank": 625,
     "countryRank": 123
   },
   {
@@ -13229,7 +13276,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 624,
+    "aggregatedRank": 626,
     "countryRank": 124
   },
   {
@@ -13248,7 +13295,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 625,
+    "aggregatedRank": 627,
     "countryRank": 36
   },
   {
@@ -13267,7 +13314,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 626,
+    "aggregatedRank": 628,
     "countryRank": 6
   },
   {
@@ -13286,7 +13333,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 627,
+    "aggregatedRank": 629,
     "countryRank": 10
   },
   {
@@ -13305,7 +13352,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 628,
+    "aggregatedRank": 630,
     "countryRank": 70
   },
   {
@@ -13324,7 +13371,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 629,
+    "aggregatedRank": 631,
     "countryRank": 57
   },
   {
@@ -13343,7 +13390,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 630,
+    "aggregatedRank": 632,
     "countryRank": 71
   },
   {
@@ -13362,7 +13409,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 631,
+    "aggregatedRank": 633,
     "countryRank": 72
   },
   {
@@ -13381,7 +13428,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 632,
+    "aggregatedRank": 634,
     "countryRank": 4
   },
   {
@@ -13400,7 +13447,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 633,
+    "aggregatedRank": 635,
     "countryRank": 11
   },
   {
@@ -13419,7 +13466,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 634,
+    "aggregatedRank": 636,
     "countryRank": 1
   },
   {
@@ -13438,7 +13485,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 635,
+    "aggregatedRank": 637,
     "countryRank": 34
   },
   {
@@ -13457,7 +13504,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 636,
+    "aggregatedRank": 638,
     "countryRank": 2
   },
   {
@@ -13476,7 +13523,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 637,
+    "aggregatedRank": 639,
     "countryRank": 8
   },
   {
@@ -13495,7 +13542,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 638,
+    "aggregatedRank": 640,
     "countryRank": 73
   },
   {
@@ -13514,27 +13561,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 639,
+    "aggregatedRank": 641,
     "countryRank": 74
-  },
-  {
-    "name": "ISCTE-University Institute of Lisbon",
-    "country": "Portugal",
-    "aggregatedScore": 636.5625,
-    "originalRankings": {
-      "qs": {
-        "rank": 661
-      },
-      "the": {
-        "rank": 601
-      },
-      "arwu": {
-        "rank": 201
-      }
-    },
-    "appearances": 3,
-    "aggregatedRank": 640,
-    "countryRank": 5
   },
   {
     "name": "University of Belgrade",
@@ -13552,7 +13580,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 641,
+    "aggregatedRank": 642,
     "countryRank": 1
   },
   {
@@ -13571,7 +13599,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 642,
+    "aggregatedRank": 643,
     "countryRank": 3
   },
   {
@@ -13590,7 +13618,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 643,
+    "aggregatedRank": 644,
     "countryRank": 37
   },
   {
@@ -13609,7 +13637,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 644,
+    "aggregatedRank": 645,
     "countryRank": 75
   },
   {
@@ -13628,7 +13656,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 645,
+    "aggregatedRank": 646,
     "countryRank": 9
   },
   {
@@ -13647,7 +13675,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 646,
+    "aggregatedRank": 647,
     "countryRank": 125
   },
   {
@@ -13666,7 +13694,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 647,
+    "aggregatedRank": 648,
     "countryRank": 38
   },
   {
@@ -13685,7 +13713,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 648,
+    "aggregatedRank": 649,
     "countryRank": 58
   },
   {
@@ -13704,7 +13732,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 649,
+    "aggregatedRank": 650,
     "countryRank": 11
   },
   {
@@ -13723,7 +13751,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 650,
+    "aggregatedRank": 651,
     "countryRank": 23
   },
   {
@@ -13742,7 +13770,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 651,
+    "aggregatedRank": 652,
     "countryRank": 3
   },
   {
@@ -13761,7 +13789,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 652,
+    "aggregatedRank": 653,
     "countryRank": 12
   },
   {
@@ -13780,7 +13808,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 653,
+    "aggregatedRank": 654,
     "countryRank": 126
   },
   {
@@ -13799,7 +13827,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 654,
+    "aggregatedRank": 655,
     "countryRank": 127
   },
   {
@@ -13818,7 +13846,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 655,
+    "aggregatedRank": 656,
     "countryRank": 15
   },
   {
@@ -13837,7 +13865,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 656,
+    "aggregatedRank": 657,
     "countryRank": 128
   },
   {
@@ -13856,7 +13884,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 657,
+    "aggregatedRank": 658,
     "countryRank": 59
   },
   {
@@ -13875,7 +13903,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 658,
+    "aggregatedRank": 659,
     "countryRank": 5
   },
   {
@@ -13894,7 +13922,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 659,
+    "aggregatedRank": 660,
     "countryRank": 16
   },
   {
@@ -13913,27 +13941,8 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 660,
-    "countryRank": 7
-  },
-  {
-    "name": "New University of Lisbon",
-    "country": "Portugal",
-    "aggregatedScore": 608.78125,
-    "originalRankings": {
-      "qs": {
-        "rank": 388
-      },
-      "the": {
-        "rank": 501
-      },
-      "arwu": {
-        "rank": 701
-      }
-    },
-    "appearances": 3,
     "aggregatedRank": 661,
-    "countryRank": 6
+    "countryRank": 7
   },
   {
     "name": "Chung-Ang University",
@@ -16979,6 +16988,22 @@
     "countryRank": 71
   },
   {
+    "name": "ISCTE-University Institute of Lisbon",
+    "country": "Portugal",
+    "aggregatedScore": 376.875,
+    "originalRankings": {
+      "qs": {
+        "rank": 661
+      },
+      "the": {
+        "rank": 601
+      }
+    },
+    "appearances": 2,
+    "aggregatedRank": 837,
+    "countryRank": 7
+  },
+  {
     "name": "Chandigarh University",
     "country": "India",
     "aggregatedScore": 376.4625,
@@ -16991,7 +17016,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 837,
+    "aggregatedRank": 838,
     "countryRank": 20
   },
   {
@@ -17010,7 +17035,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 838,
+    "aggregatedRank": 839,
     "countryRank": 21
   },
   {
@@ -17029,7 +17054,7 @@
       }
     },
     "appearances": 3,
-    "aggregatedRank": 839,
+    "aggregatedRank": 840,
     "countryRank": 72
   },
   {
@@ -17045,7 +17070,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 840,
+    "aggregatedRank": 841,
     "countryRank": 22
   },
   {
@@ -17061,7 +17086,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 841,
+    "aggregatedRank": 842,
     "countryRank": 11
   },
   {
@@ -17077,7 +17102,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 842,
+    "aggregatedRank": 843,
     "countryRank": 73
   },
   {
@@ -17093,7 +17118,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 843,
+    "aggregatedRank": 844,
     "countryRank": 17
   },
   {
@@ -17109,7 +17134,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 844,
+    "aggregatedRank": 845,
     "countryRank": 87
   },
   {
@@ -17125,7 +17150,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 845,
+    "aggregatedRank": 846,
     "countryRank": 9
   },
   {
@@ -17141,7 +17166,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 846,
+    "aggregatedRank": 847,
     "countryRank": 74
   },
   {
@@ -17157,7 +17182,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 847,
+    "aggregatedRank": 848,
     "countryRank": 11
   },
   {
@@ -17173,7 +17198,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 848,
+    "aggregatedRank": 849,
     "countryRank": 10
   },
   {
@@ -17189,7 +17214,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 849,
+    "aggregatedRank": 850,
     "countryRank": 3
   },
   {
@@ -17205,7 +17230,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 850,
+    "aggregatedRank": 851,
     "countryRank": 26
   },
   {
@@ -17221,7 +17246,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 851,
+    "aggregatedRank": 852,
     "countryRank": 21
   },
   {
@@ -17237,7 +17262,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 852,
+    "aggregatedRank": 853,
     "countryRank": 150
   },
   {
@@ -17253,7 +17278,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 853,
+    "aggregatedRank": 854,
     "countryRank": 151
   },
   {
@@ -17269,7 +17294,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 854,
+    "aggregatedRank": 855,
     "countryRank": 88
   },
   {
@@ -17285,7 +17310,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 855,
+    "aggregatedRank": 856,
     "countryRank": 89
   },
   {
@@ -17301,7 +17326,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 856,
+    "aggregatedRank": 857,
     "countryRank": 2
   },
   {
@@ -17317,7 +17342,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 857,
+    "aggregatedRank": 858,
     "countryRank": 90
   },
   {
@@ -17333,7 +17358,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 858,
+    "aggregatedRank": 859,
     "countryRank": 26
   },
   {
@@ -17349,7 +17374,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 859,
+    "aggregatedRank": 860,
     "countryRank": 22
   },
   {
@@ -17365,7 +17390,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 860,
+    "aggregatedRank": 861,
     "countryRank": 12
   },
   {
@@ -17381,7 +17406,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 861,
+    "aggregatedRank": 862,
     "countryRank": 8
   },
   {
@@ -17397,7 +17422,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 862,
+    "aggregatedRank": 863,
     "countryRank": 2
   },
   {
@@ -17413,7 +17438,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 863,
+    "aggregatedRank": 864,
     "countryRank": 9
   },
   {
@@ -17429,7 +17454,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 864,
+    "aggregatedRank": 865,
     "countryRank": 75
   },
   {
@@ -17445,7 +17470,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 865,
+    "aggregatedRank": 866,
     "countryRank": 27
   },
   {
@@ -17461,7 +17486,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 866,
+    "aggregatedRank": 867,
     "countryRank": 23
   },
   {
@@ -17477,7 +17502,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 867,
+    "aggregatedRank": 868,
     "countryRank": 6
   },
   {
@@ -17493,7 +17518,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 868,
+    "aggregatedRank": 869,
     "countryRank": 76
   },
   {
@@ -17509,7 +17534,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 869,
+    "aggregatedRank": 870,
     "countryRank": 77
   },
   {
@@ -17525,8 +17550,24 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 870,
+    "aggregatedRank": 871,
     "countryRank": 4
+  },
+  {
+    "name": "Universidad de la Republica, Uruguay",
+    "country": "Uruguay",
+    "aggregatedScore": 347.2125,
+    "originalRankings": {
+      "qs": {
+        "rank": 661
+      },
+      "usnews": {
+        "rank": 933
+      }
+    },
+    "appearances": 2,
+    "aggregatedRank": 872,
+    "countryRank": 1
   },
   {
     "name": "Savitribai Phule Pune University",
@@ -17541,7 +17582,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 871,
+    "aggregatedRank": 873,
     "countryRank": 24
   },
   {
@@ -17557,7 +17598,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 872,
+    "aggregatedRank": 874,
     "countryRank": 91
   },
   {
@@ -17573,7 +17614,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 873,
+    "aggregatedRank": 875,
     "countryRank": 25
   },
   {
@@ -17589,7 +17630,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 874,
+    "aggregatedRank": 876,
     "countryRank": 78
   },
   {
@@ -17605,7 +17646,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 875,
+    "aggregatedRank": 877,
     "countryRank": 92
   },
   {
@@ -17621,7 +17662,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 876,
+    "aggregatedRank": 878,
     "countryRank": 152
   },
   {
@@ -17637,7 +17678,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 877,
+    "aggregatedRank": 879,
     "countryRank": 153
   },
   {
@@ -17653,7 +17694,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 878,
+    "aggregatedRank": 880,
     "countryRank": 1
   },
   {
@@ -17669,7 +17710,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 879,
+    "aggregatedRank": 881,
     "countryRank": 93
   },
   {
@@ -17685,7 +17726,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 880,
+    "aggregatedRank": 882,
     "countryRank": 13
   },
   {
@@ -17701,7 +17742,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 881,
+    "aggregatedRank": 883,
     "countryRank": 94
   },
   {
@@ -17717,7 +17758,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 882,
+    "aggregatedRank": 884,
     "countryRank": 17
   },
   {
@@ -17733,7 +17774,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 883,
+    "aggregatedRank": 885,
     "countryRank": 26
   },
   {
@@ -17749,7 +17790,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 884,
+    "aggregatedRank": 886,
     "countryRank": 154
   },
   {
@@ -17765,7 +17806,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 885,
+    "aggregatedRank": 887,
     "countryRank": 42
   },
   {
@@ -17781,7 +17822,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 886,
+    "aggregatedRank": 888,
     "countryRank": 95
   },
   {
@@ -17797,7 +17838,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 887,
+    "aggregatedRank": 889,
     "countryRank": 155
   },
   {
@@ -17813,7 +17854,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 888,
+    "aggregatedRank": 890,
     "countryRank": 96
   },
   {
@@ -17829,7 +17870,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 889,
+    "aggregatedRank": 891,
     "countryRank": 79
   },
   {
@@ -17845,7 +17886,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 890,
+    "aggregatedRank": 892,
     "countryRank": 97
   },
   {
@@ -17861,7 +17902,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 891,
+    "aggregatedRank": 893,
     "countryRank": 156
   },
   {
@@ -17877,7 +17918,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 892,
+    "aggregatedRank": 894,
     "countryRank": 98
   },
   {
@@ -17893,7 +17934,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 893,
+    "aggregatedRank": 895,
     "countryRank": 99
   },
   {
@@ -17909,7 +17950,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 894,
+    "aggregatedRank": 896,
     "countryRank": 157
   },
   {
@@ -17925,7 +17966,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 895,
+    "aggregatedRank": 897,
     "countryRank": 158
   },
   {
@@ -17941,7 +17982,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 896,
+    "aggregatedRank": 898,
     "countryRank": 80
   },
   {
@@ -17957,7 +17998,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 897,
+    "aggregatedRank": 899,
     "countryRank": 159
   },
   {
@@ -17973,7 +18014,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 898,
+    "aggregatedRank": 900,
     "countryRank": 3
   },
   {
@@ -17989,7 +18030,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 899,
+    "aggregatedRank": 901,
     "countryRank": 100
   },
   {
@@ -18005,7 +18046,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 900,
+    "aggregatedRank": 902,
     "countryRank": 160
   },
   {
@@ -18021,7 +18062,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 901,
+    "aggregatedRank": 903,
     "countryRank": 20
   },
   {
@@ -18037,7 +18078,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 902,
+    "aggregatedRank": 904,
     "countryRank": 161
   },
   {
@@ -18053,7 +18094,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 903,
+    "aggregatedRank": 905,
     "countryRank": 11
   },
   {
@@ -18069,7 +18110,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 904,
+    "aggregatedRank": 906,
     "countryRank": 162
   },
   {
@@ -18085,7 +18126,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 905,
+    "aggregatedRank": 907,
     "countryRank": 43
   },
   {
@@ -18101,7 +18142,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 906,
+    "aggregatedRank": 908,
     "countryRank": 163
   },
   {
@@ -18117,7 +18158,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 907,
+    "aggregatedRank": 909,
     "countryRank": 101
   },
   {
@@ -18133,7 +18174,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 908,
+    "aggregatedRank": 910,
     "countryRank": 14
   },
   {
@@ -18149,7 +18190,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 909,
+    "aggregatedRank": 911,
     "countryRank": 11
   },
   {
@@ -18165,7 +18206,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 910,
+    "aggregatedRank": 912,
     "countryRank": 23
   },
   {
@@ -18181,7 +18222,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 911,
+    "aggregatedRank": 913,
     "countryRank": 164
   },
   {
@@ -18197,7 +18238,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 912,
+    "aggregatedRank": 914,
     "countryRank": 44
   },
   {
@@ -18213,7 +18254,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 913,
+    "aggregatedRank": 915,
     "countryRank": 165
   },
   {
@@ -18229,7 +18270,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 914,
+    "aggregatedRank": 916,
     "countryRank": 102
   },
   {
@@ -18245,7 +18286,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 915,
+    "aggregatedRank": 917,
     "countryRank": 1
   },
   {
@@ -18261,7 +18302,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 916,
+    "aggregatedRank": 918,
     "countryRank": 45
   },
   {
@@ -18277,7 +18318,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 917,
+    "aggregatedRank": 919,
     "countryRank": 6
   },
   {
@@ -18293,7 +18334,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 918,
+    "aggregatedRank": 920,
     "countryRank": 103
   },
   {
@@ -18309,7 +18350,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 919,
+    "aggregatedRank": 921,
     "countryRank": 2
   },
   {
@@ -18325,8 +18366,8 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 920,
-    "countryRank": 7
+    "aggregatedRank": 922,
+    "countryRank": 8
   },
   {
     "name": "The Robert Gordon University",
@@ -18341,7 +18382,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 921,
+    "aggregatedRank": 923,
     "countryRank": 81
   },
   {
@@ -18357,7 +18398,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 922,
+    "aggregatedRank": 924,
     "countryRank": 82
   },
   {
@@ -18373,7 +18414,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 923,
+    "aggregatedRank": 925,
     "countryRank": 166
   },
   {
@@ -18389,7 +18430,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 924,
+    "aggregatedRank": 926,
     "countryRank": 104
   },
   {
@@ -18405,7 +18446,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 925,
+    "aggregatedRank": 927,
     "countryRank": 15
   },
   {
@@ -18421,7 +18462,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 926,
+    "aggregatedRank": 928,
     "countryRank": 2
   },
   {
@@ -18437,7 +18478,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 927,
+    "aggregatedRank": 929,
     "countryRank": 105
   },
   {
@@ -18453,7 +18494,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 928,
+    "aggregatedRank": 930,
     "countryRank": 16
   },
   {
@@ -18469,7 +18510,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 929,
+    "aggregatedRank": 931,
     "countryRank": 4
   },
   {
@@ -18485,7 +18526,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 930,
+    "aggregatedRank": 932,
     "countryRank": 27
   },
   {
@@ -18501,7 +18542,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 931,
+    "aggregatedRank": 933,
     "countryRank": 167
   },
   {
@@ -18517,7 +18558,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 932,
+    "aggregatedRank": 934,
     "countryRank": 168
   },
   {
@@ -18533,7 +18574,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 933,
+    "aggregatedRank": 935,
     "countryRank": 106
   },
   {
@@ -18549,7 +18590,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 934,
+    "aggregatedRank": 936,
     "countryRank": 24
   },
   {
@@ -18565,7 +18606,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 935,
+    "aggregatedRank": 937,
     "countryRank": 107
   },
   {
@@ -18581,7 +18622,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 936,
+    "aggregatedRank": 938,
     "countryRank": 10
   },
   {
@@ -18597,7 +18638,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 937,
+    "aggregatedRank": 939,
     "countryRank": 169
   },
   {
@@ -18613,7 +18654,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 938,
+    "aggregatedRank": 940,
     "countryRank": 108
   },
   {
@@ -18629,7 +18670,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 939,
+    "aggregatedRank": 941,
     "countryRank": 170
   },
   {
@@ -18645,7 +18686,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 940,
+    "aggregatedRank": 942,
     "countryRank": 109
   },
   {
@@ -18661,7 +18702,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 941,
+    "aggregatedRank": 943,
     "countryRank": 7
   },
   {
@@ -18677,7 +18718,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 942,
+    "aggregatedRank": 944,
     "countryRank": 110
   },
   {
@@ -18690,7 +18731,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 943,
+    "aggregatedRank": 945,
     "countryRank": 111
   },
   {
@@ -18703,7 +18744,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 944,
+    "aggregatedRank": 946,
     "countryRank": 14
   },
   {
@@ -18716,7 +18757,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 945,
+    "aggregatedRank": 947,
     "countryRank": 112
   },
   {
@@ -18732,7 +18773,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 946,
+    "aggregatedRank": 948,
     "countryRank": 43
   },
   {
@@ -18748,7 +18789,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 947,
+    "aggregatedRank": 949,
     "countryRank": 83
   },
   {
@@ -18764,7 +18805,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 948,
+    "aggregatedRank": 950,
     "countryRank": 36
   },
   {
@@ -18780,7 +18821,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 949,
+    "aggregatedRank": 951,
     "countryRank": 113
   },
   {
@@ -18796,7 +18837,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 950,
+    "aggregatedRank": 952,
     "countryRank": 171
   },
   {
@@ -18809,7 +18850,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 951,
+    "aggregatedRank": 953,
     "countryRank": 9
   },
   {
@@ -18822,7 +18863,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 952,
+    "aggregatedRank": 954,
     "countryRank": 15
   },
   {
@@ -18838,7 +18879,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 953,
+    "aggregatedRank": 955,
     "countryRank": 172
   },
   {
@@ -18854,7 +18895,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 954,
+    "aggregatedRank": 956,
     "countryRank": 114
   },
   {
@@ -18867,7 +18908,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 955,
+    "aggregatedRank": 957,
     "countryRank": 115
   },
   {
@@ -18883,7 +18924,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 956,
+    "aggregatedRank": 958,
     "countryRank": 116
   },
   {
@@ -18896,7 +18937,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 957,
+    "aggregatedRank": 959,
     "countryRank": 12
   },
   {
@@ -18909,7 +18950,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 958,
+    "aggregatedRank": 960,
     "countryRank": 84
   },
   {
@@ -18922,7 +18963,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 959,
+    "aggregatedRank": 961,
     "countryRank": 173
   },
   {
@@ -18935,7 +18976,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 960,
+    "aggregatedRank": 962,
     "countryRank": 16
   },
   {
@@ -18951,7 +18992,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 961,
+    "aggregatedRank": 963,
     "countryRank": 46
   },
   {
@@ -18967,7 +19008,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 962,
+    "aggregatedRank": 964,
     "countryRank": 11
   },
   {
@@ -18980,7 +19021,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 963,
+    "aggregatedRank": 965,
     "countryRank": 174
   },
   {
@@ -18993,7 +19034,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 964,
+    "aggregatedRank": 966,
     "countryRank": 12
   },
   {
@@ -19009,7 +19050,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 965,
+    "aggregatedRank": 967,
     "countryRank": 117
   },
   {
@@ -19022,7 +19063,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 966,
+    "aggregatedRank": 968,
     "countryRank": 28
   },
   {
@@ -19038,7 +19079,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 967,
+    "aggregatedRank": 969,
     "countryRank": 18
   },
   {
@@ -19051,7 +19092,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 968,
+    "aggregatedRank": 970,
     "countryRank": 37
   },
   {
@@ -19064,7 +19105,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 969,
+    "aggregatedRank": 971,
     "countryRank": 47
   },
   {
@@ -19077,7 +19118,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 970,
+    "aggregatedRank": 972,
     "countryRank": 10
   },
   {
@@ -19093,7 +19134,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 971,
+    "aggregatedRank": 973,
     "countryRank": 118
   },
   {
@@ -19106,7 +19147,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 972,
+    "aggregatedRank": 974,
     "countryRank": 119
   },
   {
@@ -19122,7 +19163,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 973,
+    "aggregatedRank": 975,
     "countryRank": 175
   },
   {
@@ -19138,7 +19179,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 974,
+    "aggregatedRank": 976,
     "countryRank": 176
   },
   {
@@ -19154,7 +19195,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 975,
+    "aggregatedRank": 977,
     "countryRank": 27
   },
   {
@@ -19170,7 +19211,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 976,
+    "aggregatedRank": 978,
     "countryRank": 120
   },
   {
@@ -19186,7 +19227,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 977,
+    "aggregatedRank": 979,
     "countryRank": 23
   },
   {
@@ -19202,7 +19243,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 978,
+    "aggregatedRank": 980,
     "countryRank": 24
   },
   {
@@ -19218,7 +19259,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 979,
+    "aggregatedRank": 981,
     "countryRank": 177
   },
   {
@@ -19231,7 +19272,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 980,
+    "aggregatedRank": 982,
     "countryRank": 6
   },
   {
@@ -19244,7 +19285,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 981,
+    "aggregatedRank": 983,
     "countryRank": 48
   },
   {
@@ -19260,7 +19301,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 982,
+    "aggregatedRank": 984,
     "countryRank": 121
   },
   {
@@ -19273,7 +19314,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 983,
+    "aggregatedRank": 985,
     "countryRank": 1
   },
   {
@@ -19286,7 +19327,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 984,
+    "aggregatedRank": 986,
     "countryRank": 49
   },
   {
@@ -19299,21 +19340,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 985,
+    "aggregatedRank": 987,
     "countryRank": 25
-  },
-  {
-    "name": "Universidade de Lisboa",
-    "country": "Portugal",
-    "aggregatedScore": 243.046875,
-    "originalRankings": {
-      "usnews": {
-        "rank": 236
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 986,
-    "countryRank": 8
   },
   {
     "name": "University of Newcastle",
@@ -19325,7 +19353,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 987,
+    "aggregatedRank": 988,
     "countryRank": 38
   },
   {
@@ -19338,7 +19366,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 988,
+    "aggregatedRank": 989,
     "countryRank": 44
   },
   {
@@ -19354,7 +19382,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 989,
+    "aggregatedRank": 990,
     "countryRank": 85
   },
   {
@@ -19367,7 +19395,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 990,
+    "aggregatedRank": 991,
     "countryRank": 39
   },
   {
@@ -19380,21 +19408,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 991,
-    "countryRank": 50
-  },
-  {
-    "name": "Universidade do Porto",
-    "country": "Portugal",
-    "aggregatedScore": 237.578125,
-    "originalRankings": {
-      "usnews": {
-        "rank": 271
-      }
-    },
-    "appearances": 1,
     "aggregatedRank": 992,
-    "countryRank": 9
+    "countryRank": 50
   },
   {
     "name": "Kent State University",
@@ -20521,7 +20536,7 @@
     },
     "appearances": 1,
     "aggregatedRank": 1072,
-    "countryRank": 10
+    "countryRank": 9
   },
   {
     "name": "Anhui University of Finance & Economics",
@@ -20923,19 +20938,6 @@
     "countryRank": 141
   },
   {
-    "name": "Universidade Nova de Lisboa",
-    "country": "Portugal",
-    "aggregatedScore": 191.640625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 565
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1103,
-    "countryRank": 11
-  },
-  {
     "name": "Philipps University Marburg",
     "country": "Germany",
     "aggregatedScore": 191.171875,
@@ -20945,7 +20947,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1104,
+    "aggregatedRank": 1103,
     "countryRank": 62
   },
   {
@@ -20958,7 +20960,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1105,
+    "aggregatedRank": 1104,
     "countryRank": 186
   },
   {
@@ -20971,7 +20973,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1106,
+    "aggregatedRank": 1105,
     "countryRank": 38
   },
   {
@@ -20987,7 +20989,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1107,
+    "aggregatedRank": 1106,
     "countryRank": 34
   },
   {
@@ -21003,7 +21005,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1108,
+    "aggregatedRank": 1107,
     "countryRank": 12
   },
   {
@@ -21019,7 +21021,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1109,
+    "aggregatedRank": 1108,
     "countryRank": 13
   },
   {
@@ -21032,7 +21034,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1110,
+    "aggregatedRank": 1109,
     "countryRank": 15
   },
   {
@@ -21045,7 +21047,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1111,
+    "aggregatedRank": 1110,
     "countryRank": 11
   },
   {
@@ -21058,7 +21060,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1112,
+    "aggregatedRank": 1111,
     "countryRank": 28
   },
   {
@@ -21071,7 +21073,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1113,
+    "aggregatedRank": 1112,
     "countryRank": 39
   },
   {
@@ -21084,7 +21086,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1114,
+    "aggregatedRank": 1113,
     "countryRank": 40
   },
   {
@@ -21097,7 +21099,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1115,
+    "aggregatedRank": 1114,
     "countryRank": 63
   },
   {
@@ -21110,7 +21112,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1116,
+    "aggregatedRank": 1115,
     "countryRank": 8
   },
   {
@@ -21123,7 +21125,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1117,
+    "aggregatedRank": 1116,
     "countryRank": 16
   },
   {
@@ -21136,7 +21138,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1118,
+    "aggregatedRank": 1117,
     "countryRank": 14
   },
   {
@@ -21149,7 +21151,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1119,
+    "aggregatedRank": 1118,
     "countryRank": 40
   },
   {
@@ -21162,7 +21164,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1120,
+    "aggregatedRank": 1119,
     "countryRank": 11
   },
   {
@@ -21175,7 +21177,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1121,
+    "aggregatedRank": 1120,
     "countryRank": 15
   },
   {
@@ -21191,7 +21193,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1122,
+    "aggregatedRank": 1121,
     "countryRank": 64
   },
   {
@@ -21204,7 +21206,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1123,
+    "aggregatedRank": 1122,
     "countryRank": 15
   },
   {
@@ -21217,7 +21219,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1124,
+    "aggregatedRank": 1123,
     "countryRank": 19
   },
   {
@@ -21230,7 +21232,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1125,
+    "aggregatedRank": 1124,
     "countryRank": 90
   },
   {
@@ -21243,7 +21245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1126,
+    "aggregatedRank": 1125,
     "countryRank": 22
   },
   {
@@ -21256,7 +21258,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1127,
+    "aggregatedRank": 1126,
     "countryRank": 142
   },
   {
@@ -21269,7 +21271,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1128,
+    "aggregatedRank": 1127,
     "countryRank": 65
   },
   {
@@ -21282,7 +21284,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1129,
+    "aggregatedRank": 1128,
     "countryRank": 91
   },
   {
@@ -21295,7 +21297,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1130,
+    "aggregatedRank": 1129,
     "countryRank": 187
   },
   {
@@ -21308,7 +21310,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1131,
+    "aggregatedRank": 1130,
     "countryRank": 2
   },
   {
@@ -21321,7 +21323,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1132,
+    "aggregatedRank": 1131,
     "countryRank": 54
   },
   {
@@ -21334,7 +21336,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1133,
+    "aggregatedRank": 1132,
     "countryRank": 29
   },
   {
@@ -21347,7 +21349,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1134,
+    "aggregatedRank": 1133,
     "countryRank": 12
   },
   {
@@ -21360,7 +21362,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1135,
+    "aggregatedRank": 1134,
     "countryRank": 188
   },
   {
@@ -21373,7 +21375,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1136,
+    "aggregatedRank": 1135,
     "countryRank": 3
   },
   {
@@ -21386,7 +21388,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1137,
+    "aggregatedRank": 1136,
     "countryRank": 14
   },
   {
@@ -21399,7 +21401,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1138,
+    "aggregatedRank": 1137,
     "countryRank": 15
   },
   {
@@ -21412,7 +21414,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1139,
+    "aggregatedRank": 1138,
     "countryRank": 3
   },
   {
@@ -21425,7 +21427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1140,
+    "aggregatedRank": 1139,
     "countryRank": 143
   },
   {
@@ -21438,7 +21440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1141,
+    "aggregatedRank": 1140,
     "countryRank": 189
   },
   {
@@ -21451,7 +21453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1142,
+    "aggregatedRank": 1141,
     "countryRank": 3
   },
   {
@@ -21464,7 +21466,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1143,
+    "aggregatedRank": 1142,
     "countryRank": 16
   },
   {
@@ -21477,7 +21479,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1144,
+    "aggregatedRank": 1143,
     "countryRank": 41
   },
   {
@@ -21490,7 +21492,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1145,
+    "aggregatedRank": 1144,
     "countryRank": 16
   },
   {
@@ -21503,7 +21505,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1146,
+    "aggregatedRank": 1145,
     "countryRank": 30
   },
   {
@@ -21516,7 +21518,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1147,
+    "aggregatedRank": 1146,
     "countryRank": 31
   },
   {
@@ -21529,7 +21531,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1148,
+    "aggregatedRank": 1147,
     "countryRank": 35
   },
   {
@@ -21542,7 +21544,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1149,
+    "aggregatedRank": 1148,
     "countryRank": 1
   },
   {
@@ -21555,7 +21557,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1150,
+    "aggregatedRank": 1149,
     "countryRank": 12
   },
   {
@@ -21568,7 +21570,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1151,
+    "aggregatedRank": 1150,
     "countryRank": 66
   },
   {
@@ -21581,7 +21583,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1152,
+    "aggregatedRank": 1151,
     "countryRank": 67
   },
   {
@@ -21594,7 +21596,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1153,
+    "aggregatedRank": 1152,
     "countryRank": 68
   },
   {
@@ -21607,7 +21609,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1154,
+    "aggregatedRank": 1153,
     "countryRank": 7
   },
   {
@@ -21620,7 +21622,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1155,
+    "aggregatedRank": 1154,
     "countryRank": 42
   },
   {
@@ -21633,7 +21635,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1156,
+    "aggregatedRank": 1155,
     "countryRank": 13
   },
   {
@@ -21646,7 +21648,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1157,
+    "aggregatedRank": 1156,
     "countryRank": 190
   },
   {
@@ -21659,7 +21661,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1158,
+    "aggregatedRank": 1157,
     "countryRank": 69
   },
   {
@@ -21672,7 +21674,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1159,
+    "aggregatedRank": 1158,
     "countryRank": 18
   },
   {
@@ -21685,7 +21687,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1160,
+    "aggregatedRank": 1159,
     "countryRank": 3
   },
   {
@@ -21698,7 +21700,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1161,
+    "aggregatedRank": 1160,
     "countryRank": 3
   },
   {
@@ -21711,7 +21713,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1162,
+    "aggregatedRank": 1161,
     "countryRank": 70
   },
   {
@@ -21724,7 +21726,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1163,
+    "aggregatedRank": 1162,
     "countryRank": 16
   },
   {
@@ -21737,7 +21739,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1164,
+    "aggregatedRank": 1163,
     "countryRank": 43
   },
   {
@@ -21750,7 +21752,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1165,
+    "aggregatedRank": 1164,
     "countryRank": 1
   },
   {
@@ -21763,7 +21765,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1166,
+    "aggregatedRank": 1165,
     "countryRank": 17
   },
   {
@@ -21776,7 +21778,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1167,
+    "aggregatedRank": 1166,
     "countryRank": 36
   },
   {
@@ -21789,7 +21791,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1168,
+    "aggregatedRank": 1167,
     "countryRank": 37
   },
   {
@@ -21805,7 +21807,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1169,
+    "aggregatedRank": 1168,
     "countryRank": 144
   },
   {
@@ -21818,7 +21820,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1170,
+    "aggregatedRank": 1169,
     "countryRank": 191
   },
   {
@@ -21834,7 +21836,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1171,
+    "aggregatedRank": 1170,
     "countryRank": 192
   },
   {
@@ -21847,7 +21849,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1172,
+    "aggregatedRank": 1171,
     "countryRank": 32
   },
   {
@@ -21860,7 +21862,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1173,
+    "aggregatedRank": 1172,
     "countryRank": 9
   },
   {
@@ -21873,7 +21875,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1174,
+    "aggregatedRank": 1173,
     "countryRank": 1
   },
   {
@@ -21886,7 +21888,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1175,
+    "aggregatedRank": 1174,
     "countryRank": 12
   },
   {
@@ -21899,7 +21901,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1176,
+    "aggregatedRank": 1175,
     "countryRank": 2
   },
   {
@@ -21912,7 +21914,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1177,
+    "aggregatedRank": 1176,
     "countryRank": 23
   },
   {
@@ -21925,7 +21927,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1178,
+    "aggregatedRank": 1177,
     "countryRank": 3
   },
   {
@@ -21938,7 +21940,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1179,
+    "aggregatedRank": 1178,
     "countryRank": 145
   },
   {
@@ -21951,7 +21953,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1180,
+    "aggregatedRank": 1179,
     "countryRank": 55
   },
   {
@@ -21964,7 +21966,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1181,
+    "aggregatedRank": 1180,
     "countryRank": 5
   },
   {
@@ -21977,7 +21979,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1182,
+    "aggregatedRank": 1181,
     "countryRank": 5
   },
   {
@@ -21990,7 +21992,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1183,
+    "aggregatedRank": 1182,
     "countryRank": 56
   },
   {
@@ -22003,7 +22005,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1184,
+    "aggregatedRank": 1183,
     "countryRank": 13
   },
   {
@@ -22016,7 +22018,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1185,
+    "aggregatedRank": 1184,
     "countryRank": 3
   },
   {
@@ -22029,7 +22031,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1186,
+    "aggregatedRank": 1185,
     "countryRank": 193
   },
   {
@@ -22042,7 +22044,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1187,
+    "aggregatedRank": 1186,
     "countryRank": 32
   },
   {
@@ -22055,7 +22057,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1188,
+    "aggregatedRank": 1187,
     "countryRank": 71
   },
   {
@@ -22068,7 +22070,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1189,
+    "aggregatedRank": 1188,
     "countryRank": 1
   },
   {
@@ -22081,7 +22083,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1190,
+    "aggregatedRank": 1189,
     "countryRank": 17
   },
   {
@@ -22094,7 +22096,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1191,
+    "aggregatedRank": 1190,
     "countryRank": 2
   },
   {
@@ -22107,7 +22109,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1192,
+    "aggregatedRank": 1191,
     "countryRank": 1
   },
   {
@@ -22120,7 +22122,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1193,
+    "aggregatedRank": 1192,
     "countryRank": 44
   },
   {
@@ -22133,7 +22135,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1194,
+    "aggregatedRank": 1193,
     "countryRank": 45
   },
   {
@@ -22146,7 +22148,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1195,
+    "aggregatedRank": 1194,
     "countryRank": 8
   },
   {
@@ -22159,7 +22161,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1196,
+    "aggregatedRank": 1195,
     "countryRank": 19
   },
   {
@@ -22172,7 +22174,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1197,
+    "aggregatedRank": 1196,
     "countryRank": 20
   },
   {
@@ -22185,7 +22187,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1198,
+    "aggregatedRank": 1197,
     "countryRank": 21
   },
   {
@@ -22198,7 +22200,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1199,
+    "aggregatedRank": 1198,
     "countryRank": 22
   },
   {
@@ -22211,7 +22213,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1200,
+    "aggregatedRank": 1199,
     "countryRank": 23
   },
   {
@@ -22224,7 +22226,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1201,
+    "aggregatedRank": 1200,
     "countryRank": 57
   },
   {
@@ -22237,7 +22239,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1202,
+    "aggregatedRank": 1201,
     "countryRank": 58
   },
   {
@@ -22250,7 +22252,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1203,
+    "aggregatedRank": 1202,
     "countryRank": 22
   },
   {
@@ -22263,7 +22265,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1204,
+    "aggregatedRank": 1203,
     "countryRank": 18
   },
   {
@@ -22276,8 +22278,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1205,
-    "countryRank": 12
+    "aggregatedRank": 1204,
+    "countryRank": 10
   },
   {
     "name": "St. Petersburg State Mining Institute (Technical University)",
@@ -22289,7 +22291,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1206,
+    "aggregatedRank": 1205,
     "countryRank": 20
   },
   {
@@ -22302,7 +22304,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1207,
+    "aggregatedRank": 1206,
     "countryRank": 14
   },
   {
@@ -22315,7 +22317,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1208,
+    "aggregatedRank": 1207,
     "countryRank": 92
   },
   {
@@ -22328,7 +22330,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1209,
+    "aggregatedRank": 1208,
     "countryRank": 93
   },
   {
@@ -22341,7 +22343,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1210,
+    "aggregatedRank": 1209,
     "countryRank": 194
   },
   {
@@ -22354,7 +22356,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1211,
+    "aggregatedRank": 1210,
     "countryRank": 195
   },
   {
@@ -22367,7 +22369,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1212,
+    "aggregatedRank": 1211,
     "countryRank": 4
   },
   {
@@ -22380,7 +22382,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1213,
+    "aggregatedRank": 1212,
     "countryRank": 33
   },
   {
@@ -22393,7 +22395,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1214,
+    "aggregatedRank": 1213,
     "countryRank": 94
   },
   {
@@ -22406,7 +22408,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1215,
+    "aggregatedRank": 1214,
     "countryRank": 46
   },
   {
@@ -22419,7 +22421,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1216,
+    "aggregatedRank": 1215,
     "countryRank": 59
   },
   {
@@ -22432,7 +22434,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1217,
+    "aggregatedRank": 1216,
     "countryRank": 38
   },
   {
@@ -22445,7 +22447,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1218,
+    "aggregatedRank": 1217,
     "countryRank": 34
   },
   {
@@ -22458,7 +22460,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1219,
+    "aggregatedRank": 1218,
     "countryRank": 60
   },
   {
@@ -22471,7 +22473,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1220,
+    "aggregatedRank": 1219,
     "countryRank": 95
   },
   {
@@ -22484,7 +22486,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1221,
+    "aggregatedRank": 1220,
     "countryRank": 17
   },
   {
@@ -22497,7 +22499,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1222,
+    "aggregatedRank": 1221,
     "countryRank": 5
   },
   {
@@ -22510,7 +22512,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1223,
+    "aggregatedRank": 1222,
     "countryRank": 24
   },
   {
@@ -22523,7 +22525,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1224,
+    "aggregatedRank": 1223,
     "countryRank": 25
   },
   {
@@ -22536,7 +22538,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1225,
+    "aggregatedRank": 1224,
     "countryRank": 26
   },
   {
@@ -22549,7 +22551,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1226,
+    "aggregatedRank": 1225,
     "countryRank": 21
   },
   {
@@ -22562,7 +22564,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1227,
+    "aggregatedRank": 1226,
     "countryRank": 19
   },
   {
@@ -22575,7 +22577,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1228,
+    "aggregatedRank": 1227,
     "countryRank": 20
   },
   {
@@ -22588,7 +22590,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1229,
+    "aggregatedRank": 1228,
     "countryRank": 35
   },
   {
@@ -22601,7 +22603,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1230,
+    "aggregatedRank": 1229,
     "countryRank": 36
   },
   {
@@ -22614,7 +22616,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1231,
+    "aggregatedRank": 1230,
     "countryRank": 37
   },
   {
@@ -22627,7 +22629,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1232,
+    "aggregatedRank": 1231,
     "countryRank": 24
   },
   {
@@ -22640,7 +22642,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1233,
+    "aggregatedRank": 1232,
     "countryRank": 21
   },
   {
@@ -22653,7 +22655,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1234,
+    "aggregatedRank": 1233,
     "countryRank": 38
   },
   {
@@ -22666,7 +22668,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1235,
+    "aggregatedRank": 1234,
     "countryRank": 39
   },
   {
@@ -22679,7 +22681,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1236,
+    "aggregatedRank": 1235,
     "countryRank": 39
   },
   {
@@ -22692,7 +22694,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1237,
+    "aggregatedRank": 1236,
     "countryRank": 4
   },
   {
@@ -22705,7 +22707,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1238,
+    "aggregatedRank": 1237,
     "countryRank": 22
   },
   {
@@ -22718,7 +22720,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1239,
+    "aggregatedRank": 1238,
     "countryRank": 96
   },
   {
@@ -22731,7 +22733,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1240,
+    "aggregatedRank": 1239,
     "countryRank": 146
   },
   {
@@ -22744,7 +22746,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1241,
+    "aggregatedRank": 1240,
     "countryRank": 13
   },
   {
@@ -22757,7 +22759,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1242,
+    "aggregatedRank": 1241,
     "countryRank": 40
   },
   {
@@ -22770,7 +22772,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1243,
+    "aggregatedRank": 1242,
     "countryRank": 8
   },
   {
@@ -22783,7 +22785,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1244,
+    "aggregatedRank": 1243,
     "countryRank": 40
   },
   {
@@ -22796,7 +22798,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1245,
+    "aggregatedRank": 1244,
     "countryRank": 1
   },
   {
@@ -22809,7 +22811,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1246,
+    "aggregatedRank": 1245,
     "countryRank": 196
   },
   {
@@ -22825,7 +22827,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1247,
+    "aggregatedRank": 1246,
     "countryRank": 6
   },
   {
@@ -22841,7 +22843,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1248,
+    "aggregatedRank": 1247,
     "countryRank": 47
   },
   {
@@ -22854,7 +22856,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1249,
+    "aggregatedRank": 1248,
     "countryRank": 14
   },
   {
@@ -22867,7 +22869,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1250,
+    "aggregatedRank": 1249,
     "countryRank": 3
   },
   {
@@ -22880,7 +22882,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1251,
+    "aggregatedRank": 1250,
     "countryRank": 197
   },
   {
@@ -22893,7 +22895,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1252,
+    "aggregatedRank": 1251,
     "countryRank": 4
   },
   {
@@ -22906,7 +22908,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1253,
+    "aggregatedRank": 1252,
     "countryRank": 18
   },
   {
@@ -22919,7 +22921,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1254,
+    "aggregatedRank": 1253,
     "countryRank": 10
   },
   {
@@ -22932,7 +22934,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1255,
+    "aggregatedRank": 1254,
     "countryRank": 198
   },
   {
@@ -22945,7 +22947,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1256,
+    "aggregatedRank": 1255,
     "countryRank": 199
   },
   {
@@ -22958,7 +22960,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1257,
+    "aggregatedRank": 1256,
     "countryRank": 200
   },
   {
@@ -22971,7 +22973,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1258,
+    "aggregatedRank": 1257,
     "countryRank": 201
   },
   {
@@ -22984,7 +22986,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1259,
+    "aggregatedRank": 1258,
     "countryRank": 27
   },
   {
@@ -22997,7 +22999,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1260,
+    "aggregatedRank": 1259,
     "countryRank": 41
   },
   {
@@ -23010,7 +23012,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1261,
+    "aggregatedRank": 1260,
     "countryRank": 4
   },
   {
@@ -23023,7 +23025,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1262,
+    "aggregatedRank": 1261,
     "countryRank": 202
   },
   {
@@ -23036,7 +23038,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1263,
+    "aggregatedRank": 1262,
     "countryRank": 147
   },
   {
@@ -23049,7 +23051,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1264,
+    "aggregatedRank": 1263,
     "countryRank": 19
   },
   {
@@ -23062,7 +23064,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1265,
+    "aggregatedRank": 1264,
     "countryRank": 3
   },
   {
@@ -23075,7 +23077,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1266,
+    "aggregatedRank": 1265,
     "countryRank": 72
   },
   {
@@ -23088,7 +23090,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1267,
+    "aggregatedRank": 1266,
     "countryRank": 9
   },
   {
@@ -23101,7 +23103,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1268,
+    "aggregatedRank": 1267,
     "countryRank": 14
   },
   {
@@ -23114,7 +23116,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1269,
+    "aggregatedRank": 1268,
     "countryRank": 148
   },
   {
@@ -23127,7 +23129,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1270,
+    "aggregatedRank": 1269,
     "countryRank": 42
   },
   {
@@ -23140,7 +23142,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1271,
+    "aggregatedRank": 1270,
     "countryRank": 18
   },
   {
@@ -23156,7 +23158,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1272,
+    "aggregatedRank": 1271,
     "countryRank": 7
   },
   {
@@ -23169,7 +23171,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1273,
+    "aggregatedRank": 1272,
     "countryRank": 4
   },
   {
@@ -23182,7 +23184,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1274,
+    "aggregatedRank": 1273,
     "countryRank": 97
   },
   {
@@ -23195,7 +23197,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1275,
+    "aggregatedRank": 1274,
     "countryRank": 149
   },
   {
@@ -23208,7 +23210,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1276,
+    "aggregatedRank": 1275,
     "countryRank": 19
   },
   {
@@ -23221,7 +23223,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1277,
+    "aggregatedRank": 1276,
     "countryRank": 61
   },
   {
@@ -23234,7 +23236,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1278,
+    "aggregatedRank": 1277,
     "countryRank": 150
   },
   {
@@ -23247,7 +23249,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1279,
+    "aggregatedRank": 1278,
     "countryRank": 98
   },
   {
@@ -23260,7 +23262,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1280,
+    "aggregatedRank": 1279,
     "countryRank": 41
   },
   {
@@ -23273,7 +23275,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1281,
+    "aggregatedRank": 1280,
     "countryRank": 20
   },
   {
@@ -23286,7 +23288,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1282,
+    "aggregatedRank": 1281,
     "countryRank": 28
   },
   {
@@ -23302,7 +23304,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1283,
+    "aggregatedRank": 1282,
     "countryRank": 5
   },
   {
@@ -23315,7 +23317,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1284,
+    "aggregatedRank": 1283,
     "countryRank": 203
   },
   {
@@ -23328,7 +23330,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1285,
+    "aggregatedRank": 1284,
     "countryRank": 151
   },
   {
@@ -23341,7 +23343,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1286,
+    "aggregatedRank": 1285,
     "countryRank": 204
   },
   {
@@ -23354,7 +23356,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1287,
+    "aggregatedRank": 1286,
     "countryRank": 205
   },
   {
@@ -23367,7 +23369,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1288,
+    "aggregatedRank": 1287,
     "countryRank": 73
   },
   {
@@ -23380,7 +23382,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1289,
+    "aggregatedRank": 1288,
     "countryRank": 1
   },
   {
@@ -23393,7 +23395,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1290,
+    "aggregatedRank": 1289,
     "countryRank": 41
   },
   {
@@ -23406,7 +23408,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1291,
+    "aggregatedRank": 1290,
     "countryRank": 5
   },
   {
@@ -23419,7 +23421,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1292,
+    "aggregatedRank": 1291,
     "countryRank": 23
   },
   {
@@ -23432,7 +23434,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1293,
+    "aggregatedRank": 1292,
     "countryRank": 10
   },
   {
@@ -23448,7 +23450,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1294,
+    "aggregatedRank": 1293,
     "countryRank": 23
   },
   {
@@ -23461,21 +23463,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1295,
+    "aggregatedRank": 1294,
     "countryRank": 11
-  },
-  {
-    "name": "Universidad de la Republica, Uruguay",
-    "country": "Uruguay",
-    "aggregatedScore": 134.140625,
-    "originalRankings": {
-      "usnews": {
-        "rank": 933
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1296,
-    "countryRank": 1
   },
   {
     "name": "Universitat de Girona",
@@ -23487,7 +23476,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1297,
+    "aggregatedRank": 1295,
     "countryRank": 43
   },
   {
@@ -23500,7 +23489,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1298,
+    "aggregatedRank": 1296,
     "countryRank": 21
   },
   {
@@ -23513,7 +23502,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1299,
+    "aggregatedRank": 1297,
     "countryRank": 28
   },
   {
@@ -23526,7 +23515,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1300,
+    "aggregatedRank": 1298,
     "countryRank": 44
   },
   {
@@ -23539,7 +23528,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1301,
+    "aggregatedRank": 1299,
     "countryRank": 11
   },
   {
@@ -23552,7 +23541,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1302,
+    "aggregatedRank": 1300,
     "countryRank": 45
   },
   {
@@ -23565,7 +23554,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1303,
+    "aggregatedRank": 1301,
     "countryRank": 24
   },
   {
@@ -23578,7 +23567,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1304,
+    "aggregatedRank": 1302,
     "countryRank": 48
   },
   {
@@ -23591,7 +23580,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1305,
+    "aggregatedRank": 1303,
     "countryRank": 2
   },
   {
@@ -23604,7 +23593,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1306,
+    "aggregatedRank": 1304,
     "countryRank": 152
   },
   {
@@ -23617,7 +23606,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1307,
+    "aggregatedRank": 1305,
     "countryRank": 2
   },
   {
@@ -23630,7 +23619,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1308,
+    "aggregatedRank": 1306,
     "countryRank": 42
   },
   {
@@ -23643,7 +23632,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1309,
+    "aggregatedRank": 1307,
     "countryRank": 49
   },
   {
@@ -23656,7 +23645,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1310,
+    "aggregatedRank": 1308,
     "countryRank": 4
   },
   {
@@ -23669,7 +23658,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1311,
+    "aggregatedRank": 1309,
     "countryRank": 2
   },
   {
@@ -23682,7 +23671,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1312,
+    "aggregatedRank": 1310,
     "countryRank": 15
   },
   {
@@ -23695,7 +23684,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1313,
+    "aggregatedRank": 1311,
     "countryRank": 17
   },
   {
@@ -23708,7 +23697,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1314,
+    "aggregatedRank": 1312,
     "countryRank": 24
   },
   {
@@ -23721,7 +23710,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1315,
+    "aggregatedRank": 1313,
     "countryRank": 12
   },
   {
@@ -23734,7 +23723,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1316,
+    "aggregatedRank": 1314,
     "countryRank": 12
   },
   {
@@ -23747,7 +23736,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1317,
+    "aggregatedRank": 1315,
     "countryRank": 29
   },
   {
@@ -23760,7 +23749,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1318,
+    "aggregatedRank": 1316,
     "countryRank": 30
   },
   {
@@ -23773,7 +23762,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1319,
+    "aggregatedRank": 1317,
     "countryRank": 25
   },
   {
@@ -23786,7 +23775,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1320,
+    "aggregatedRank": 1318,
     "countryRank": 18
   },
   {
@@ -23799,7 +23788,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1321,
+    "aggregatedRank": 1319,
     "countryRank": 4
   },
   {
@@ -23812,7 +23801,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1322,
+    "aggregatedRank": 1320,
     "countryRank": 5
   },
   {
@@ -23825,7 +23814,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1323,
+    "aggregatedRank": 1321,
     "countryRank": 33
   },
   {
@@ -23838,7 +23827,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1324,
+    "aggregatedRank": 1322,
     "countryRank": 34
   },
   {
@@ -23851,7 +23840,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1325,
+    "aggregatedRank": 1323,
     "countryRank": 46
   },
   {
@@ -23864,7 +23853,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1326,
+    "aggregatedRank": 1324,
     "countryRank": 1
   },
   {
@@ -23877,7 +23866,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1327,
+    "aggregatedRank": 1325,
     "countryRank": 50
   },
   {
@@ -23890,7 +23879,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1328,
+    "aggregatedRank": 1326,
     "countryRank": 51
   },
   {
@@ -23903,7 +23892,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1329,
+    "aggregatedRank": 1327,
     "countryRank": 52
   },
   {
@@ -23916,7 +23905,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1330,
+    "aggregatedRank": 1328,
     "countryRank": 43
   },
   {
@@ -23929,7 +23918,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1331,
+    "aggregatedRank": 1329,
     "countryRank": 44
   },
   {
@@ -23942,7 +23931,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1332,
+    "aggregatedRank": 1330,
     "countryRank": 45
   },
   {
@@ -23955,7 +23944,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1333,
+    "aggregatedRank": 1331,
     "countryRank": 46
   },
   {
@@ -23968,7 +23957,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1334,
+    "aggregatedRank": 1332,
     "countryRank": 31
   },
   {
@@ -23981,7 +23970,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1335,
+    "aggregatedRank": 1333,
     "countryRank": 32
   },
   {
@@ -23994,7 +23983,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1336,
+    "aggregatedRank": 1334,
     "countryRank": 33
   },
   {
@@ -24007,7 +23996,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1337,
+    "aggregatedRank": 1335,
     "countryRank": 34
   },
   {
@@ -24020,7 +24009,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1338,
+    "aggregatedRank": 1336,
     "countryRank": 35
   },
   {
@@ -24033,7 +24022,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1339,
+    "aggregatedRank": 1337,
     "countryRank": 36
   },
   {
@@ -24046,7 +24035,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1340,
+    "aggregatedRank": 1338,
     "countryRank": 37
   },
   {
@@ -24059,7 +24048,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1341,
+    "aggregatedRank": 1339,
     "countryRank": 38
   },
   {
@@ -24072,7 +24061,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1342,
+    "aggregatedRank": 1340,
     "countryRank": 39
   },
   {
@@ -24085,7 +24074,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1343,
+    "aggregatedRank": 1341,
     "countryRank": 2
   },
   {
@@ -24098,7 +24087,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1344,
+    "aggregatedRank": 1342,
     "countryRank": 62
   },
   {
@@ -24111,7 +24100,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1345,
+    "aggregatedRank": 1343,
     "countryRank": 63
   },
   {
@@ -24124,7 +24113,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1346,
+    "aggregatedRank": 1344,
     "countryRank": 64
   },
   {
@@ -24137,7 +24126,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1347,
+    "aggregatedRank": 1345,
     "countryRank": 6
   },
   {
@@ -24150,7 +24139,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1348,
+    "aggregatedRank": 1346,
     "countryRank": 25
   },
   {
@@ -24163,7 +24152,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1349,
+    "aggregatedRank": 1347,
     "countryRank": 26
   },
   {
@@ -24176,7 +24165,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1350,
+    "aggregatedRank": 1348,
     "countryRank": 29
   },
   {
@@ -24189,7 +24178,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1351,
+    "aggregatedRank": 1349,
     "countryRank": 5
   },
   {
@@ -24202,7 +24191,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1352,
+    "aggregatedRank": 1350,
     "countryRank": 26
   },
   {
@@ -24215,7 +24204,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1353,
+    "aggregatedRank": 1351,
     "countryRank": 27
   },
   {
@@ -24228,7 +24217,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1354,
+    "aggregatedRank": 1352,
     "countryRank": 28
   },
   {
@@ -24241,7 +24230,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1355,
+    "aggregatedRank": 1353,
     "countryRank": 29
   },
   {
@@ -24254,7 +24243,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1356,
+    "aggregatedRank": 1354,
     "countryRank": 6
   },
   {
@@ -24267,7 +24256,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1357,
+    "aggregatedRank": 1355,
     "countryRank": 25
   },
   {
@@ -24280,7 +24269,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1358,
+    "aggregatedRank": 1356,
     "countryRank": 13
   },
   {
@@ -24293,7 +24282,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1359,
+    "aggregatedRank": 1357,
     "countryRank": 14
   },
   {
@@ -24306,7 +24295,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1360,
+    "aggregatedRank": 1358,
     "countryRank": 15
   },
   {
@@ -24319,7 +24308,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1361,
+    "aggregatedRank": 1359,
     "countryRank": 1
   },
   {
@@ -24332,7 +24321,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1362,
+    "aggregatedRank": 1360,
     "countryRank": 99
   },
   {
@@ -24345,7 +24334,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1363,
+    "aggregatedRank": 1361,
     "countryRank": 100
   },
   {
@@ -24358,7 +24347,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1364,
+    "aggregatedRank": 1362,
     "countryRank": 101
   },
   {
@@ -24371,7 +24360,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1365,
+    "aggregatedRank": 1363,
     "countryRank": 102
   },
   {
@@ -24384,7 +24373,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1366,
+    "aggregatedRank": 1364,
     "countryRank": 103
   },
   {
@@ -24397,7 +24386,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1367,
+    "aggregatedRank": 1365,
     "countryRank": 4
   },
   {
@@ -24410,7 +24399,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1368,
+    "aggregatedRank": 1366,
     "countryRank": 206
   },
   {
@@ -24423,7 +24412,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1369,
+    "aggregatedRank": 1367,
     "countryRank": 207
   },
   {
@@ -24436,7 +24425,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1370,
+    "aggregatedRank": 1368,
     "countryRank": 208
   },
   {
@@ -24449,7 +24438,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1371,
+    "aggregatedRank": 1369,
     "countryRank": 209
   },
   {
@@ -24462,7 +24451,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1372,
+    "aggregatedRank": 1370,
     "countryRank": 210
   },
   {
@@ -24475,7 +24464,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1373,
+    "aggregatedRank": 1371,
     "countryRank": 65
   },
   {
@@ -24488,7 +24477,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1374,
+    "aggregatedRank": 1372,
     "countryRank": 104
   },
   {
@@ -24501,7 +24490,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1375,
+    "aggregatedRank": 1373,
     "countryRank": 47
   },
   {
@@ -24514,7 +24503,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1376,
+    "aggregatedRank": 1374,
     "countryRank": 48
   },
   {
@@ -24527,7 +24516,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1377,
+    "aggregatedRank": 1375,
     "countryRank": 49
   },
   {
@@ -24540,7 +24529,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1378,
+    "aggregatedRank": 1376,
     "countryRank": 50
   },
   {
@@ -24553,7 +24542,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1379,
+    "aggregatedRank": 1377,
     "countryRank": 40
   },
   {
@@ -24566,7 +24555,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1380,
+    "aggregatedRank": 1378,
     "countryRank": 105
   },
   {
@@ -24579,7 +24568,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1381,
+    "aggregatedRank": 1379,
     "countryRank": 5
   },
   {
@@ -24592,7 +24581,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1382,
+    "aggregatedRank": 1380,
     "countryRank": 30
   },
   {
@@ -24605,7 +24594,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1383,
+    "aggregatedRank": 1381,
     "countryRank": 51
   },
   {
@@ -24618,7 +24607,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1384,
+    "aggregatedRank": 1382,
     "countryRank": 52
   },
   {
@@ -24631,7 +24620,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1385,
+    "aggregatedRank": 1383,
     "countryRank": 53
   },
   {
@@ -24644,7 +24633,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1386,
+    "aggregatedRank": 1384,
     "countryRank": 15
   },
   {
@@ -24657,7 +24646,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1387,
+    "aggregatedRank": 1385,
     "countryRank": 47
   },
   {
@@ -24670,7 +24659,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1388,
+    "aggregatedRank": 1386,
     "countryRank": 6
   },
   {
@@ -24683,7 +24672,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1389,
+    "aggregatedRank": 1387,
     "countryRank": 5
   },
   {
@@ -24696,7 +24685,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1390,
+    "aggregatedRank": 1388,
     "countryRank": 7
   },
   {
@@ -24709,7 +24698,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1391,
+    "aggregatedRank": 1389,
     "countryRank": 31
   },
   {
@@ -24722,7 +24711,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1392,
+    "aggregatedRank": 1390,
     "countryRank": 2
   },
   {
@@ -24735,7 +24724,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1393,
+    "aggregatedRank": 1391,
     "countryRank": 54
   },
   {
@@ -24748,7 +24737,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1394,
+    "aggregatedRank": 1392,
     "countryRank": 55
   },
   {
@@ -24761,7 +24750,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1395,
+    "aggregatedRank": 1393,
     "countryRank": 56
   },
   {
@@ -24774,7 +24763,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1396,
+    "aggregatedRank": 1394,
     "countryRank": 2
   },
   {
@@ -24787,7 +24776,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1397,
+    "aggregatedRank": 1395,
     "countryRank": 26
   },
   {
@@ -24800,7 +24789,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1398,
+    "aggregatedRank": 1396,
     "countryRank": 12
   },
   {
@@ -24813,7 +24802,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1399,
+    "aggregatedRank": 1397,
     "countryRank": 9
   },
   {
@@ -24826,7 +24815,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1400,
+    "aggregatedRank": 1398,
     "countryRank": 41
   },
   {
@@ -24839,7 +24828,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1401,
+    "aggregatedRank": 1399,
     "countryRank": 57
   },
   {
@@ -24852,7 +24841,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1402,
+    "aggregatedRank": 1400,
     "countryRank": 58
   },
   {
@@ -24865,7 +24854,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1403,
+    "aggregatedRank": 1401,
     "countryRank": 74
   },
   {
@@ -24878,7 +24867,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1404,
+    "aggregatedRank": 1402,
     "countryRank": 2
   },
   {
@@ -24894,7 +24883,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1405,
+    "aggregatedRank": 1403,
     "countryRank": 48
   },
   {
@@ -24910,7 +24899,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1406,
+    "aggregatedRank": 1404,
     "countryRank": 4
   },
   {
@@ -24926,7 +24915,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1407,
+    "aggregatedRank": 1405,
     "countryRank": 27
   },
   {
@@ -24939,7 +24928,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1408,
+    "aggregatedRank": 1406,
     "countryRank": 5
   },
   {
@@ -24952,7 +24941,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1409,
+    "aggregatedRank": 1407,
     "countryRank": 4
   },
   {
@@ -24968,7 +24957,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1410,
+    "aggregatedRank": 1408,
     "countryRank": 7
   },
   {
@@ -24984,7 +24973,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1411,
+    "aggregatedRank": 1409,
     "countryRank": 16
   },
   {
@@ -25000,7 +24989,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1412,
+    "aggregatedRank": 1410,
     "countryRank": 35
   },
   {
@@ -25013,7 +25002,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1413,
+    "aggregatedRank": 1411,
     "countryRank": 3
   },
   {
@@ -25029,7 +25018,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1414,
+    "aggregatedRank": 1412,
     "countryRank": 16
   },
   {
@@ -25042,7 +25031,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1415,
+    "aggregatedRank": 1413,
     "countryRank": 4
   },
   {
@@ -25058,7 +25047,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1416,
+    "aggregatedRank": 1414,
     "countryRank": 17
   },
   {
@@ -25074,7 +25063,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1417,
+    "aggregatedRank": 1415,
     "countryRank": 6
   },
   {
@@ -25087,7 +25076,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1418,
+    "aggregatedRank": 1416,
     "countryRank": 3
   },
   {
@@ -25103,7 +25092,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1419,
+    "aggregatedRank": 1417,
     "countryRank": 17
   },
   {
@@ -25119,7 +25108,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1420,
+    "aggregatedRank": 1418,
     "countryRank": 30
   },
   {
@@ -25132,7 +25121,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1421,
+    "aggregatedRank": 1419,
     "countryRank": 2
   },
   {
@@ -25148,7 +25137,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1422,
+    "aggregatedRank": 1420,
     "countryRank": 2
   },
   {
@@ -25161,7 +25150,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1423,
+    "aggregatedRank": 1421,
     "countryRank": 6
   },
   {
@@ -25174,7 +25163,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1424,
+    "aggregatedRank": 1422,
     "countryRank": 75
   },
   {
@@ -25187,7 +25176,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1425,
+    "aggregatedRank": 1423,
     "countryRank": 1
   },
   {
@@ -25200,7 +25189,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1426,
+    "aggregatedRank": 1424,
     "countryRank": 4
   },
   {
@@ -25216,7 +25205,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1427,
+    "aggregatedRank": 1425,
     "countryRank": 2
   },
   {
@@ -25232,7 +25221,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1428,
+    "aggregatedRank": 1426,
     "countryRank": 8
   },
   {
@@ -25245,7 +25234,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1429,
+    "aggregatedRank": 1427,
     "countryRank": 18
   },
   {
@@ -25258,7 +25247,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1430,
+    "aggregatedRank": 1428,
     "countryRank": 5
   },
   {
@@ -25271,7 +25260,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1431,
+    "aggregatedRank": 1429,
     "countryRank": 49
   },
   {
@@ -25284,7 +25273,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1432,
+    "aggregatedRank": 1430,
     "countryRank": 6
   },
   {
@@ -25300,7 +25289,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1433,
+    "aggregatedRank": 1431,
     "countryRank": 59
   },
   {
@@ -25316,7 +25305,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1434,
+    "aggregatedRank": 1432,
     "countryRank": 28
   },
   {
@@ -25332,7 +25321,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1435,
+    "aggregatedRank": 1433,
     "countryRank": 9
   },
   {
@@ -25345,7 +25334,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1436,
+    "aggregatedRank": 1434,
     "countryRank": 2
   },
   {
@@ -25358,7 +25347,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1437,
+    "aggregatedRank": 1435,
     "countryRank": 9
   },
   {
@@ -25371,7 +25360,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1438,
+    "aggregatedRank": 1436,
     "countryRank": 1
   },
   {
@@ -25384,7 +25373,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1439,
+    "aggregatedRank": 1437,
     "countryRank": 2
   },
   {
@@ -25397,7 +25386,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1440,
+    "aggregatedRank": 1438,
     "countryRank": 20
   },
   {
@@ -25410,7 +25399,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1441,
+    "aggregatedRank": 1439,
     "countryRank": 10
   },
   {
@@ -25423,7 +25412,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1442,
+    "aggregatedRank": 1440,
     "countryRank": 3
   },
   {
@@ -25439,7 +25428,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1443,
+    "aggregatedRank": 1441,
     "countryRank": 4
   },
   {
@@ -25455,7 +25444,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1444,
+    "aggregatedRank": 1442,
     "countryRank": 29
   },
   {
@@ -25468,7 +25457,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1445,
+    "aggregatedRank": 1443,
     "countryRank": 60
   },
   {
@@ -25481,7 +25470,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1446,
+    "aggregatedRank": 1444,
     "countryRank": 5
   },
   {
@@ -25494,7 +25483,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1447,
+    "aggregatedRank": 1445,
     "countryRank": 30
   },
   {
@@ -25507,7 +25496,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1448,
+    "aggregatedRank": 1446,
     "countryRank": 2
   },
   {
@@ -25520,7 +25509,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1449,
+    "aggregatedRank": 1447,
     "countryRank": 50
   },
   {
@@ -25533,7 +25522,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1450,
+    "aggregatedRank": 1448,
     "countryRank": 4
   },
   {
@@ -25546,7 +25535,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1451,
+    "aggregatedRank": 1449,
     "countryRank": 22
   },
   {
@@ -25559,7 +25548,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1452,
+    "aggregatedRank": 1450,
     "countryRank": 8
   },
   {
@@ -25572,7 +25561,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1453,
+    "aggregatedRank": 1451,
     "countryRank": 7
   },
   {
@@ -25585,7 +25574,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1454,
+    "aggregatedRank": 1452,
     "countryRank": 6
   },
   {
@@ -25598,7 +25587,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1455,
+    "aggregatedRank": 1453,
     "countryRank": 21
   },
   {
@@ -25614,7 +25603,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1456,
+    "aggregatedRank": 1454,
     "countryRank": 51
   },
   {
@@ -25630,7 +25619,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1457,
+    "aggregatedRank": 1455,
     "countryRank": 31
   },
   {
@@ -25646,7 +25635,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1458,
+    "aggregatedRank": 1456,
     "countryRank": 10
   },
   {
@@ -25659,7 +25648,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1459,
+    "aggregatedRank": 1457,
     "countryRank": 7
   },
   {
@@ -25672,7 +25661,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1460,
+    "aggregatedRank": 1458,
     "countryRank": 5
   },
   {
@@ -25685,7 +25674,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1461,
+    "aggregatedRank": 1459,
     "countryRank": 19
   },
   {
@@ -25698,7 +25687,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1462,
+    "aggregatedRank": 1460,
     "countryRank": 22
   },
   {
@@ -25711,7 +25700,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1463,
+    "aggregatedRank": 1461,
     "countryRank": 6
   },
   {
@@ -25724,7 +25713,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1464,
+    "aggregatedRank": 1462,
     "countryRank": 11
   },
   {
@@ -25737,7 +25726,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1465,
+    "aggregatedRank": 1463,
     "countryRank": 5
   },
   {
@@ -25750,7 +25739,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1466,
+    "aggregatedRank": 1464,
     "countryRank": 23
   },
   {
@@ -25763,7 +25752,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1467,
+    "aggregatedRank": 1465,
     "countryRank": 211
   },
   {
@@ -25776,7 +25765,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1468,
+    "aggregatedRank": 1466,
     "countryRank": 32
   },
   {
@@ -25789,7 +25778,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1469,
+    "aggregatedRank": 1467,
     "countryRank": 3
   },
   {
@@ -25805,7 +25794,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1470,
+    "aggregatedRank": 1468,
     "countryRank": 33
   },
   {
@@ -25821,7 +25810,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1471,
+    "aggregatedRank": 1469,
     "countryRank": 11
   },
   {
@@ -25834,7 +25823,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1472,
+    "aggregatedRank": 1470,
     "countryRank": 31
   },
   {
@@ -25847,7 +25836,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1473,
+    "aggregatedRank": 1471,
     "countryRank": 212
   },
   {
@@ -25860,7 +25849,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1474,
+    "aggregatedRank": 1472,
     "countryRank": 1
   },
   {
@@ -25873,21 +25862,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1475,
+    "aggregatedRank": 1473,
     "countryRank": 23
-  },
-  {
-    "name": "University of the Republic",
-    "country": "Uruguay",
-    "aggregatedScore": 48.24999999999999,
-    "originalRankings": {
-      "qs": {
-        "rank": 661
-      }
-    },
-    "appearances": 1,
-    "aggregatedRank": 1476,
-    "countryRank": 2
   },
   {
     "name": "Kazakh National Pedagogical University",
@@ -25899,7 +25875,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1477,
+    "aggregatedRank": 1474,
     "countryRank": 6
   },
   {
@@ -25912,7 +25888,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1478,
+    "aggregatedRank": 1475,
     "countryRank": 7
   },
   {
@@ -25925,7 +25901,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1479,
+    "aggregatedRank": 1476,
     "countryRank": 61
   },
   {
@@ -25938,7 +25914,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1480,
+    "aggregatedRank": 1477,
     "countryRank": 1
   },
   {
@@ -25951,7 +25927,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1481,
+    "aggregatedRank": 1478,
     "countryRank": 5
   },
   {
@@ -25964,7 +25940,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1482,
+    "aggregatedRank": 1479,
     "countryRank": 1
   },
   {
@@ -25977,7 +25953,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1483,
+    "aggregatedRank": 1480,
     "countryRank": 32
   },
   {
@@ -25993,7 +25969,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1484,
+    "aggregatedRank": 1481,
     "countryRank": 34
   },
   {
@@ -26009,7 +25985,7 @@
       }
     },
     "appearances": 2,
-    "aggregatedRank": 1485,
+    "aggregatedRank": 1482,
     "countryRank": 32
   },
   {
@@ -26022,7 +25998,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1486,
+    "aggregatedRank": 1483,
     "countryRank": 3
   },
   {
@@ -26035,7 +26011,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1487,
+    "aggregatedRank": 1484,
     "countryRank": 53
   },
   {
@@ -26048,7 +26024,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1488,
+    "aggregatedRank": 1485,
     "countryRank": 8
   },
   {
@@ -26061,7 +26037,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1489,
+    "aggregatedRank": 1486,
     "countryRank": 62
   },
   {
@@ -26074,7 +26050,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1490,
+    "aggregatedRank": 1487,
     "countryRank": 24
   },
   {
@@ -26087,7 +26063,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1491,
+    "aggregatedRank": 1488,
     "countryRank": 5
   },
   {
@@ -26100,7 +26076,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1492,
+    "aggregatedRank": 1489,
     "countryRank": 8
   },
   {
@@ -26113,7 +26089,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1493,
+    "aggregatedRank": 1490,
     "countryRank": 63
   },
   {
@@ -26126,7 +26102,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1494,
+    "aggregatedRank": 1491,
     "countryRank": 1
   },
   {
@@ -26139,7 +26115,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1495,
+    "aggregatedRank": 1492,
     "countryRank": 27
   },
   {
@@ -26152,7 +26128,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1496,
+    "aggregatedRank": 1493,
     "countryRank": 3
   },
   {
@@ -26165,7 +26141,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1497,
+    "aggregatedRank": 1494,
     "countryRank": 25
   },
   {
@@ -26178,8 +26154,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1498,
-    "countryRank": 3
+    "aggregatedRank": 1495,
+    "countryRank": 2
   },
   {
     "name": "Catholic University Andres Bello",
@@ -26191,7 +26167,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1499,
+    "aggregatedRank": 1496,
     "countryRank": 2
   },
   {
@@ -26204,7 +26180,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1500,
+    "aggregatedRank": 1497,
     "countryRank": 3
   },
   {
@@ -26217,7 +26193,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1501,
+    "aggregatedRank": 1498,
     "countryRank": 4
   },
   {
@@ -26230,7 +26206,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1502,
+    "aggregatedRank": 1499,
     "countryRank": 6
   },
   {
@@ -26243,7 +26219,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1503,
+    "aggregatedRank": 1500,
     "countryRank": 213
   },
   {
@@ -26256,7 +26232,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1504,
+    "aggregatedRank": 1501,
     "countryRank": 8
   },
   {
@@ -26269,7 +26245,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1505,
+    "aggregatedRank": 1502,
     "countryRank": 7
   },
   {
@@ -26282,7 +26258,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1506,
+    "aggregatedRank": 1503,
     "countryRank": 7
   },
   {
@@ -26295,7 +26271,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1507,
+    "aggregatedRank": 1504,
     "countryRank": 6
   },
   {
@@ -26308,7 +26284,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1508,
+    "aggregatedRank": 1505,
     "countryRank": 7
   },
   {
@@ -26321,7 +26297,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1509,
+    "aggregatedRank": 1506,
     "countryRank": 2
   },
   {
@@ -26334,7 +26310,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1510,
+    "aggregatedRank": 1507,
     "countryRank": 6
   },
   {
@@ -26347,7 +26323,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1511,
+    "aggregatedRank": 1508,
     "countryRank": 2
   },
   {
@@ -26360,7 +26336,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1512,
+    "aggregatedRank": 1509,
     "countryRank": 214
   },
   {
@@ -26373,7 +26349,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1513,
+    "aggregatedRank": 1510,
     "countryRank": 13
   },
   {
@@ -26386,7 +26362,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1514,
+    "aggregatedRank": 1511,
     "countryRank": 8
   },
   {
@@ -26399,7 +26375,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1515,
+    "aggregatedRank": 1512,
     "countryRank": 1
   },
   {
@@ -26412,7 +26388,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1516,
+    "aggregatedRank": 1513,
     "countryRank": 8
   },
   {
@@ -26425,7 +26401,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1517,
+    "aggregatedRank": 1514,
     "countryRank": 2
   },
   {
@@ -26438,7 +26414,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1518,
+    "aggregatedRank": 1515,
     "countryRank": 64
   },
   {
@@ -26451,7 +26427,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1519,
+    "aggregatedRank": 1516,
     "countryRank": 2
   },
   {
@@ -26464,7 +26440,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1520,
+    "aggregatedRank": 1517,
     "countryRank": 8
   },
   {
@@ -26477,7 +26453,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1521,
+    "aggregatedRank": 1518,
     "countryRank": 24
   },
   {
@@ -26490,7 +26466,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1522,
+    "aggregatedRank": 1519,
     "countryRank": 4
   },
   {
@@ -26503,7 +26479,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1523,
+    "aggregatedRank": 1520,
     "countryRank": 9
   },
   {
@@ -26516,7 +26492,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1524,
+    "aggregatedRank": 1521,
     "countryRank": 9
   },
   {
@@ -26529,7 +26505,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1525,
+    "aggregatedRank": 1522,
     "countryRank": 1
   },
   {
@@ -26542,7 +26518,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1526,
+    "aggregatedRank": 1523,
     "countryRank": 2
   },
   {
@@ -26555,7 +26531,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1527,
+    "aggregatedRank": 1524,
     "countryRank": 26
   },
   {
@@ -26568,7 +26544,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1528,
+    "aggregatedRank": 1525,
     "countryRank": 8
   },
   {
@@ -26581,7 +26557,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1529,
+    "aggregatedRank": 1526,
     "countryRank": 1
   },
   {
@@ -26594,7 +26570,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1530,
+    "aggregatedRank": 1527,
     "countryRank": 12
   },
   {
@@ -26607,7 +26583,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1531,
+    "aggregatedRank": 1528,
     "countryRank": 9
   },
   {
@@ -26620,7 +26596,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1532,
+    "aggregatedRank": 1529,
     "countryRank": 1
   },
   {
@@ -26633,7 +26609,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1533,
+    "aggregatedRank": 1530,
     "countryRank": 3
   },
   {
@@ -26646,7 +26622,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1534,
+    "aggregatedRank": 1531,
     "countryRank": 9
   },
   {
@@ -26659,7 +26635,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1535,
+    "aggregatedRank": 1532,
     "countryRank": 5
   },
   {
@@ -26672,7 +26648,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1536,
+    "aggregatedRank": 1533,
     "countryRank": 4
   },
   {
@@ -26685,7 +26661,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1537,
+    "aggregatedRank": 1534,
     "countryRank": 12
   },
   {
@@ -26698,7 +26674,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1538,
+    "aggregatedRank": 1535,
     "countryRank": 13
   },
   {
@@ -26711,7 +26687,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1539,
+    "aggregatedRank": 1536,
     "countryRank": 3
   },
   {
@@ -26724,8 +26700,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1540,
-    "countryRank": 4
+    "aggregatedRank": 1537,
+    "countryRank": 3
   },
   {
     "name": "Clarkson University",
@@ -26737,7 +26713,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1541,
+    "aggregatedRank": 1538,
     "countryRank": 215
   },
   {
@@ -26750,7 +26726,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1542,
+    "aggregatedRank": 1539,
     "countryRank": 216
   },
   {
@@ -26763,7 +26739,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1543,
+    "aggregatedRank": 1540,
     "countryRank": 5
   },
   {
@@ -26776,7 +26752,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1544,
+    "aggregatedRank": 1541,
     "countryRank": 11
   },
   {
@@ -26789,7 +26765,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1545,
+    "aggregatedRank": 1542,
     "countryRank": 14
   },
   {
@@ -26802,7 +26778,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1546,
+    "aggregatedRank": 1543,
     "countryRank": 217
   },
   {
@@ -26815,7 +26791,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1547,
+    "aggregatedRank": 1544,
     "countryRank": 218
   },
   {
@@ -26828,7 +26804,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1548,
+    "aggregatedRank": 1545,
     "countryRank": 153
   },
   {
@@ -26841,7 +26817,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1549,
+    "aggregatedRank": 1546,
     "countryRank": 1
   },
   {
@@ -26854,7 +26830,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1550,
+    "aggregatedRank": 1547,
     "countryRank": 9
   },
   {
@@ -26867,7 +26843,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1551,
+    "aggregatedRank": 1548,
     "countryRank": 10
   },
   {
@@ -26880,7 +26856,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1552,
+    "aggregatedRank": 1549,
     "countryRank": 2
   },
   {
@@ -26893,7 +26869,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1553,
+    "aggregatedRank": 1550,
     "countryRank": 54
   },
   {
@@ -26906,7 +26882,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1554,
+    "aggregatedRank": 1551,
     "countryRank": 2
   },
   {
@@ -26919,7 +26895,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1555,
+    "aggregatedRank": 1552,
     "countryRank": 7
   },
   {
@@ -26932,7 +26908,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1556,
+    "aggregatedRank": 1553,
     "countryRank": 8
   },
   {
@@ -26945,7 +26921,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1557,
+    "aggregatedRank": 1554,
     "countryRank": 35
   },
   {
@@ -26958,7 +26934,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1558,
+    "aggregatedRank": 1555,
     "countryRank": 2
   },
   {
@@ -26971,7 +26947,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1559,
+    "aggregatedRank": 1556,
     "countryRank": 10
   },
   {
@@ -26984,7 +26960,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1560,
+    "aggregatedRank": 1557,
     "countryRank": 3
   },
   {
@@ -26997,7 +26973,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1561,
+    "aggregatedRank": 1558,
     "countryRank": 15
   },
   {
@@ -27010,7 +26986,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1562,
+    "aggregatedRank": 1559,
     "countryRank": 27
   },
   {
@@ -27023,7 +26999,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1563,
+    "aggregatedRank": 1560,
     "countryRank": 3
   },
   {
@@ -27036,7 +27012,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1564,
+    "aggregatedRank": 1561,
     "countryRank": 16
   },
   {
@@ -27049,7 +27025,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1565,
+    "aggregatedRank": 1562,
     "countryRank": 106
   },
   {
@@ -27062,8 +27038,8 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1566,
-    "countryRank": 5
+    "aggregatedRank": 1563,
+    "countryRank": 4
   },
   {
     "name": "Wroclaw University of Science and Technology",
@@ -27075,7 +27051,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1567,
+    "aggregatedRank": 1564,
     "countryRank": 16
   },
   {
@@ -27088,7 +27064,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1568,
+    "aggregatedRank": 1565,
     "countryRank": 6
   },
   {
@@ -27101,7 +27077,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1569,
+    "aggregatedRank": 1566,
     "countryRank": 11
   },
   {
@@ -27114,7 +27090,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1570,
+    "aggregatedRank": 1567,
     "countryRank": 11
   },
   {
@@ -27127,7 +27103,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1571,
+    "aggregatedRank": 1568,
     "countryRank": 28
   },
   {
@@ -27140,7 +27116,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1572,
+    "aggregatedRank": 1569,
     "countryRank": 7
   },
   {
@@ -27153,7 +27129,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1573,
+    "aggregatedRank": 1570,
     "countryRank": 8
   },
   {
@@ -27166,7 +27142,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1574,
+    "aggregatedRank": 1571,
     "countryRank": 9
   },
   {
@@ -27179,7 +27155,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1575,
+    "aggregatedRank": 1572,
     "countryRank": 10
   },
   {
@@ -27192,7 +27168,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1576,
+    "aggregatedRank": 1573,
     "countryRank": 1
   },
   {
@@ -27205,7 +27181,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1577,
+    "aggregatedRank": 1574,
     "countryRank": 4
   },
   {
@@ -27218,7 +27194,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1578,
+    "aggregatedRank": 1575,
     "countryRank": 9
   },
   {
@@ -27231,7 +27207,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1579,
+    "aggregatedRank": 1576,
     "countryRank": 10
   },
   {
@@ -27244,7 +27220,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1580,
+    "aggregatedRank": 1577,
     "countryRank": 12
   },
   {
@@ -27257,7 +27233,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1581,
+    "aggregatedRank": 1578,
     "countryRank": 10
   },
   {
@@ -27270,7 +27246,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1582,
+    "aggregatedRank": 1579,
     "countryRank": 3
   },
   {
@@ -27283,7 +27259,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1583,
+    "aggregatedRank": 1580,
     "countryRank": 52
   },
   {
@@ -27296,7 +27272,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1584,
+    "aggregatedRank": 1581,
     "countryRank": 55
   },
   {
@@ -27309,7 +27285,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1585,
+    "aggregatedRank": 1582,
     "countryRank": 10
   },
   {
@@ -27322,7 +27298,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1586,
+    "aggregatedRank": 1583,
     "countryRank": 10
   },
   {
@@ -27335,7 +27311,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1587,
+    "aggregatedRank": 1584,
     "countryRank": 9
   },
   {
@@ -27348,7 +27324,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1588,
+    "aggregatedRank": 1585,
     "countryRank": 36
   },
   {
@@ -27361,7 +27337,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1589,
+    "aggregatedRank": 1586,
     "countryRank": 37
   },
   {
@@ -27374,7 +27350,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1590,
+    "aggregatedRank": 1587,
     "countryRank": 1
   },
   {
@@ -27387,7 +27363,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1591,
+    "aggregatedRank": 1588,
     "countryRank": 10
   },
   {
@@ -27400,7 +27376,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1592,
+    "aggregatedRank": 1589,
     "countryRank": 7
   },
   {
@@ -27413,7 +27389,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1593,
+    "aggregatedRank": 1590,
     "countryRank": 8
   },
   {
@@ -27426,7 +27402,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1594,
+    "aggregatedRank": 1591,
     "countryRank": 13
   },
   {
@@ -27439,7 +27415,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1595,
+    "aggregatedRank": 1592,
     "countryRank": 29
   },
   {
@@ -27452,7 +27428,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1596,
+    "aggregatedRank": 1593,
     "countryRank": 3
   },
   {
@@ -27465,7 +27441,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1597,
+    "aggregatedRank": 1594,
     "countryRank": 65
   },
   {
@@ -27478,7 +27454,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1598,
+    "aggregatedRank": 1595,
     "countryRank": 12
   },
   {
@@ -27491,7 +27467,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1599,
+    "aggregatedRank": 1596,
     "countryRank": 154
   },
   {
@@ -27504,7 +27480,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1600,
+    "aggregatedRank": 1597,
     "countryRank": 155
   },
   {
@@ -27517,7 +27493,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1601,
+    "aggregatedRank": 1598,
     "countryRank": 76
   },
   {
@@ -27530,7 +27506,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1602,
+    "aggregatedRank": 1599,
     "countryRank": 219
   },
   {
@@ -27543,7 +27519,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1603,
+    "aggregatedRank": 1600,
     "countryRank": 156
   },
   {
@@ -27556,7 +27532,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1604,
+    "aggregatedRank": 1601,
     "countryRank": 157
   },
   {
@@ -27569,7 +27545,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1605,
+    "aggregatedRank": 1602,
     "countryRank": 158
   },
   {
@@ -27582,7 +27558,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1606,
+    "aggregatedRank": 1603,
     "countryRank": 159
   },
   {
@@ -27595,7 +27571,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1607,
+    "aggregatedRank": 1604,
     "countryRank": 160
   },
   {
@@ -27608,7 +27584,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1608,
+    "aggregatedRank": 1605,
     "countryRank": 161
   },
   {
@@ -27621,7 +27597,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1609,
+    "aggregatedRank": 1606,
     "countryRank": 162
   },
   {
@@ -27634,7 +27610,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1610,
+    "aggregatedRank": 1607,
     "countryRank": 163
   },
   {
@@ -27647,7 +27623,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1611,
+    "aggregatedRank": 1608,
     "countryRank": 164
   },
   {
@@ -27660,7 +27636,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1612,
+    "aggregatedRank": 1609,
     "countryRank": 53
   },
   {
@@ -27673,7 +27649,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1613,
+    "aggregatedRank": 1610,
     "countryRank": 12
   },
   {
@@ -27686,7 +27662,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1614,
+    "aggregatedRank": 1611,
     "countryRank": 220
   },
   {
@@ -27699,7 +27675,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1615,
+    "aggregatedRank": 1612,
     "countryRank": 165
   },
   {
@@ -27712,7 +27688,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1616,
+    "aggregatedRank": 1613,
     "countryRank": 166
   },
   {
@@ -27725,7 +27701,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1617,
+    "aggregatedRank": 1614,
     "countryRank": 167
   },
   {
@@ -27738,7 +27714,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1618,
+    "aggregatedRank": 1615,
     "countryRank": 168
   },
   {
@@ -27751,7 +27727,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1619,
+    "aggregatedRank": 1616,
     "countryRank": 169
   },
   {
@@ -27764,7 +27740,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1620,
+    "aggregatedRank": 1617,
     "countryRank": 170
   },
   {
@@ -27777,7 +27753,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1621,
+    "aggregatedRank": 1618,
     "countryRank": 171
   },
   {
@@ -27790,7 +27766,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1622,
+    "aggregatedRank": 1619,
     "countryRank": 172
   },
   {
@@ -27803,7 +27779,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1623,
+    "aggregatedRank": 1620,
     "countryRank": 173
   },
   {
@@ -27816,7 +27792,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1624,
+    "aggregatedRank": 1621,
     "countryRank": 174
   },
   {
@@ -27829,7 +27805,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1625,
+    "aggregatedRank": 1622,
     "countryRank": 175
   },
   {
@@ -27842,7 +27818,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1626,
+    "aggregatedRank": 1623,
     "countryRank": 176
   },
   {
@@ -27855,7 +27831,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1627,
+    "aggregatedRank": 1624,
     "countryRank": 38
   },
   {
@@ -27868,7 +27844,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1628,
+    "aggregatedRank": 1625,
     "countryRank": 221
   },
   {
@@ -27881,7 +27857,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1629,
+    "aggregatedRank": 1626,
     "countryRank": 19
   },
   {
@@ -27894,7 +27870,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1630,
+    "aggregatedRank": 1627,
     "countryRank": 177
   },
   {
@@ -27907,7 +27883,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1631,
+    "aggregatedRank": 1628,
     "countryRank": 178
   },
   {
@@ -27920,7 +27896,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1632,
+    "aggregatedRank": 1629,
     "countryRank": 5
   },
   {
@@ -27933,7 +27909,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1633,
+    "aggregatedRank": 1630,
     "countryRank": 179
   },
   {
@@ -27946,7 +27922,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1634,
+    "aggregatedRank": 1631,
     "countryRank": 180
   },
   {
@@ -27959,7 +27935,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1635,
+    "aggregatedRank": 1632,
     "countryRank": 181
   },
   {
@@ -27972,7 +27948,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1636,
+    "aggregatedRank": 1633,
     "countryRank": 17
   },
   {
@@ -27985,7 +27961,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1637,
+    "aggregatedRank": 1634,
     "countryRank": 18
   },
   {
@@ -27998,7 +27974,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1638,
+    "aggregatedRank": 1635,
     "countryRank": 19
   },
   {
@@ -28011,7 +27987,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1639,
+    "aggregatedRank": 1636,
     "countryRank": 182
   },
   {
@@ -28024,7 +28000,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1640,
+    "aggregatedRank": 1637,
     "countryRank": 183
   },
   {
@@ -28037,7 +28013,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1641,
+    "aggregatedRank": 1638,
     "countryRank": 184
   },
   {
@@ -28050,7 +28026,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1642,
+    "aggregatedRank": 1639,
     "countryRank": 185
   },
   {
@@ -28063,7 +28039,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1643,
+    "aggregatedRank": 1640,
     "countryRank": 77
   },
   {
@@ -28076,7 +28052,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1644,
+    "aggregatedRank": 1641,
     "countryRank": 78
   },
   {
@@ -28089,7 +28065,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1645,
+    "aggregatedRank": 1642,
     "countryRank": 79
   },
   {
@@ -28102,7 +28078,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1646,
+    "aggregatedRank": 1643,
     "countryRank": 54
   },
   {
@@ -28115,7 +28091,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1647,
+    "aggregatedRank": 1644,
     "countryRank": 55
   },
   {
@@ -28128,7 +28104,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1648,
+    "aggregatedRank": 1645,
     "countryRank": 39
   },
   {
@@ -28141,7 +28117,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1649,
+    "aggregatedRank": 1646,
     "countryRank": 40
   },
   {
@@ -28154,7 +28130,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1650,
+    "aggregatedRank": 1647,
     "countryRank": 33
   },
   {
@@ -28167,7 +28143,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1651,
+    "aggregatedRank": 1648,
     "countryRank": 15
   },
   {
@@ -28180,7 +28156,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1652,
+    "aggregatedRank": 1649,
     "countryRank": 222
   },
   {
@@ -28193,7 +28169,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1653,
+    "aggregatedRank": 1650,
     "countryRank": 56
   },
   {
@@ -28206,7 +28182,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1654,
+    "aggregatedRank": 1651,
     "countryRank": 186
   },
   {
@@ -28219,7 +28195,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1655,
+    "aggregatedRank": 1652,
     "countryRank": 187
   },
   {
@@ -28232,7 +28208,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1656,
+    "aggregatedRank": 1653,
     "countryRank": 188
   },
   {
@@ -28245,7 +28221,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1657,
+    "aggregatedRank": 1654,
     "countryRank": 66
   },
   {
@@ -28258,7 +28234,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1658,
+    "aggregatedRank": 1655,
     "countryRank": 189
   },
   {
@@ -28271,7 +28247,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1659,
+    "aggregatedRank": 1656,
     "countryRank": 20
   },
   {
@@ -28284,7 +28260,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1660,
+    "aggregatedRank": 1657,
     "countryRank": 21
   },
   {
@@ -28297,7 +28273,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1661,
+    "aggregatedRank": 1658,
     "countryRank": 190
   },
   {
@@ -28310,7 +28286,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1662,
+    "aggregatedRank": 1659,
     "countryRank": 191
   },
   {
@@ -28323,7 +28299,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1663,
+    "aggregatedRank": 1660,
     "countryRank": 192
   },
   {
@@ -28336,7 +28312,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1664,
+    "aggregatedRank": 1661,
     "countryRank": 193
   },
   {
@@ -28349,7 +28325,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1665,
+    "aggregatedRank": 1662,
     "countryRank": 194
   },
   {
@@ -28362,7 +28338,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1666,
+    "aggregatedRank": 1663,
     "countryRank": 195
   },
   {
@@ -28375,7 +28351,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1667,
+    "aggregatedRank": 1664,
     "countryRank": 196
   },
   {
@@ -28388,7 +28364,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1668,
+    "aggregatedRank": 1665,
     "countryRank": 197
   },
   {
@@ -28401,7 +28377,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1669,
+    "aggregatedRank": 1666,
     "countryRank": 80
   },
   {
@@ -28414,7 +28390,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1670,
+    "aggregatedRank": 1667,
     "countryRank": 57
   },
   {
@@ -28427,7 +28403,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1671,
+    "aggregatedRank": 1668,
     "countryRank": 58
   },
   {
@@ -28440,7 +28416,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1672,
+    "aggregatedRank": 1669,
     "countryRank": 34
   },
   {
@@ -28453,7 +28429,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1673,
+    "aggregatedRank": 1670,
     "countryRank": 198
   },
   {
@@ -28466,7 +28442,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1674,
+    "aggregatedRank": 1671,
     "countryRank": 199
   },
   {
@@ -28479,7 +28455,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1675,
+    "aggregatedRank": 1672,
     "countryRank": 200
   },
   {
@@ -28492,7 +28468,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1676,
+    "aggregatedRank": 1673,
     "countryRank": 201
   },
   {
@@ -28505,7 +28481,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1677,
+    "aggregatedRank": 1674,
     "countryRank": 202
   },
   {
@@ -28518,7 +28494,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1678,
+    "aggregatedRank": 1675,
     "countryRank": 203
   },
   {
@@ -28531,7 +28507,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1679,
+    "aggregatedRank": 1676,
     "countryRank": 18
   },
   {
@@ -28544,7 +28520,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1680,
+    "aggregatedRank": 1677,
     "countryRank": 223
   },
   {
@@ -28557,7 +28533,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1681,
+    "aggregatedRank": 1678,
     "countryRank": 22
   },
   {
@@ -28570,7 +28546,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1682,
+    "aggregatedRank": 1679,
     "countryRank": 23
   },
   {
@@ -28583,7 +28559,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1683,
+    "aggregatedRank": 1680,
     "countryRank": 24
   },
   {
@@ -28596,7 +28572,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1684,
+    "aggregatedRank": 1681,
     "countryRank": 25
   },
   {
@@ -28609,7 +28585,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1685,
+    "aggregatedRank": 1682,
     "countryRank": 26
   },
   {
@@ -28622,7 +28598,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1686,
+    "aggregatedRank": 1683,
     "countryRank": 36
   },
   {
@@ -28635,7 +28611,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1687,
+    "aggregatedRank": 1684,
     "countryRank": 11
   },
   {
@@ -28648,7 +28624,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1688,
+    "aggregatedRank": 1685,
     "countryRank": 204
   },
   {
@@ -28661,7 +28637,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1689,
+    "aggregatedRank": 1686,
     "countryRank": 205
   },
   {
@@ -28674,7 +28650,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1690,
+    "aggregatedRank": 1687,
     "countryRank": 206
   },
   {
@@ -28687,7 +28663,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1691,
+    "aggregatedRank": 1688,
     "countryRank": 207
   },
   {
@@ -28700,7 +28676,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1692,
+    "aggregatedRank": 1689,
     "countryRank": 208
   },
   {
@@ -28713,7 +28689,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1693,
+    "aggregatedRank": 1690,
     "countryRank": 209
   },
   {
@@ -28726,7 +28702,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1694,
+    "aggregatedRank": 1691,
     "countryRank": 210
   },
   {
@@ -28739,7 +28715,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1695,
+    "aggregatedRank": 1692,
     "countryRank": 211
   },
   {
@@ -28752,7 +28728,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1696,
+    "aggregatedRank": 1693,
     "countryRank": 212
   },
   {
@@ -28765,7 +28741,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1697,
+    "aggregatedRank": 1694,
     "countryRank": 56
   },
   {
@@ -28778,7 +28754,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1698,
+    "aggregatedRank": 1695,
     "countryRank": 57
   },
   {
@@ -28791,7 +28767,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1699,
+    "aggregatedRank": 1696,
     "countryRank": 59
   },
   {
@@ -28804,7 +28780,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1700,
+    "aggregatedRank": 1697,
     "countryRank": 41
   },
   {
@@ -28817,7 +28793,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1701,
+    "aggregatedRank": 1698,
     "countryRank": 35
   },
   {
@@ -28830,7 +28806,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1702,
+    "aggregatedRank": 1699,
     "countryRank": 19
   },
   {
@@ -28843,7 +28819,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1703,
+    "aggregatedRank": 1700,
     "countryRank": 20
   },
   {
@@ -28856,7 +28832,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1704,
+    "aggregatedRank": 1701,
     "countryRank": 224
   },
   {
@@ -28869,7 +28845,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1705,
+    "aggregatedRank": 1702,
     "countryRank": 225
   },
   {
@@ -28882,7 +28858,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1706,
+    "aggregatedRank": 1703,
     "countryRank": 226
   },
   {
@@ -28895,7 +28871,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1707,
+    "aggregatedRank": 1704,
     "countryRank": 227
   },
   {
@@ -28908,7 +28884,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1708,
+    "aggregatedRank": 1705,
     "countryRank": 213
   },
   {
@@ -28921,7 +28897,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1709,
+    "aggregatedRank": 1706,
     "countryRank": 3
   },
   {
@@ -28934,7 +28910,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1710,
+    "aggregatedRank": 1707,
     "countryRank": 228
   },
   {
@@ -28947,7 +28923,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1711,
+    "aggregatedRank": 1708,
     "countryRank": 214
   },
   {
@@ -28960,7 +28936,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1712,
+    "aggregatedRank": 1709,
     "countryRank": 215
   },
   {
@@ -28973,7 +28949,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1713,
+    "aggregatedRank": 1710,
     "countryRank": 16
   },
   {
@@ -28986,7 +28962,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1714,
+    "aggregatedRank": 1711,
     "countryRank": 216
   },
   {
@@ -28999,7 +28975,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1715,
+    "aggregatedRank": 1712,
     "countryRank": 217
   },
   {
@@ -29012,7 +28988,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1716,
+    "aggregatedRank": 1713,
     "countryRank": 218
   },
   {
@@ -29025,7 +29001,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1717,
+    "aggregatedRank": 1714,
     "countryRank": 219
   },
   {
@@ -29038,7 +29014,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1718,
+    "aggregatedRank": 1715,
     "countryRank": 220
   },
   {
@@ -29051,7 +29027,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1719,
+    "aggregatedRank": 1716,
     "countryRank": 221
   },
   {
@@ -29064,7 +29040,7 @@
       }
     },
     "appearances": 1,
-    "aggregatedRank": 1720,
+    "aggregatedRank": 1717,
     "countryRank": 222
   }
 ]

--- a/frontend/public/data/manual-university-mapping.json
+++ b/frontend/public/data/manual-university-mapping.json
@@ -491,4 +491,20 @@
     "originalName": "Queen's University",
     "suggestedStandardizedName": "Queens University"
   }
+  ,{
+    "originalName": "University of Porto",
+    "suggestedStandardizedName": "Universidade do Porto"
+  },
+  {
+    "originalName": "University of Lisbon",
+    "suggestedStandardizedName": "Universidade de Lisboa"
+  },
+  {
+    "originalName": "New University of Lisbon",
+    "suggestedStandardizedName": "Universidade Nova de Lisboa"
+  },
+  {
+    "originalName": "University of the Republic",
+    "suggestedStandardizedName": "Universidad de la Republica, Uruguay"
+  }
 ]


### PR DESCRIPTION
## Summary
- map several English names to their Spanish/Portuguese counterparts
- regenerate aggregated rankings

## Testing
- `npm install`
- `node scripts/scrape-rankings.js`

------
https://chatgpt.com/codex/tasks/task_e_685246dcbff08320976b2ac5233d6e49