### PR TITLE
Redesign portfolio experience — cinematic studio layout

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,21 +1,39 @@
-import React, { useState, useEffect, createContext, useContext } from 'react';
+import React, { useState, useEffect, useMemo, createContext, useContext } from 'react';
 import {
+  Search,
+  TrendingUp,
+  Globe,
+  Award,
+  ChevronDown,
+  ChevronUp,
   ArrowUpRight,
   Sun,
   Moon,
   Monitor,
-  Sparkles,
+  Database,
   Layers,
-  Palette,
-  Code2,
-  Globe,
-  Github,
-  Mail,
-  ArrowRight,
-  Briefcase,
-  Award,
-  Stars
+  BarChart3
 } from 'lucide-react';
+import { Doughnut } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  Tooltip,
+  Legend,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  ArcElement
+} from 'chart.js';
+import EnhancedCardTabs from './components/EnhancedCardTabs';
+
+ChartJS.register(
+  Tooltip,
+  Legend,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  ArcElement
+);
 
 // --- Theme Context ---
 const ThemeContext = createContext();
@@ -46,7 +64,13 @@ const ThemeProvider = ({ children }) => {
 
 const useTheme = () => useContext(ThemeContext);
 
+// --- Constants ---
+const IVY_LEAGUE = ["Brown University", "Columbia University", "Cornell University", "Dartmouth College", "Harvard University", "University of Pennsylvania", "Princeton University", "Yale University"];
+const BIG_TEN = ["University of Illinois Urbana-Champaign", "Indiana University Bloomington", "University of Iowa", "University of Maryland College Park", "University of Michigan", "Michigan State University", "University of Minnesota Twin Cities", "University of Nebraska Lincoln", "Northwestern University", "Ohio State University", "University of Oregon", "Pennsylvania State University", "Purdue University", "Rutgers University New Brunswick", "University of California Los Angeles", "University of Southern California", "University of Washington Seattle", "University of Wisconsin Madison"];
+const RUSSELL_GROUP = ["University of Birmingham", "University of Bristol", "University of Cambridge", "Cardiff University", "Durham University", "University of Edinburgh", "University of Exeter", "University of Glasgow", "Imperial College London", "King's College London", "University of Leeds", "University of Liverpool", "London School Economics & Political Science", "University of Manchester", "Newcastle University - UK", "University of Nottingham", "University of Oxford", "Queen Mary University London", "Queens University Belfast", "University of Sheffield", "University of Southampton", "University College London", "University of Warwick", "University of York - UK"];
+
 // --- Components ---
+
 const ThemeToggle = () => {
   const { theme, setTheme } = useTheme();
 
@@ -77,340 +101,568 @@ const ThemeToggle = () => {
   );
 };
 
-const Pill = ({ children }) => (
-  <span className="px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider bg-muted text-muted-foreground border border-border">
-    {children}
-  </span>
-);
-
-const SectionTitle = ({ eyebrow, title, subtitle }) => (
-  <div className="max-w-2xl">
-    <div className="flex items-center gap-2 text-sm font-semibold text-primary">
-      <Sparkles size={16} />
-      <span className="uppercase tracking-[0.2em]">{eyebrow}</span>
+const StatCard = ({ label, value, sub, icon: Icon, trend }) => (
+  <div className="bg-card text-card-foreground p-6 rounded-2xl border border-border relative overflow-hidden group hover:border-primary/40 transition-all shadow-sm">
+    <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity"></div>
+    <div className="absolute top-0 right-0 p-4 opacity-10 group-hover:opacity-20 transition-opacity">
+      <Icon size={48} className="text-foreground" />
     </div>
-    <h2 className="mt-3 text-3xl md:text-4xl font-bold tracking-tight">
-      {title}
-    </h2>
-    {subtitle && <p className="mt-4 text-lg text-muted-foreground">{subtitle}</p>}
-  </div>
-);
-
-const ProjectCard = ({ title, description, tags, metric }) => (
-  <div className="group bg-card text-card-foreground border border-border rounded-2xl p-6 transition-all hover:border-primary/40 hover:-translate-y-1 shadow-sm">
-    <div className="flex items-center justify-between">
-      <h3 className="text-xl font-semibold">{title}</h3>
-      <ArrowUpRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
-    </div>
-    <p className="mt-3 text-muted-foreground leading-relaxed">{description}</p>
-    <div className="mt-4 flex flex-wrap gap-2">
-      {tags.map(tag => (
-        <span key={tag} className="text-xs font-medium bg-muted/70 text-muted-foreground px-2.5 py-1 rounded-full">
-          {tag}
-        </span>
-      ))}
-    </div>
-    <div className="mt-6 flex items-center gap-2 text-sm font-semibold text-primary">
-      <Stars size={14} />
-      {metric}
-    </div>
-  </div>
-);
-
-const ExperienceCard = ({ role, company, time, summary }) => (
-  <div className="border border-border rounded-2xl p-5 bg-card">
-    <div className="flex items-center justify-between gap-4">
-      <div>
-        <p className="text-sm text-muted-foreground uppercase tracking-[0.2em]">{time}</p>
-        <h3 className="text-lg font-semibold mt-2">{role}</h3>
-        <p className="text-sm text-muted-foreground">{company}</p>
+    <div className="relative z-10">
+      <div className="flex items-center gap-2 mb-2 text-muted-foreground text-sm font-medium uppercase tracking-wider">
+        {label}
       </div>
-      <Briefcase className="w-5 h-5 text-primary" />
-    </div>
-    <p className="mt-4 text-muted-foreground leading-relaxed">{summary}</p>
-  </div>
-);
-
-const TestimonialCard = ({ quote, name, title }) => (
-  <div className="bg-card border border-border rounded-2xl p-6">
-    <p className="text-lg leading-relaxed">“{quote}”</p>
-    <div className="mt-6">
-      <p className="font-semibold">{name}</p>
-      <p className="text-sm text-muted-foreground">{title}</p>
+      <div className="text-3xl font-bold mb-1 font-space tracking-tight">
+        {value}
+      </div>
+      {sub && (
+        <div className="text-sm text-muted-foreground flex items-center gap-2">
+          {trend && <span className="text-emerald-500 font-medium flex items-center"><ArrowUpRight size={14} className="mr-1" />{trend}</span>}
+          {sub}
+        </div>
+      )}
     </div>
   </div>
 );
 
+const HighlightCard = ({ title, value, subtitle }) => (
+  <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+    <div className="text-xs uppercase tracking-[0.3em] text-muted-foreground">{title}</div>
+    <div className="text-3xl font-bold mt-3 font-space">{value}</div>
+    <p className="text-sm text-muted-foreground mt-2">{subtitle}</p>
+  </div>
+);
+
+const Badge = ({ children, className = "", variant = "neutral" }) => {
+  const variants = {
+    neutral: "bg-muted text-muted-foreground border-transparent",
+    primary: "bg-primary/10 text-primary border-primary/20",
+    success: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
+    warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
+  };
+  return (
+    <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium border ${variants[variant]} ${className}`}>
+      {children}
+    </span>
+  );
+};
+
+const UniversityCard = ({ university, expanded, onToggle, globalStats }) => {
+  const bestRank = Math.min(...Object.values(university.originalRankings).map(r => r.rank));
+  const hasInsights = !!university.insights;
+
+  // Get consensus badge for mini display
+  const getConsensusBadge = () => {
+    if (!hasInsights || !university.insights.disagreement) return null;
+    const category = university.insights.disagreement.category;
+    if (category === 'high-consensus') return { label: 'High Consensus', color: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' };
+    if (category === 'high-disagreement') return { label: 'Disputed', color: 'bg-red-500/10 text-red-600 dark:text-red-400' };
+    return null;
+  };
+  const consensusBadge = getConsensusBadge();
+
+  return (
+    <div className={`bg-card text-card-foreground rounded-xl border border-border overflow-hidden hover:border-primary/30 transition-colors duration-200 ${expanded ? 'ring-1 ring-primary/20' : ''} shadow-sm`}>
+      <div
+        className="p-5 flex flex-col md:flex-row items-start md:items-center gap-6 cursor-pointer"
+        onClick={onToggle}
+      >
+        {/* Rank Box */}
+        <div className="flex-shrink-0 flex flex-row md:flex-col items-center gap-3 md:gap-1 min-w-[80px]">
+          <div className="text-3xl md:text-4xl font-bold font-space text-foreground">
+            #{university.aggregatedRank}
+          </div>
+          <div className="text-xs text-muted-foreground uppercase tracking-widest font-semibold">Rank</div>
+        </div>
+
+        {/* Info */}
+        <div className="flex-grow min-w-0">
+          <div className="flex items-center gap-2 mb-2 flex-wrap">
+            <h3 className="text-xl font-bold break-words sm:truncate group-hover:text-primary transition-colors">
+              {university.name}
+            </h3>
+            {consensusBadge && (
+              <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${consensusBadge.color}`}>
+                {consensusBadge.label}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+            <span className="flex items-center gap-1.5">
+              <Globe size={14} />
+              {university.country}
+            </span>
+            <span className="hidden sm:inline-flex w-1 h-1 rounded-full bg-border"></span>
+            <span className="font-mono">Score: <span className="text-foreground font-medium">{university.aggregatedScore.toFixed(1)}</span></span>
+            <span className="hidden sm:inline-flex w-1 h-1 rounded-full bg-border"></span>
+            <span>Best: <span className="text-emerald-500 font-medium">#{bestRank}</span></span>
+          </div>
+        </div>
+
+        {/* Mini Grid */}
+        <div className="hidden md:grid grid-cols-4 gap-2 w-full md:w-auto">
+          {Object.entries(university.originalRankings).map(([source, data]) => (
+            <div key={source} className="text-center px-3 py-2 bg-muted/50 rounded-lg border border-border">
+              <div className="text-[10px] text-muted-foreground uppercase mb-0.5 font-bold">{source === 'usnews' ? 'USN' : source.toUpperCase()}</div>
+              <div className="font-mono text-sm font-medium">#{data.rank}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="ml-auto text-muted-foreground">
+          {expanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
+        </div>
+      </div>
+
+      {/* Expanded Details */}
+      {expanded && (
+        <div className="border-t border-border bg-muted/30 p-6 animate-in fade-in slide-in-from-top-2 duration-200">
+          {hasInsights ? (
+            <EnhancedCardTabs university={university} globalStats={globalStats} />
+          ) : (
+            /* Fallback to original view if no insights */
+            <div className="grid md:grid-cols-2 gap-8">
+              <div>
+                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-4">Rankings Breakdown</h4>
+                <div className="space-y-3">
+                  {Object.entries(university.originalRankings).map(([source, data]) => (
+                    <div key={source} className="flex items-center justify-between p-3 rounded-lg bg-card border border-border shadow-sm">
+                      <div className="flex items-center gap-3">
+                        <span className={`w-2 h-2 rounded-full ${source === 'qs' ? 'bg-orange-500' : source === 'the' ? 'bg-yellow-500' : source === 'arwu' ? 'bg-red-500' : 'bg-blue-500'}`}></span>
+                        <span className="capitalize font-medium">
+                          {source === 'usnews' ? 'US News & World Report' :
+                            source === 'the' ? 'Times Higher Education' :
+                              source === 'qs' ? 'QS World University' : 'ARWU (Shanghai)'}
+                        </span>
+                      </div>
+                      <div className="font-mono text-lg font-bold">#{data.rank}</div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-4">Performance Metrics</h4>
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="p-4 rounded-lg bg-card border border-border shadow-sm">
+                    <div className="text-xs text-muted-foreground mb-1 font-medium">National Rank</div>
+                    <div className="text-2xl font-bold">#{university.countryRank}</div>
+                  </div>
+                  <div className="p-4 rounded-lg bg-card border border-border shadow-sm">
+                    <div className="text-xs text-muted-foreground mb-1 font-medium">Consistency Score</div>
+                    <div className="text-2xl font-bold">{(university.aggregatedScore / 100).toFixed(1)}/10</div>
+                  </div>
+                  <div className="p-4 rounded-lg bg-card border border-border shadow-sm col-span-2">
+                    <div className="text-xs text-muted-foreground mb-2 font-medium">Ranking Sources</div>
+                    <div className="flex gap-2">
+                      {Object.keys(university.originalRankings).map(source => (
+                        <Badge key={source} variant="neutral" className="uppercase">{source}</Badge>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+// --- Main Content (Wrapped) ---
 const MainApp = () => {
-  const projects = [
-    {
-      title: 'Lumen Commerce Platform',
-      description: 'Reimagined a retail experience with cinematic product narratives, reactive micro-interactions, and a seamless checkout journey.',
-      tags: ['Design System', 'Front-End', 'Strategy'],
-      metric: '68% conversion lift post-launch'
-    },
-    {
-      title: 'Orbit Analytics Studio',
-      description: 'Crafted an immersive data story interface that lets teams explore insights through elegant layers and modular dashboards.',
-      tags: ['Data Visualization', 'UX Research', 'Motion'],
-      metric: '12+ hours saved weekly per analyst'
-    },
-    {
-      title: 'Signal Creative Portfolio',
-      description: 'Built a signature portfolio experience with editorial typography, adaptive theming, and polished interaction states.',
-      tags: ['Brand', 'Webflow-to-React', 'Content'],
-      metric: 'Featured in 3 design galleries'
-    }
-  ];
+  const [universities, setUniversities] = useState([]);
+  const [globalStats, setGlobalStats] = useState(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sortBy, setSortBy] = useState('aggregatedRank');
+  const [expandedId, setExpandedId] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedCountry, setSelectedCountry] = useState('');
+  const [selectedGroup, setSelectedGroup] = useState('');
+  const itemsPerPage = 50;
 
-  const experience = [
-    {
-      role: 'Lead Product Designer',
-      company: 'Studio Sora',
-      time: '2022 — Present',
-      summary: 'Directing multi-disciplinary product launches, partnering with founders, and crafting premium digital experiences across web, mobile, and spatial.'
-    },
-    {
-      role: 'Design Engineer',
-      company: 'Lightpath Labs',
-      time: '2020 — 2022',
-      summary: 'Built component systems, prototyped AI workflows, and collaborated with engineering to ship a cohesive design language.'
-    }
-  ];
+  useEffect(() => {
+    // Load enhanced rankings (with insights) and global stats in parallel
+    Promise.all([
+      fetch(process.env.PUBLIC_URL + '/data/enhanced-aggregated-rankings.json').then(res => res.json()),
+      fetch(process.env.PUBLIC_URL + '/data/global-stats.json').then(res => res.json())
+    ])
+      .then(([data, stats]) => {
+        setUniversities(data);
+        setGlobalStats(stats);
+        setIsLoading(false);
+      })
+      .catch(err => {
+        console.error('Error loading enhanced data, falling back to basic:', err);
+        // Fallback to basic aggregated rankings if enhanced not available
+        fetch(process.env.PUBLIC_URL + '/data/aggregated-rankings.json')
+          .then(res => res.json())
+          .then(data => { setUniversities(data); setIsLoading(false); })
+          .catch(e => console.error(e));
+      });
+  }, []);
 
-  const testimonials = [
-    {
-      quote: 'A rare mix of visual precision and product thinking. Every screen feels intentional and alive.',
-      name: 'Avery Hart',
-      title: 'Creative Director, Flux'
-    },
-    {
-      quote: 'From strategy to delivery, the work elevates every brand moment. True partner energy.',
-      name: 'Noah Lin',
-      title: 'Founder, Apex Collective'
+  // --- Derived State ---
+  const uniqueCountries = useMemo(() => [...new Set(universities.map(u => u.country).filter(Boolean))].sort(), [universities]);
+
+  const metrics = useMemo(() => {
+    if (!universities.length) return null;
+    const avgScore = universities.reduce((a, b) => a + b.aggregatedScore, 0) / universities.length;
+    const topUni = universities.reduce((a, b) => a.aggregatedRank < b.aggregatedRank ? a : b);
+
+    // Country Counts
+    const counts = {};
+    universities.forEach(u => counts[u.country] = (counts[u.country] || 0) + 1);
+    const sortedCountries = Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, 5);
+
+    return {
+      total: universities.length,
+      countries: uniqueCountries.length,
+      avgScore: avgScore.toFixed(1),
+      topUni,
+      topCountries: sortedCountries,
+      chartData: {
+        labels: sortedCountries.map(c => c[0]),
+        datasets: [{
+          data: sortedCountries.map(c => c[1]),
+          backgroundColor: ['#8b5cf6', '#6366f1', '#ec4899', '#14b8a6', '#f59e0b'],
+          borderWidth: 0,
+          hoverOffset: 10
+        }]
+      }
+    };
+  }, [universities, uniqueCountries]);
+
+  const filteredData = useMemo(() => {
+    let result = universities;
+
+    // Filter
+    if (selectedCountry) result = result.filter(u => u.country === selectedCountry);
+    if (selectedGroup === "Ivy League") result = result.filter(u => IVY_LEAGUE.includes(u.name));
+    if (selectedGroup === "Big Ten") result = result.filter(u => BIG_TEN.includes(u.name));
+    if (selectedGroup === "Russell Group") result = result.filter(u => RUSSELL_GROUP.includes(u.name));
+
+    // Search
+    if (searchTerm) {
+      const token = searchTerm.toLowerCase().replace(/[^a-z0-9]/g, '');
+      result = result.filter(u => u.name.toLowerCase().replace(/[^a-z0-9]/g, '').includes(token));
     }
-  ];
+
+    // Sort
+    return result.sort((a, b) => {
+      if (sortBy === 'name') return a.name.localeCompare(b.name);
+      if (sortBy === 'aggregatedScore') return b.aggregatedScore - a.aggregatedScore;
+      if (sortBy === 'aggregatedRank') return a.aggregatedRank - b.aggregatedRank;
+      if (['qs', 'the', 'arwu', 'usnews'].includes(sortBy)) {
+        const rankA = a.originalRankings[sortBy]?.rank ?? 9999;
+        const rankB = b.originalRankings[sortBy]?.rank ?? 9999;
+        return rankA - rankB;
+      }
+      return 0;
+    });
+  }, [universities, selectedCountry, selectedGroup, searchTerm, sortBy]);
+
+  // Pagination
+  const paginatedData = filteredData.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
+
+  if (isLoading || !metrics) {
+    return (
+      <div className="min-h-screen bg-background flex items-center justify-center">
+        <div className="flex flex-col items-center gap-4">
+          <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
+          <p className="text-muted-foreground font-mono text-sm animate-pulse">Initializing System...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen bg-background text-foreground transition-colors duration-300">
       <div className="noise-bg"></div>
 
-      <header className="relative z-50 border-b border-border bg-background/90 backdrop-blur-xl sticky top-0">
+      {/* --- HEADER --- */}
+      <header className="relative z-50 border-b border-border bg-background/95 backdrop-blur-xl sticky top-0 transition-colors duration-300 supports-[backdrop-filter]:bg-background/80">
         <div className="container mx-auto px-6 h-16 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary to-violet-600 flex items-center justify-center shadow-lg shadow-primary/20">
-              <Sparkles className="text-white w-4 h-4" strokeWidth={2.5} />
+            <div className="w-9 h-9 bg-gradient-to-br from-primary to-violet-600 rounded-xl flex items-center justify-center shadow-lg shadow-primary/30">
+              <BarChart3 className="text-white w-4 h-4" strokeWidth={2.5} />
             </div>
             <div>
-              <p className="text-sm text-muted-foreground uppercase tracking-[0.2em]">Portfolio</p>
-              <p className="text-lg font-bold tracking-tight">Visionary Studio</p>
+              <div className="text-xs uppercase tracking-[0.35em] text-muted-foreground">Unified Rankings</div>
+              <span className="text-lg font-bold font-space tracking-tight"><span className="text-foreground">Uni</span><span className="text-primary">Rank</span></span>
             </div>
+            <Badge variant="primary" className="ml-2 hidden sm:flex">LIVE</Badge>
           </div>
 
-          <div className="flex items-center gap-4">
-            <div className="hidden md:flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="w-2 h-2 rounded-full bg-emerald-500"></span>
-              Available for select collaborations
+          <div className="flex items-center gap-6">
+            <div className="text-xs text-muted-foreground font-mono hidden md:flex items-center gap-2">
+              <span className="w-2 h-2 rounded-full bg-emerald-500 animate-pulse"></span>
+              Updated {new Date().toLocaleDateString()}
             </div>
             <ThemeToggle />
           </div>
         </div>
       </header>
 
-      <main className="relative z-10">
-        <section className="container mx-auto px-6 pt-16 pb-20">
+      <main className="relative z-10 container mx-auto px-4 sm:px-6 py-12">
+
+        {/* --- HERO --- */}
+        <section className="mb-16 mt-8">
           <div className="grid lg:grid-cols-[1.1fr_0.9fr] gap-10 items-center">
             <div>
-              <div className="flex flex-wrap gap-2">
-                <Pill>Design Engineer</Pill>
-                <Pill>Creative Direction</Pill>
-                <Pill>Interactive Web</Pill>
+              <div className="inline-flex items-center gap-2 rounded-full border border-border px-4 py-2 text-xs uppercase tracking-[0.3em] text-muted-foreground">
+                <span className="w-2 h-2 rounded-full bg-primary"></span>
+                Global Intelligence Layer
               </div>
-              <h1 className="mt-8 text-4xl md:text-6xl font-black tracking-tight leading-tight">
-                Building luminous digital experiences
-                <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary to-violet-500"> that feel alive</span>.
+              <h1 className="text-5xl md:text-7xl font-black font-space mt-6 mb-6 tracking-tight text-transparent bg-clip-text bg-gradient-to-br from-foreground via-foreground to-muted-foreground">
+                University rankings,
+                <span className="text-foreground"> orchestrated</span>.
               </h1>
-              <p className="mt-6 text-lg text-muted-foreground max-w-xl">
-                I design and engineer premium portfolios, products, and brand moments for teams who want their work to feel unforgettable.
-                Every pixel is intentional, every interaction adds a layer of story.
+              <p className="text-xl text-muted-foreground max-w-2xl font-light leading-relaxed">
+                UniRank fuses QS, THE, ARWU, and US News into a single intelligence layer—revealing momentum, consensus, and gaps you can actually act on.
               </p>
               <div className="mt-8 flex flex-wrap gap-3">
-                <button className="px-6 py-3 rounded-full bg-primary text-primary-foreground font-semibold shadow-lg shadow-primary/25 flex items-center gap-2">
-                  View signature work <ArrowRight size={16} />
+                <button className="px-6 py-3 rounded-full bg-primary text-primary-foreground font-semibold shadow-lg shadow-primary/25">
+                  Explore the leaderboard
                 </button>
                 <button className="px-6 py-3 rounded-full border border-border text-foreground font-semibold hover:border-primary/50 transition-colors">
-                  Download résumé
+                  View methodology
                 </button>
               </div>
-              <div className="mt-10 flex items-center gap-6 text-sm text-muted-foreground">
-                <div className="flex items-center gap-2">
-                  <Mail size={16} />
-                  hello@visionary.studio
+
+              {/* Pipeline Stats Banner */}
+              {globalStats && (
+                <div className="mt-10 grid sm:grid-cols-3 gap-4">
+                  <HighlightCard
+                    title="Universities"
+                    value={globalStats.totalUniversities.toLocaleString()}
+                    subtitle="institutions tracked globally"
+                  />
+                  <HighlightCard
+                    title="Sources"
+                    value={globalStats.totalSources}
+                    subtitle="ranking systems unified"
+                  />
+                  <HighlightCard
+                    title="Resolved"
+                    value={(globalStats.manualMappingsCount + globalStats.autoMappingsCount).toLocaleString()}
+                    subtitle="name variations reconciled"
+                  />
                 </div>
-                <div className="flex items-center gap-2">
-                  <Globe size={16} />
-                  Based in Los Angeles, CA
-                </div>
-              </div>
+              )}
             </div>
 
             <div className="relative">
-              <div className="absolute -top-12 -right-8 w-32 h-32 rounded-full bg-primary/20 blur-3xl"></div>
-              <div className="absolute -bottom-16 left-6 w-40 h-40 rounded-full bg-violet-500/20 blur-3xl"></div>
+              <div className="absolute -top-10 right-4 w-40 h-40 rounded-full bg-primary/20 blur-3xl"></div>
+              <div className="absolute -bottom-10 left-10 w-48 h-48 rounded-full bg-violet-500/20 blur-3xl"></div>
               <div className="bg-card border border-border rounded-3xl p-6 shadow-xl">
                 <div className="flex items-center justify-between">
                   <div>
-                    <p className="text-sm text-muted-foreground uppercase tracking-[0.2em]">Currently</p>
-                    <h3 className="text-2xl font-semibold mt-2">Designing the future of creative tooling</h3>
+                    <div className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Top Ranked</div>
+                    <h2 className="text-2xl font-semibold mt-3">{metrics.topUni.name}</h2>
                   </div>
                   <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
-                    <Layers size={20} className="text-primary" />
+                    <Award className="text-primary" size={20} />
                   </div>
                 </div>
-                <div className="mt-6 space-y-4">
-                  {[
-                    { label: 'Projects shipped', value: '38+' },
-                    { label: 'Years in craft', value: '8' },
-                    { label: 'Global collaborations', value: '14' }
-                  ].map(item => (
-                    <div key={item.label} className="flex items-center justify-between">
-                      <span className="text-sm text-muted-foreground">{item.label}</span>
-                      <span className="text-lg font-semibold">{item.value}</span>
-                    </div>
-                  ))}
-                </div>
-                <div className="mt-6 rounded-2xl bg-muted/60 p-4">
-                  <p className="text-sm text-muted-foreground">
-                    Crafting immersive brand ecosystems, blending strategy, narrative, and engineering to deliver impactful launches.
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        <section className="container mx-auto px-6 pb-20">
-          <div className="grid gap-10">
-            <SectionTitle
-              eyebrow="Signature Work"
-              title="Flagship projects that elevate product stories"
-              subtitle="From concept to polish, each engagement is shaped to amplify clarity, craft, and momentum."
-            />
-            <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
-              {projects.map(project => (
-                <ProjectCard key={project.title} {...project} />
-              ))}
-            </div>
-          </div>
-        </section>
-
-        <section className="container mx-auto px-6 pb-20">
-          <div className="grid lg:grid-cols-[0.9fr_1.1fr] gap-10 items-start">
-            <div className="space-y-6">
-              <SectionTitle
-                eyebrow="Capabilities"
-                title="A studio-grade toolkit for end-to-end delivery"
-                subtitle="I partner with founders and teams to ship cohesive, premium experiences across digital touchpoints."
-              />
-              <div className="grid gap-4">
-                {[
-                  { icon: Palette, title: 'Brand & Visual Systems', desc: 'Identity, typography, color, and design systems that scale across products.' },
-                  { icon: Code2, title: 'Front-End Engineering', desc: 'Modern React builds, WebGL touches, and performance-minded architecture.' },
-                  { icon: Award, title: 'Launch & Growth', desc: 'Go-to-market storytelling, editorial content, and product marketing assets.' }
-                ].map(item => (
-                  <div key={item.title} className="flex gap-4 p-5 rounded-2xl border border-border bg-card">
-                    <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center">
-                      <item.icon size={18} className="text-primary" />
-                    </div>
-                    <div>
-                      <h3 className="font-semibold">{item.title}</h3>
-                      <p className="text-sm text-muted-foreground mt-2">{item.desc}</p>
-                    </div>
+                <div className="mt-6 grid grid-cols-2 gap-4">
+                  <div className="bg-muted/60 rounded-2xl p-4">
+                    <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Aggregate Rank</div>
+                    <div className="text-3xl font-semibold mt-2">#{metrics.topUni.aggregatedRank}</div>
                   </div>
-                ))}
-              </div>
-            </div>
-
-            <div className="grid gap-6">
-              <div className="bg-gradient-to-br from-primary/10 to-violet-500/10 border border-primary/20 rounded-3xl p-6">
-                <h3 className="text-2xl font-semibold">Design impact metrics</h3>
-                <p className="mt-3 text-muted-foreground">Evidence-driven outcomes with a focus on polish, clarity, and conversion.</p>
-                <div className="mt-6 grid sm:grid-cols-2 gap-4">
-                  {[
-                    { label: 'Avg. conversion lift', value: '54%' },
-                    { label: 'Product launches', value: '21' },
-                    { label: 'Awards & features', value: '9' },
-                    { label: 'Repeat partnerships', value: '78%' }
-                  ].map(item => (
-                    <div key={item.label} className="bg-background/70 border border-border rounded-2xl p-4">
-                      <p className="text-sm text-muted-foreground">{item.label}</p>
-                      <p className="text-2xl font-semibold mt-2">{item.value}</p>
-                    </div>
-                  ))}
+                  <div className="bg-muted/60 rounded-2xl p-4">
+                    <div className="text-xs uppercase tracking-[0.2em] text-muted-foreground">Score</div>
+                    <div className="text-3xl font-semibold mt-2">{metrics.topUni.aggregatedScore.toFixed(1)}</div>
+                  </div>
+                </div>
+                <div className="mt-6 rounded-2xl bg-muted/40 p-4 text-sm text-muted-foreground leading-relaxed">
+                  A synthesis of four major rankings, continuously normalized and reconciled to surface true academic momentum.
                 </div>
               </div>
+            </div>
+          </div>
+        </section>
 
-              <div className="grid gap-4">
-                {experience.map(entry => (
-                  <ExperienceCard key={entry.role} {...entry} />
-                ))}
+        {/* --- METRICS GRID --- */}
+        <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-20">
+          <StatCard icon={Globe} label="Universities Tracked" value={metrics.total} sub={`${metrics.countries} Countries Represented`} />
+          <StatCard icon={Award} label="Top Performer" value={metrics.topUni.name} sub="Highest Aggregate Score" trend="#1 Globally" />
+          <StatCard icon={TrendingUp} label="Global Average" value={metrics.avgScore} sub="Aggregate Index Score" />
+
+          {/* Chart Card */}
+          <div className="bg-card text-card-foreground p-6 rounded-2xl flex items-center justify-between border border-border relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-transparent opacity-70"></div>
+            <div className="relative z-10">
+              <div className="text-muted-foreground text-sm font-medium uppercase tracking-wider mb-2">Top Region</div>
+              <div className="text-2xl font-bold font-space">{metrics.topCountries[0][0]}</div>
+              <div className="text-sm text-muted-foreground">{metrics.topCountries[0][1]} Universities</div>
+            </div>
+            <div className="relative z-10 w-20 h-20">
+              <Doughnut data={metrics.chartData} options={{ cutout: '70%', plugins: { legend: { display: false }, tooltip: { enabled: false } } }} />
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-16 grid lg:grid-cols-[1fr_1fr] gap-6">
+          <div className="bg-card border border-border rounded-3xl p-8">
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <Database size={18} className="text-primary" />
+              Data integrity pulse
+            </div>
+            <h3 className="text-2xl font-semibold mt-4">Confidence built into every rank.</h3>
+            <p className="text-muted-foreground mt-3 leading-relaxed">
+              UniRank resolves naming conflicts, accounts for missing data, and fuses multiple methodologies into a consistent signal so you can compare globally without the noise.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Badge variant="success">Consensus scoring</Badge>
+              <Badge variant="primary">Borda count aggregation</Badge>
+              <Badge variant="neutral">Pattern-based normalization</Badge>
+            </div>
+          </div>
+          <div className="bg-card border border-border rounded-3xl p-8">
+            <div className="flex items-center gap-3 text-sm text-muted-foreground">
+              <Layers size={18} className="text-primary" />
+              Signal stack
+            </div>
+            <h3 className="text-2xl font-semibold mt-4">See the full picture, faster.</h3>
+            <p className="text-muted-foreground mt-3 leading-relaxed">
+              Filter by region or academic group, compare ranking sources, and surface the schools with the strongest cross-source momentum.
+            </p>
+            <div className="mt-6 grid grid-cols-2 gap-4 text-sm">
+              <div className="rounded-2xl border border-border p-4">
+                <div className="text-xs uppercase tracking-[0.25em] text-muted-foreground">Top country</div>
+                <div className="text-xl font-semibold mt-2">{metrics.topCountries[0][0]}</div>
+              </div>
+              <div className="rounded-2xl border border-border p-4">
+                <div className="text-xs uppercase tracking-[0.25em] text-muted-foreground">Average score</div>
+                <div className="text-xl font-semibold mt-2">{metrics.avgScore}</div>
               </div>
             </div>
           </div>
         </section>
 
-        <section className="container mx-auto px-6 pb-20">
-          <div className="grid gap-10">
-            <SectionTitle
-              eyebrow="Praise"
-              title="Partners and teams who trusted the process"
-              subtitle="Collaborations rooted in clarity, momentum, and craft-first delivery."
+
+        {/* --- CONTROLS (DOCKED TOOLBAR) --- */}
+        <section className="sticky top-16 z-40 border-b border-border bg-background/95 backdrop-blur-xl transition-all duration-300 shadow-sm supports-[backdrop-filter]:bg-background/80">
+          <div className="container mx-auto px-4 sm:px-6 py-4">
+            <div className="flex items-center justify-between flex-wrap gap-4 mb-4">
+              <div>
+                <div className="text-xs uppercase tracking-[0.3em] text-muted-foreground">Command center</div>
+                <h2 className="text-lg font-semibold">Refine the signal</h2>
+              </div>
+              <div className="text-xs text-muted-foreground font-mono">
+                {filteredData.length.toLocaleString()} universities in scope
+              </div>
+            </div>
+            <div className="flex flex-col md:flex-row gap-6">
+              <div className="relative flex-grow">
+                <Search className="absolute left-5 top-1/2 -translate-y-1/2 text-muted-foreground w-4 h-4" />
+                <input
+                  type="text"
+                  placeholder="Search universities..."
+                  className="w-full bg-muted/50 text-foreground pl-12 pr-4 py-3 rounded-xl border border-transparent focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 outline-none transition-all placeholder:text-muted-foreground/70 text-sm font-medium"
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                />
+              </div>
+
+              <div className="flex gap-2 overflow-x-auto pb-1 md:pb-0 no-scrollbar">
+                <select
+                  className="bg-muted/50 text-foreground px-4 py-3 rounded-xl border border-transparent outline-none focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 appearance-none min-w-[180px] text-sm font-medium cursor-pointer hover:bg-muted/80 transition-colors"
+                  value={sortBy}
+                  onChange={(e) => setSortBy(e.target.value)}
+                >
+                  <option value="aggregatedRank">Rank (Aggregated)</option>
+                  <option value="qs">Rank (QS)</option>
+                  <option value="the">Rank (THE)</option>
+                  <option value="arwu">Rank (ARWU)</option>
+                  <option value="usnews">Rank (US News)</option>
+                  <option value="name">Name (A-Z)</option>
+                </select>
+
+                <select
+                  className="bg-muted/50 text-foreground px-4 py-3 rounded-xl border border-transparent outline-none focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 appearance-none min-w-[160px] text-sm font-medium cursor-pointer hover:bg-muted/80 transition-colors"
+                  value={selectedCountry}
+                  onChange={(e) => setSelectedCountry(e.target.value)}
+                >
+                  <option value="">All Countries</option>
+                  {uniqueCountries.map(c => <option key={c} value={c}>{c}</option>)}
+                </select>
+
+                <select
+                  className="bg-muted/50 text-foreground px-4 py-3 rounded-xl border border-transparent outline-none focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 appearance-none min-w-[160px] text-sm font-medium cursor-pointer hover:bg-muted/80 transition-colors"
+                  value={selectedGroup}
+                  onChange={(e) => setSelectedGroup(e.target.value)}
+                >
+                  <option value="">All Groups</option>
+                  <option value="Ivy League">Ivy League</option>
+                  <option value="Russell Group">Russell Group</option>
+                  <option value="Big Ten">Big Ten</option>
+                </select>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* --- LIST --- */}
+        <section className="mt-6 space-y-3">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <div className="text-xs uppercase tracking-[0.35em] text-muted-foreground">Ranked results</div>
+              <h3 className="text-xl font-semibold mt-2">Global leaderboard</h3>
+              <p className="text-sm text-muted-foreground mt-1">Showing {paginatedData.length} of {filteredData.length} institutions</p>
+            </div>
+            <div className="text-xs font-mono text-muted-foreground uppercase tracking-widest">
+              Page {currentPage}
+            </div>
+          </div>
+
+          {paginatedData.map((uni, i) => (
+            <UniversityCard
+              key={uni.name}
+              university={uni}
+              expanded={expandedId === i}
+              onToggle={() => setExpandedId(expandedId === i ? null : i)}
+              globalStats={globalStats}
             />
-            <div className="grid md:grid-cols-2 gap-6">
-              {testimonials.map(item => (
-                <TestimonialCard key={item.name} {...item} />
-              ))}
+          ))}
+
+          {paginatedData.length === 0 && (
+            <div className="text-center py-20">
+              <div className="text-muted-foreground text-lg">No universities found matching your criteria.</div>
             </div>
-          </div>
+          )}
         </section>
 
-        <section className="container mx-auto px-6 pb-24">
-          <div className="bg-card border border-border rounded-3xl p-10 md:p-14 relative overflow-hidden">
-            <div className="absolute inset-0 bg-gradient-to-r from-primary/10 via-transparent to-violet-500/10"></div>
-            <div className="relative">
-              <SectionTitle
-                eyebrow="Let’s build"
-                title="Ready to craft the next iconic experience?"
-                subtitle="Tell me about your vision, timeline, and where the story begins. I’ll bring the craft, strategy, and momentum."
-              />
-              <div className="mt-8 flex flex-wrap gap-4">
-                <button className="px-6 py-3 rounded-full bg-primary text-primary-foreground font-semibold shadow-lg shadow-primary/20 flex items-center gap-2">
-                  Start a project <ArrowRight size={16} />
-                </button>
-                <button className="px-6 py-3 rounded-full border border-border text-foreground font-semibold hover:border-primary/50 transition-colors flex items-center gap-2">
-                  <Github size={16} /> See the build log
-                </button>
-              </div>
-            </div>
-          </div>
-        </section>
-      </main>
-
-      <footer className="border-t border-border">
-        <div className="container mx-auto px-6 py-8 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-          <div>
-            <p className="font-semibold">Visionary Studio</p>
-            <p className="text-sm text-muted-foreground">Crafting digital experiences with soul.</p>
-          </div>
-          <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
-            <span className="flex items-center gap-2"><Mail size={16} /> hello@visionary.studio</span>
-            <span className="flex items-center gap-2"><Globe size={16} /> visionary.studio</span>
-          </div>
+        {/* --- PAGINATION --- */}
+        <div className="mt-12 flex justify-center gap-2">
+          <button
+            disabled={currentPage === 1}
+            onClick={() => setCurrentPage(p => p - 1)}
+            className="px-4 py-2 rounded-lg bg-muted text-muted-foreground disabled:opacity-30 hover:bg-muted/80 transition-colors font-medium text-sm"
+          >
+            Previous
+          </button>
+          <span className="px-4 py-2 text-muted-foreground font-mono text-sm">
+            Page {currentPage}
+          </span>
+          <button
+            disabled={paginatedData.length < itemsPerPage}
+            onClick={() => {
+              setCurrentPage(p => p + 1);
+              window.scrollTo({ top: 0, behavior: 'smooth' });
+            }}
+            className="px-4 py-2 rounded-lg bg-muted text-muted-foreground disabled:opacity-30 hover:bg-muted/80 transition-colors font-medium text-sm"
+          >
+            Next
+          </button>
         </div>
-      </footer>
+
+      </main>
     </div>
   );
-};
+}
 
 function App() {
   return (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,40 +1,21 @@
-import React, { useState, useEffect, useMemo, createContext, useContext } from 'react';
+import React, { useState, useEffect, createContext, useContext } from 'react';
 import {
-  Search,
-  TrendingUp,
-  Globe,
-  Award,
-  ChevronDown,
-  ChevronUp,
   ArrowUpRight,
   Sun,
   Moon,
   Monitor,
-  Database,
-  GitMerge,
+  Sparkles,
   Layers,
-  BarChart3
+  Palette,
+  Code2,
+  Globe,
+  Github,
+  Mail,
+  ArrowRight,
+  Briefcase,
+  Award,
+  Stars
 } from 'lucide-react';
-import { Doughnut } from 'react-chartjs-2';
-import {
-  Chart as ChartJS,
-  Tooltip,
-  Legend,
-  CategoryScale,
-  LinearScale,
-  BarElement,
-  ArcElement
-} from 'chart.js';
-import EnhancedCardTabs from './components/EnhancedCardTabs';
-
-ChartJS.register(
-  Tooltip,
-  Legend,
-  CategoryScale,
-  LinearScale,
-  BarElement,
-  ArcElement
-);
 
 // --- Theme Context ---
 const ThemeContext = createContext();
@@ -65,13 +46,7 @@ const ThemeProvider = ({ children }) => {
 
 const useTheme = () => useContext(ThemeContext);
 
-// --- Constants ---
-const IVY_LEAGUE = ["Brown University", "Columbia University", "Cornell University", "Dartmouth College", "Harvard University", "University of Pennsylvania", "Princeton University", "Yale University"];
-const BIG_TEN = ["University of Illinois Urbana-Champaign", "Indiana University Bloomington", "University of Iowa", "University of Maryland College Park", "University of Michigan", "Michigan State University", "University of Minnesota Twin Cities", "University of Nebraska Lincoln", "Northwestern University", "Ohio State University", "University of Oregon", "Pennsylvania State University", "Purdue University", "Rutgers University New Brunswick", "University of California Los Angeles", "University of Southern California", "University of Washington Seattle", "University of Wisconsin Madison"];
-const RUSSELL_GROUP = ["University of Birmingham", "University of Bristol", "University of Cambridge", "Cardiff University", "Durham University", "University of Edinburgh", "University of Exeter", "University of Glasgow", "Imperial College London", "King's College London", "University of Leeds", "University of Liverpool", "London School Economics & Political Science", "University of Manchester", "Newcastle University - UK", "University of Nottingham", "University of Oxford", "Queen Mary University London", "Queens University Belfast", "University of Sheffield", "University of Southampton", "University College London", "University of Warwick", "University of York - UK"];
-
 // --- Components ---
-
 const ThemeToggle = () => {
   const { theme, setTheme } = useTheme();
 
@@ -102,462 +77,340 @@ const ThemeToggle = () => {
   );
 };
 
-const StatCard = ({ label, value, sub, icon: Icon, trend }) => (
-  <div className="bg-card text-card-foreground p-6 rounded-2xl border border-border relative overflow-hidden group hover:border-primary/30 transition-colors shadow-sm">
-    <div className="absolute top-0 right-0 p-4 opacity-5 group-hover:opacity-10 transition-opacity">
-      <Icon size={48} className="text-foreground" />
+const Pill = ({ children }) => (
+  <span className="px-3 py-1 rounded-full text-xs font-semibold uppercase tracking-wider bg-muted text-muted-foreground border border-border">
+    {children}
+  </span>
+);
+
+const SectionTitle = ({ eyebrow, title, subtitle }) => (
+  <div className="max-w-2xl">
+    <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+      <Sparkles size={16} />
+      <span className="uppercase tracking-[0.2em]">{eyebrow}</span>
     </div>
-    <div className="relative z-10">
-      <div className="flex items-center gap-2 mb-2 text-muted-foreground text-sm font-medium uppercase tracking-wider">
-        {label}
-      </div>
-      <div className="text-3xl font-bold mb-1 font-space tracking-tight">
-        {value}
-      </div>
-      {sub && (
-        <div className="text-sm text-muted-foreground flex items-center gap-2">
-          {trend && <span className="text-emerald-500 font-medium flex items-center"><ArrowUpRight size={14} className="mr-1" />{trend}</span>}
-          {sub}
-        </div>
-      )}
+    <h2 className="mt-3 text-3xl md:text-4xl font-bold tracking-tight">
+      {title}
+    </h2>
+    {subtitle && <p className="mt-4 text-lg text-muted-foreground">{subtitle}</p>}
+  </div>
+);
+
+const ProjectCard = ({ title, description, tags, metric }) => (
+  <div className="group bg-card text-card-foreground border border-border rounded-2xl p-6 transition-all hover:border-primary/40 hover:-translate-y-1 shadow-sm">
+    <div className="flex items-center justify-between">
+      <h3 className="text-xl font-semibold">{title}</h3>
+      <ArrowUpRight className="w-4 h-4 text-muted-foreground group-hover:text-primary transition-colors" />
+    </div>
+    <p className="mt-3 text-muted-foreground leading-relaxed">{description}</p>
+    <div className="mt-4 flex flex-wrap gap-2">
+      {tags.map(tag => (
+        <span key={tag} className="text-xs font-medium bg-muted/70 text-muted-foreground px-2.5 py-1 rounded-full">
+          {tag}
+        </span>
+      ))}
+    </div>
+    <div className="mt-6 flex items-center gap-2 text-sm font-semibold text-primary">
+      <Stars size={14} />
+      {metric}
     </div>
   </div>
 );
 
-const Badge = ({ children, className = "", variant = "neutral" }) => {
-  const variants = {
-    neutral: "bg-muted text-muted-foreground border-transparent",
-    primary: "bg-primary/10 text-primary border-primary/20",
-    success: "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20",
-    warning: "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
-  };
-  return (
-    <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium border ${variants[variant]} ${className}`}>
-      {children}
-    </span>
-  );
-};
-
-const UniversityCard = ({ university, expanded, onToggle, globalStats }) => {
-  const bestRank = Math.min(...Object.values(university.originalRankings).map(r => r.rank));
-  const hasInsights = !!university.insights;
-
-  // Get consensus badge for mini display
-  const getConsensusBadge = () => {
-    if (!hasInsights || !university.insights.disagreement) return null;
-    const category = university.insights.disagreement.category;
-    if (category === 'high-consensus') return { label: 'High Consensus', color: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400' };
-    if (category === 'high-disagreement') return { label: 'Disputed', color: 'bg-red-500/10 text-red-600 dark:text-red-400' };
-    return null;
-  };
-  const consensusBadge = getConsensusBadge();
-
-  return (
-    <div className={`bg-card text-card-foreground rounded-xl border border-border overflow-hidden hover:border-primary/30 transition-colors duration-200 ${expanded ? 'ring-1 ring-primary/20' : ''} shadow-sm`}>
-      <div
-        className="p-5 flex flex-col md:flex-row items-start md:items-center gap-6 cursor-pointer"
-        onClick={onToggle}
-      >
-        {/* Rank Box */}
-        <div className="flex-shrink-0 flex flex-row md:flex-col items-center gap-3 md:gap-1 min-w-[80px]">
-          <div className="text-3xl md:text-4xl font-bold font-space text-foreground">
-            #{university.aggregatedRank}
-          </div>
-          <div className="text-xs text-muted-foreground uppercase tracking-widest font-semibold">Rank</div>
-        </div>
-
-        {/* Info */}
-        <div className="flex-grow min-w-0">
-          <div className="flex items-center gap-2 mb-2 flex-wrap">
-            <h3 className="text-xl font-bold break-words sm:truncate group-hover:text-primary transition-colors">
-              {university.name}
-            </h3>
-            {consensusBadge && (
-              <span className={`px-2 py-0.5 rounded-full text-[10px] font-medium ${consensusBadge.color}`}>
-                {consensusBadge.label}
-              </span>
-            )}
-          </div>
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-            <span className="flex items-center gap-1.5">
-              <Globe size={14} />
-              {university.country}
-            </span>
-            <span className="hidden sm:inline-flex w-1 h-1 rounded-full bg-border"></span>
-            <span className="font-mono">Score: <span className="text-foreground font-medium">{university.aggregatedScore.toFixed(1)}</span></span>
-            <span className="hidden sm:inline-flex w-1 h-1 rounded-full bg-border"></span>
-            <span>Best: <span className="text-emerald-500 font-medium">#{bestRank}</span></span>
-          </div>
-        </div>
-
-        {/* Mini Grid */}
-        <div className="hidden md:grid grid-cols-4 gap-2 w-full md:w-auto">
-          {Object.entries(university.originalRankings).map(([source, data]) => (
-            <div key={source} className="text-center px-3 py-2 bg-muted/50 rounded-lg border border-border">
-              <div className="text-[10px] text-muted-foreground uppercase mb-0.5 font-bold">{source === 'usnews' ? 'USN' : source.toUpperCase()}</div>
-              <div className="font-mono text-sm font-medium">#{data.rank}</div>
-            </div>
-          ))}
-        </div>
-
-        <div className="ml-auto text-muted-foreground">
-          {expanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
-        </div>
+const ExperienceCard = ({ role, company, time, summary }) => (
+  <div className="border border-border rounded-2xl p-5 bg-card">
+    <div className="flex items-center justify-between gap-4">
+      <div>
+        <p className="text-sm text-muted-foreground uppercase tracking-[0.2em]">{time}</p>
+        <h3 className="text-lg font-semibold mt-2">{role}</h3>
+        <p className="text-sm text-muted-foreground">{company}</p>
       </div>
-
-      {/* Expanded Details */}
-      {expanded && (
-        <div className="border-t border-border bg-muted/30 p-6 animate-in fade-in slide-in-from-top-2 duration-200">
-          {hasInsights ? (
-            <EnhancedCardTabs university={university} globalStats={globalStats} />
-          ) : (
-            /* Fallback to original view if no insights */
-            <div className="grid md:grid-cols-2 gap-8">
-              <div>
-                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-4">Rankings Breakdown</h4>
-                <div className="space-y-3">
-                  {Object.entries(university.originalRankings).map(([source, data]) => (
-                    <div key={source} className="flex items-center justify-between p-3 rounded-lg bg-card border border-border shadow-sm">
-                      <div className="flex items-center gap-3">
-                        <span className={`w-2 h-2 rounded-full ${source === 'qs' ? 'bg-orange-500' : source === 'the' ? 'bg-yellow-500' : source === 'arwu' ? 'bg-red-500' : 'bg-blue-500'}`}></span>
-                        <span className="capitalize font-medium">
-                          {source === 'usnews' ? 'US News & World Report' :
-                            source === 'the' ? 'Times Higher Education' :
-                              source === 'qs' ? 'QS World University' : 'ARWU (Shanghai)'}
-                        </span>
-                      </div>
-                      <div className="font-mono text-lg font-bold">#{data.rank}</div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-
-              <div>
-                <h4 className="text-xs font-bold text-muted-foreground uppercase tracking-wider mb-4">Performance Metrics</h4>
-                <div className="grid grid-cols-2 gap-4">
-                  <div className="p-4 rounded-lg bg-card border border-border shadow-sm">
-                    <div className="text-xs text-muted-foreground mb-1 font-medium">National Rank</div>
-                    <div className="text-2xl font-bold">#{university.countryRank}</div>
-                  </div>
-                  <div className="p-4 rounded-lg bg-card border border-border shadow-sm">
-                    <div className="text-xs text-muted-foreground mb-1 font-medium">Consistency Score</div>
-                    <div className="text-2xl font-bold">{(university.aggregatedScore / 100).toFixed(1)}/10</div>
-                  </div>
-                  <div className="p-4 rounded-lg bg-card border border-border shadow-sm col-span-2">
-                    <div className="text-xs text-muted-foreground mb-2 font-medium">Ranking Sources</div>
-                    <div className="flex gap-2">
-                      {Object.keys(university.originalRankings).map(source => (
-                        <Badge key={source} variant="neutral" className="uppercase">{source}</Badge>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-        </div>
-      )}
+      <Briefcase className="w-5 h-5 text-primary" />
     </div>
-  );
-};
+    <p className="mt-4 text-muted-foreground leading-relaxed">{summary}</p>
+  </div>
+);
 
-// --- Main Content (Wrapped) ---
+const TestimonialCard = ({ quote, name, title }) => (
+  <div className="bg-card border border-border rounded-2xl p-6">
+    <p className="text-lg leading-relaxed">“{quote}”</p>
+    <div className="mt-6">
+      <p className="font-semibold">{name}</p>
+      <p className="text-sm text-muted-foreground">{title}</p>
+    </div>
+  </div>
+);
+
 const MainApp = () => {
-  const [universities, setUniversities] = useState([]);
-  const [globalStats, setGlobalStats] = useState(null);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [sortBy, setSortBy] = useState('aggregatedRank');
-  const [expandedId, setExpandedId] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [selectedCountry, setSelectedCountry] = useState('');
-  const [selectedGroup, setSelectedGroup] = useState('');
-  const itemsPerPage = 50;
-
-  useEffect(() => {
-    // Load enhanced rankings (with insights) and global stats in parallel
-    Promise.all([
-      fetch(process.env.PUBLIC_URL + '/data/enhanced-aggregated-rankings.json').then(res => res.json()),
-      fetch(process.env.PUBLIC_URL + '/data/global-stats.json').then(res => res.json())
-    ])
-      .then(([data, stats]) => {
-        setUniversities(data);
-        setGlobalStats(stats);
-        setIsLoading(false);
-      })
-      .catch(err => {
-        console.error('Error loading enhanced data, falling back to basic:', err);
-        // Fallback to basic aggregated rankings if enhanced not available
-        fetch(process.env.PUBLIC_URL + '/data/aggregated-rankings.json')
-          .then(res => res.json())
-          .then(data => { setUniversities(data); setIsLoading(false); })
-          .catch(e => console.error(e));
-      });
-  }, []);
-
-  // --- Derived State ---
-  const uniqueCountries = useMemo(() => [...new Set(universities.map(u => u.country).filter(Boolean))].sort(), [universities]);
-
-  const metrics = useMemo(() => {
-    if (!universities.length) return null;
-    const avgScore = universities.reduce((a, b) => a + b.aggregatedScore, 0) / universities.length;
-    const topUni = universities.reduce((a, b) => a.aggregatedRank < b.aggregatedRank ? a : b);
-
-    // Country Counts
-    const counts = {};
-    universities.forEach(u => counts[u.country] = (counts[u.country] || 0) + 1);
-    const sortedCountries = Object.entries(counts).sort((a, b) => b[1] - a[1]).slice(0, 5);
-
-    return {
-      total: universities.length,
-      countries: uniqueCountries.length,
-      avgScore: avgScore.toFixed(1),
-      topUni,
-      topCountries: sortedCountries,
-      chartData: {
-        labels: sortedCountries.map(c => c[0]),
-        datasets: [{
-          data: sortedCountries.map(c => c[1]),
-          backgroundColor: ['#8b5cf6', '#6366f1', '#ec4899', '#14b8a6', '#f59e0b'],
-          borderWidth: 0,
-          hoverOffset: 10
-        }]
-      }
-    };
-  }, [universities, uniqueCountries]);
-
-  const filteredData = useMemo(() => {
-    let result = universities;
-
-    // Filter
-    if (selectedCountry) result = result.filter(u => u.country === selectedCountry);
-    if (selectedGroup === "Ivy League") result = result.filter(u => IVY_LEAGUE.includes(u.name));
-    if (selectedGroup === "Big Ten") result = result.filter(u => BIG_TEN.includes(u.name));
-    if (selectedGroup === "Russell Group") result = result.filter(u => RUSSELL_GROUP.includes(u.name));
-
-    // Search
-    if (searchTerm) {
-      const token = searchTerm.toLowerCase().replace(/[^a-z0-9]/g, '');
-      result = result.filter(u => u.name.toLowerCase().replace(/[^a-z0-9]/g, '').includes(token));
+  const projects = [
+    {
+      title: 'Lumen Commerce Platform',
+      description: 'Reimagined a retail experience with cinematic product narratives, reactive micro-interactions, and a seamless checkout journey.',
+      tags: ['Design System', 'Front-End', 'Strategy'],
+      metric: '68% conversion lift post-launch'
+    },
+    {
+      title: 'Orbit Analytics Studio',
+      description: 'Crafted an immersive data story interface that lets teams explore insights through elegant layers and modular dashboards.',
+      tags: ['Data Visualization', 'UX Research', 'Motion'],
+      metric: '12+ hours saved weekly per analyst'
+    },
+    {
+      title: 'Signal Creative Portfolio',
+      description: 'Built a signature portfolio experience with editorial typography, adaptive theming, and polished interaction states.',
+      tags: ['Brand', 'Webflow-to-React', 'Content'],
+      metric: 'Featured in 3 design galleries'
     }
+  ];
 
-    // Sort
-    return result.sort((a, b) => {
-      if (sortBy === 'name') return a.name.localeCompare(b.name);
-      if (sortBy === 'aggregatedScore') return b.aggregatedScore - a.aggregatedScore;
-      if (sortBy === 'aggregatedRank') return a.aggregatedRank - b.aggregatedRank;
-      if (['qs', 'the', 'arwu', 'usnews'].includes(sortBy)) {
-        const rankA = a.originalRankings[sortBy]?.rank ?? 9999;
-        const rankB = b.originalRankings[sortBy]?.rank ?? 9999;
-        return rankA - rankB;
-      }
-      return 0;
-    });
-  }, [universities, selectedCountry, selectedGroup, searchTerm, sortBy]);
+  const experience = [
+    {
+      role: 'Lead Product Designer',
+      company: 'Studio Sora',
+      time: '2022 — Present',
+      summary: 'Directing multi-disciplinary product launches, partnering with founders, and crafting premium digital experiences across web, mobile, and spatial.'
+    },
+    {
+      role: 'Design Engineer',
+      company: 'Lightpath Labs',
+      time: '2020 — 2022',
+      summary: 'Built component systems, prototyped AI workflows, and collaborated with engineering to ship a cohesive design language.'
+    }
+  ];
 
-  // Pagination
-  const paginatedData = filteredData.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage);
-
-  if (isLoading || !metrics) {
-    return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="flex flex-col items-center gap-4">
-          <div className="w-8 h-8 border-2 border-primary border-t-transparent rounded-full animate-spin"></div>
-          <p className="text-muted-foreground font-mono text-sm animate-pulse">Initializing System...</p>
-        </div>
-      </div>
-    );
-  }
+  const testimonials = [
+    {
+      quote: 'A rare mix of visual precision and product thinking. Every screen feels intentional and alive.',
+      name: 'Avery Hart',
+      title: 'Creative Director, Flux'
+    },
+    {
+      quote: 'From strategy to delivery, the work elevates every brand moment. True partner energy.',
+      name: 'Noah Lin',
+      title: 'Founder, Apex Collective'
+    }
+  ];
 
   return (
     <div className="min-h-screen bg-background text-foreground transition-colors duration-300">
       <div className="noise-bg"></div>
 
-      {/* --- HEADER --- */}
-      <header className="relative z-50 border-b border-border bg-background/95 backdrop-blur-xl sticky top-0 transition-colors duration-300 supports-[backdrop-filter]:bg-background/80">
+      <header className="relative z-50 border-b border-border bg-background/90 backdrop-blur-xl sticky top-0">
         <div className="container mx-auto px-6 h-16 flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <div className="w-8 h-8 bg-gradient-to-br from-primary to-violet-600 rounded-lg flex items-center justify-center shadow-lg shadow-primary/20">
-              <BarChart3 className="text-white w-4 h-4" strokeWidth={2.5} />
+            <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary to-violet-600 flex items-center justify-center shadow-lg shadow-primary/20">
+              <Sparkles className="text-white w-4 h-4" strokeWidth={2.5} />
             </div>
-            <span className="text-lg font-bold font-space tracking-tight"><span className="text-foreground">Uni</span><span className="text-primary">Rank</span></span>
-            <Badge variant="primary" className="ml-2 hidden sm:flex">BETA</Badge>
+            <div>
+              <p className="text-sm text-muted-foreground uppercase tracking-[0.2em]">Portfolio</p>
+              <p className="text-lg font-bold tracking-tight">Visionary Studio</p>
+            </div>
           </div>
 
-          <div className="flex items-center gap-6">
-            <div className="text-xs text-muted-foreground font-mono hidden md:block">
-              Updated {new Date().toLocaleDateString()}
+          <div className="flex items-center gap-4">
+            <div className="hidden md:flex items-center gap-2 text-xs text-muted-foreground">
+              <span className="w-2 h-2 rounded-full bg-emerald-500"></span>
+              Available for select collaborations
             </div>
             <ThemeToggle />
           </div>
         </div>
       </header>
 
-      <main className="relative z-10 container mx-auto px-4 sm:px-6 py-12">
-
-        {/* --- HERO --- */}
-        <section className="mb-16 mt-8">
-          <h1 className="text-6xl md:text-8xl font-black font-space mb-6 tracking-tighter text-transparent bg-clip-text bg-gradient-to-b from-foreground to-muted-foreground">
-            Rankings.<br />
-            <span className="text-foreground">Redefined.</span>
-          </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl font-light leading-relaxed">
-            Aggregating global university data from QS, THE, ARWU, and US News into a single, decisive metric.
-          </p>
-
-          {/* Pipeline Stats Banner */}
-          {globalStats && (
-            <div className="mt-10 inline-flex flex-wrap items-center gap-3 md:gap-0 py-3 px-1 md:px-0">
-              <div className="flex items-center gap-2.5 text-sm group">
-                <div className="p-1.5 rounded-md bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                  <Database size={14} className="text-primary" />
-                </div>
-                <span className="font-mono font-semibold text-foreground">{globalStats.totalUniversities.toLocaleString()}</span>
-                <span className="text-muted-foreground">universities</span>
-              </div>
-              <span className="hidden md:block w-px h-4 bg-border mx-6" />
-              <div className="flex items-center gap-2.5 text-sm group">
-                <div className="p-1.5 rounded-md bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                  <Layers size={14} className="text-primary" />
-                </div>
-                <span className="font-mono font-semibold text-foreground">{globalStats.totalSources}</span>
-                <span className="text-muted-foreground">ranking sources</span>
-              </div>
-              <span className="hidden md:block w-px h-4 bg-border mx-6" />
-              <div className="flex items-center gap-2.5 text-sm group">
-                <div className="p-1.5 rounded-md bg-primary/10 group-hover:bg-primary/20 transition-colors">
-                  <GitMerge size={14} className="text-primary" />
-                </div>
-                <span className="font-mono font-semibold text-foreground">{(globalStats.manualMappingsCount + globalStats.autoMappingsCount).toLocaleString()}</span>
-                <span className="text-muted-foreground">name variations resolved</span>
-              </div>
-            </div>
-          )}
-        </section>
-
-        {/* --- METRICS GRID --- */}
-        <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-20">
-          <StatCard icon={Globe} label="Universities Tracked" value={metrics.total} sub={`${metrics.countries} Countries Represented`} />
-          <StatCard icon={Award} label="Top Performer" value={metrics.topUni.name} sub="Highest Aggregate Score" trend="#1 Globally" />
-          <StatCard icon={TrendingUp} label="Global Average" value={metrics.avgScore} sub="Aggregate Index Score" />
-
-          {/* Chart Card */}
-          <div className="bg-card text-card-foreground p-6 rounded-2xl flex items-center justify-between border border-border">
+      <main className="relative z-10">
+        <section className="container mx-auto px-6 pt-16 pb-20">
+          <div className="grid lg:grid-cols-[1.1fr_0.9fr] gap-10 items-center">
             <div>
-              <div className="text-muted-foreground text-sm font-medium uppercase tracking-wider mb-2">Top Region</div>
-              <div className="text-2xl font-bold font-space">{metrics.topCountries[0][0]}</div>
-              <div className="text-sm text-muted-foreground">{metrics.topCountries[0][1]} Universities</div>
+              <div className="flex flex-wrap gap-2">
+                <Pill>Design Engineer</Pill>
+                <Pill>Creative Direction</Pill>
+                <Pill>Interactive Web</Pill>
+              </div>
+              <h1 className="mt-8 text-4xl md:text-6xl font-black tracking-tight leading-tight">
+                Building luminous digital experiences
+                <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary to-violet-500"> that feel alive</span>.
+              </h1>
+              <p className="mt-6 text-lg text-muted-foreground max-w-xl">
+                I design and engineer premium portfolios, products, and brand moments for teams who want their work to feel unforgettable.
+                Every pixel is intentional, every interaction adds a layer of story.
+              </p>
+              <div className="mt-8 flex flex-wrap gap-3">
+                <button className="px-6 py-3 rounded-full bg-primary text-primary-foreground font-semibold shadow-lg shadow-primary/25 flex items-center gap-2">
+                  View signature work <ArrowRight size={16} />
+                </button>
+                <button className="px-6 py-3 rounded-full border border-border text-foreground font-semibold hover:border-primary/50 transition-colors">
+                  Download résumé
+                </button>
+              </div>
+              <div className="mt-10 flex items-center gap-6 text-sm text-muted-foreground">
+                <div className="flex items-center gap-2">
+                  <Mail size={16} />
+                  hello@visionary.studio
+                </div>
+                <div className="flex items-center gap-2">
+                  <Globe size={16} />
+                  Based in Los Angeles, CA
+                </div>
+              </div>
             </div>
-            <div className="w-20 h-20">
-              <Doughnut data={metrics.chartData} options={{ cutout: '70%', plugins: { legend: { display: false }, tooltip: { enabled: false } } }} />
+
+            <div className="relative">
+              <div className="absolute -top-12 -right-8 w-32 h-32 rounded-full bg-primary/20 blur-3xl"></div>
+              <div className="absolute -bottom-16 left-6 w-40 h-40 rounded-full bg-violet-500/20 blur-3xl"></div>
+              <div className="bg-card border border-border rounded-3xl p-6 shadow-xl">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="text-sm text-muted-foreground uppercase tracking-[0.2em]">Currently</p>
+                    <h3 className="text-2xl font-semibold mt-2">Designing the future of creative tooling</h3>
+                  </div>
+                  <div className="w-12 h-12 rounded-2xl bg-muted flex items-center justify-center">
+                    <Layers size={20} className="text-primary" />
+                  </div>
+                </div>
+                <div className="mt-6 space-y-4">
+                  {[
+                    { label: 'Projects shipped', value: '38+' },
+                    { label: 'Years in craft', value: '8' },
+                    { label: 'Global collaborations', value: '14' }
+                  ].map(item => (
+                    <div key={item.label} className="flex items-center justify-between">
+                      <span className="text-sm text-muted-foreground">{item.label}</span>
+                      <span className="text-lg font-semibold">{item.value}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-6 rounded-2xl bg-muted/60 p-4">
+                  <p className="text-sm text-muted-foreground">
+                    Crafting immersive brand ecosystems, blending strategy, narrative, and engineering to deliver impactful launches.
+                  </p>
+                </div>
+              </div>
             </div>
           </div>
         </section>
 
-
-        {/* --- CONTROLS (DOCKED TOOLBAR) --- */}
-        <section className="sticky top-16 z-40 border-b border-border bg-background/95 backdrop-blur-xl transition-all duration-300 shadow-sm supports-[backdrop-filter]:bg-background/80">
-          <div className="container mx-auto px-4 sm:px-6 py-4 flex flex-col md:flex-row gap-6">
-            <div className="relative flex-grow">
-              <Search className="absolute left-5 top-1/2 -translate-y-1/2 text-muted-foreground w-4 h-4" />
-              <input
-                type="text"
-                placeholder="Search universities..."
-                className="w-full bg-muted/50 text-foreground pl-12 pr-4 py-3 rounded-xl border border-transparent focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 outline-none transition-all placeholder:text-muted-foreground/70 text-sm font-medium"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-              />
-            </div>
-
-            <div className="flex gap-2 overflow-x-auto pb-1 md:pb-0 no-scrollbar">
-              <select
-                className="bg-muted/50 text-foreground px-4 py-3 rounded-xl border border-transparent outline-none focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 appearance-none min-w-[180px] text-sm font-medium cursor-pointer hover:bg-muted/80 transition-colors"
-                value={sortBy}
-                onChange={(e) => setSortBy(e.target.value)}
-              >
-                <option value="aggregatedRank">Rank (Aggregated)</option>
-                <option value="qs">Rank (QS)</option>
-                <option value="the">Rank (THE)</option>
-                <option value="arwu">Rank (ARWU)</option>
-                <option value="usnews">Rank (US News)</option>
-                <option value="name">Name (A-Z)</option>
-              </select>
-
-              <select
-                className="bg-muted/50 text-foreground px-4 py-3 rounded-xl border border-transparent outline-none focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 appearance-none min-w-[160px] text-sm font-medium cursor-pointer hover:bg-muted/80 transition-colors"
-                value={selectedCountry}
-                onChange={(e) => setSelectedCountry(e.target.value)}
-              >
-                <option value="">All Countries</option>
-                {uniqueCountries.map(c => <option key={c} value={c}>{c}</option>)}
-              </select>
-
-              <select
-                className="bg-muted/50 text-foreground px-4 py-3 rounded-xl border border-transparent outline-none focus:bg-background focus:border-primary/50 focus:ring-2 focus:ring-primary/20 appearance-none min-w-[160px] text-sm font-medium cursor-pointer hover:bg-muted/80 transition-colors"
-                value={selectedGroup}
-                onChange={(e) => setSelectedGroup(e.target.value)}
-              >
-                <option value="">All Groups</option>
-                <option value="Ivy League">Ivy League</option>
-                <option value="Russell Group">Russell Group</option>
-                <option value="Big Ten">Big Ten</option>
-              </select>
-            </div>
-          </div>
-        </section>
-
-        {/* --- LIST --- */}
-        <section className="mt-6 space-y-3">
-          <div className="text-xs font-mono text-muted-foreground uppercase tracking-widest flex justify-between items-center">
-            <span>Showing {paginatedData.length} of {filteredData.length} Results</span>
-            <span>Page {currentPage}</span>
-          </div>
-
-          {paginatedData.map((uni, i) => (
-            <UniversityCard
-              key={uni.name}
-              university={uni}
-              expanded={expandedId === i}
-              onToggle={() => setExpandedId(expandedId === i ? null : i)}
-              globalStats={globalStats}
+        <section className="container mx-auto px-6 pb-20">
+          <div className="grid gap-10">
+            <SectionTitle
+              eyebrow="Signature Work"
+              title="Flagship projects that elevate product stories"
+              subtitle="From concept to polish, each engagement is shaped to amplify clarity, craft, and momentum."
             />
-          ))}
-
-          {paginatedData.length === 0 && (
-            <div className="text-center py-20">
-              <div className="text-muted-foreground text-lg">No universities found matching your criteria.</div>
+            <div className="grid md:grid-cols-2 xl:grid-cols-3 gap-6">
+              {projects.map(project => (
+                <ProjectCard key={project.title} {...project} />
+              ))}
             </div>
-          )}
+          </div>
         </section>
 
-        {/* --- PAGINATION --- */}
-        <div className="mt-12 flex justify-center gap-2">
-          <button
-            disabled={currentPage === 1}
-            onClick={() => setCurrentPage(p => p - 1)}
-            className="px-4 py-2 rounded-lg bg-muted text-muted-foreground disabled:opacity-30 hover:bg-muted/80 transition-colors font-medium text-sm"
-          >
-            Previous
-          </button>
-          <span className="px-4 py-2 text-muted-foreground font-mono text-sm">
-            Page {currentPage}
-          </span>
-          <button
-            disabled={paginatedData.length < itemsPerPage}
-            onClick={() => {
-              setCurrentPage(p => p + 1);
-              window.scrollTo({ top: 0, behavior: 'smooth' });
-            }}
-            className="px-4 py-2 rounded-lg bg-muted text-muted-foreground disabled:opacity-30 hover:bg-muted/80 transition-colors font-medium text-sm"
-          >
-            Next
-          </button>
-        </div>
+        <section className="container mx-auto px-6 pb-20">
+          <div className="grid lg:grid-cols-[0.9fr_1.1fr] gap-10 items-start">
+            <div className="space-y-6">
+              <SectionTitle
+                eyebrow="Capabilities"
+                title="A studio-grade toolkit for end-to-end delivery"
+                subtitle="I partner with founders and teams to ship cohesive, premium experiences across digital touchpoints."
+              />
+              <div className="grid gap-4">
+                {[
+                  { icon: Palette, title: 'Brand & Visual Systems', desc: 'Identity, typography, color, and design systems that scale across products.' },
+                  { icon: Code2, title: 'Front-End Engineering', desc: 'Modern React builds, WebGL touches, and performance-minded architecture.' },
+                  { icon: Award, title: 'Launch & Growth', desc: 'Go-to-market storytelling, editorial content, and product marketing assets.' }
+                ].map(item => (
+                  <div key={item.title} className="flex gap-4 p-5 rounded-2xl border border-border bg-card">
+                    <div className="w-10 h-10 rounded-2xl bg-primary/10 flex items-center justify-center">
+                      <item.icon size={18} className="text-primary" />
+                    </div>
+                    <div>
+                      <h3 className="font-semibold">{item.title}</h3>
+                      <p className="text-sm text-muted-foreground mt-2">{item.desc}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
 
+            <div className="grid gap-6">
+              <div className="bg-gradient-to-br from-primary/10 to-violet-500/10 border border-primary/20 rounded-3xl p-6">
+                <h3 className="text-2xl font-semibold">Design impact metrics</h3>
+                <p className="mt-3 text-muted-foreground">Evidence-driven outcomes with a focus on polish, clarity, and conversion.</p>
+                <div className="mt-6 grid sm:grid-cols-2 gap-4">
+                  {[
+                    { label: 'Avg. conversion lift', value: '54%' },
+                    { label: 'Product launches', value: '21' },
+                    { label: 'Awards & features', value: '9' },
+                    { label: 'Repeat partnerships', value: '78%' }
+                  ].map(item => (
+                    <div key={item.label} className="bg-background/70 border border-border rounded-2xl p-4">
+                      <p className="text-sm text-muted-foreground">{item.label}</p>
+                      <p className="text-2xl font-semibold mt-2">{item.value}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-4">
+                {experience.map(entry => (
+                  <ExperienceCard key={entry.role} {...entry} />
+                ))}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="container mx-auto px-6 pb-20">
+          <div className="grid gap-10">
+            <SectionTitle
+              eyebrow="Praise"
+              title="Partners and teams who trusted the process"
+              subtitle="Collaborations rooted in clarity, momentum, and craft-first delivery."
+            />
+            <div className="grid md:grid-cols-2 gap-6">
+              {testimonials.map(item => (
+                <TestimonialCard key={item.name} {...item} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="container mx-auto px-6 pb-24">
+          <div className="bg-card border border-border rounded-3xl p-10 md:p-14 relative overflow-hidden">
+            <div className="absolute inset-0 bg-gradient-to-r from-primary/10 via-transparent to-violet-500/10"></div>
+            <div className="relative">
+              <SectionTitle
+                eyebrow="Let’s build"
+                title="Ready to craft the next iconic experience?"
+                subtitle="Tell me about your vision, timeline, and where the story begins. I’ll bring the craft, strategy, and momentum."
+              />
+              <div className="mt-8 flex flex-wrap gap-4">
+                <button className="px-6 py-3 rounded-full bg-primary text-primary-foreground font-semibold shadow-lg shadow-primary/20 flex items-center gap-2">
+                  Start a project <ArrowRight size={16} />
+                </button>
+                <button className="px-6 py-3 rounded-full border border-border text-foreground font-semibold hover:border-primary/50 transition-colors flex items-center gap-2">
+                  <Github size={16} /> See the build log
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
       </main>
+
+      <footer className="border-t border-border">
+        <div className="container mx-auto px-6 py-8 flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
+          <div>
+            <p className="font-semibold">Visionary Studio</p>
+            <p className="text-sm text-muted-foreground">Crafting digital experiences with soul.</p>
+          </div>
+          <div className="flex flex-wrap gap-4 text-sm text-muted-foreground">
+            <span className="flex items-center gap-2"><Mail size={16} /> hello@visionary.studio</span>
+            <span className="flex items-center gap-2"><Globe size={16} /> visionary.studio</span>
+          </div>
+        </div>
+      </footer>
     </div>
   );
-}
+};
 
 function App() {
   return (


### PR DESCRIPTION
### Motivation
- Replace the previous university-ranking focused UI with a more cinematic, portfolio-first experience that better showcases design work and narrative flow.  
- Preserve the existing theme system and theme picker behavior (`light`, `dark`, `system`) while overhauling layout and content.  
- Deliver a premium studio narrative with hero, projects, capabilities, metrics, testimonials, CTA, and refined header/footer sections.

### Description
- Replaced the main application UI by rewriting `frontend/src/App.js` to remove ranking-specific data flows and add a portfolio layout with new components (`Pill`, `SectionTitle`, `ProjectCard`, `ExperienceCard`, `TestimonialCard`).
- Removed ChartJS and enhanced-ranking related code and imports, and added visual/content-focused icons and copy for a studio-grade presentation while keeping the `ThemeToggle` intact.  
- Updated header, hero, signature work, capabilities, metrics, testimonials, CTA, and footer sections and populated stubbed `projects`, `experience`, and `testimonials` data for the new layout.

### Testing
- Started the frontend dev server with `npm start` and the app compiled successfully (development build).  
- Captured a full-page screenshot via a Playwright script (`artifacts/portfolio-redesign.png`) to validate the new layout rendering successfully.  
- No unit tests were modified or executed as part of this design-first change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698552b64cc88320b024d57a5a72816d)