### PR TITLE
Improve mobile wrapping in university cards

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -153,17 +153,17 @@ const UniversityCard = ({ university, expanded, onToggle }) => {
 
         {/* Info */}
         <div className="flex-grow min-w-0">
-          <h3 className="text-xl font-bold mb-2 truncate group-hover:text-primary transition-colors">
+          <h3 className="text-xl font-bold mb-2 break-words sm:truncate group-hover:text-primary transition-colors">
             {university.name}
           </h3>
-          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
             <span className="flex items-center gap-1.5">
               <Globe size={14} />
               {university.country}
             </span>
-            <span className="w-1 h-1 rounded-full bg-border"></span>
+            <span className="hidden sm:inline-flex w-1 h-1 rounded-full bg-border"></span>
             <span className="font-mono">Score: <span className="text-foreground font-medium">{university.aggregatedScore.toFixed(1)}</span></span>
-            <span className="w-1 h-1 rounded-full bg-border"></span>
+            <span className="hidden sm:inline-flex w-1 h-1 rounded-full bg-border"></span>
             <span>Best: <span className="text-emerald-500 font-medium">#{bestRank}</span></span>
           </div>
         </div>


### PR DESCRIPTION
### Motivation

- Fix truncated and awkwardly-wrapped university names on small viewports so long names remain readable on mobile.
- Reduce horizontal spacing and avoid separator dots causing line breaks in the metadata row on narrow screens.
- Preserve the existing truncated behavior on larger viewports to keep the desktop layout compact.

### Description

- Allow the card title to wrap on small screens by replacing `truncate` with `break-words sm:truncate` on the university name element.
- Tighten metadata spacing by switching from `gap-3` to `gap-x-3 gap-y-1` for the info row to improve multi-line flow.
- Hide the separator dots on small screens by changing separators to `hidden sm:inline-flex` so they only appear on `sm` and up.
- Changes applied to `frontend/src/App.js` (4 insertions, 4 deletions) to adjust classes for responsive behavior.

### Testing

- Started the frontend with `npm --prefix frontend start`, and the dev server compiled successfully and served the app.
- Ran a Playwright script to load the app at a mobile viewport and capture a screenshot, which completed and produced an artifact (`artifacts/university-card-mobile.png`).
- No unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696033421924832082e7f1a78d430b81)