### PR TITLE
Fix Sun Yet-San mapping

### DIFF
--- a/frontend/public/data/manual-university-mapping.json
+++ b/frontend/public/data/manual-university-mapping.json
@@ -506,5 +506,9 @@
   {
     "originalName": "University of the Republic",
     "suggestedStandardizedName": "Universidad de la Republica, Uruguay"
+  },
+  {
+    "originalName": "Sun Yet-San University",
+    "suggestedStandardizedName": "Sun Yat Sen University"
   }
 ]


### PR DESCRIPTION
## Summary
- revert the typo-correction rule for Sun Yat-sen
- map "Sun Yet-San University" manually
- regenerate aggregated rankings

## Testing
- `npm test -- --passWithNoTests`
- `node scripts/scrape-rankings.js`


------
https://chatgpt.com/codex/tasks/task_e_68525068adc88320bbd7cfb1f4aead46