### PR TITLE
Add national ranking context to university cards

### DIFF
--- a/frontend/public/data/aggregated-rankings.json
+++ b/frontend/public/data/aggregated-rankings.json
@@ -19,7 +19,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 1,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 220
   },
   {
     "name": "Harvard University",
@@ -41,7 +42,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 2,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 220
   },
   {
     "name": "Stanford University",
@@ -63,7 +65,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 3,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 220
   },
   {
     "name": "University of Oxford",
@@ -85,7 +88,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 4,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 102
   },
   {
     "name": "University of Cambridge",
@@ -107,7 +111,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 5,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 102
   },
   {
     "name": "University of California Berkeley",
@@ -129,7 +134,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 6,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 220
   },
   {
     "name": "Imperial College London",
@@ -151,7 +157,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 7,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 102
   },
   {
     "name": "California Institute of Technology",
@@ -173,7 +180,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 8,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 220
   },
   {
     "name": "Yale University",
@@ -195,7 +203,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 9,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 220
   },
   {
     "name": "Princeton University",
@@ -217,7 +226,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 10,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 220
   },
   {
     "name": "University College London",
@@ -239,7 +249,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 11,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 102
   },
   {
     "name": "University of Pennsylvania",
@@ -261,7 +272,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 12,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 220
   },
   {
     "name": "Tsinghua University",
@@ -283,7 +295,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 13,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 224
   },
   {
     "name": "Cornell University",
@@ -305,7 +318,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 14,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 220
   },
   {
     "name": "University of Chicago",
@@ -327,7 +341,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 15,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 220
   },
   {
     "name": "Johns Hopkins University",
@@ -349,7 +364,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 16,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 220
   },
   {
     "name": "ETH Zurich",
@@ -371,7 +387,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 17,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 13
   },
   {
     "name": "Peking University",
@@ -393,7 +410,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 18,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 224
   },
   {
     "name": "Columbia University",
@@ -415,7 +433,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 19,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 220
   },
   {
     "name": "University of Toronto",
@@ -437,7 +456,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 20,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 35
   },
   {
     "name": "University of California Los Angeles",
@@ -459,7 +479,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 21,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 220
   },
   {
     "name": "National University of Singapore",
@@ -481,7 +502,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 22,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "University of Michigan",
@@ -503,7 +525,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 23,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 220
   },
   {
     "name": "University of Melbourne",
@@ -525,7 +548,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 24,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 41
   },
   {
     "name": "Northwestern University",
@@ -547,7 +571,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 25,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 220
   },
   {
     "name": "University of Washington Seattle",
@@ -569,7 +594,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 26,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 220
   },
   {
     "name": "University of Edinburgh",
@@ -591,7 +617,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 27,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 102
   },
   {
     "name": "New York University",
@@ -613,7 +640,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 28,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 220
   },
   {
     "name": "University of California San Diego",
@@ -635,7 +663,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 29,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 220
   },
   {
     "name": "Zhejiang University",
@@ -657,7 +686,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 30,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 224
   },
   {
     "name": "Nanyang Technological University",
@@ -679,7 +709,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 31,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "Shanghai Jiao Tong University",
@@ -701,7 +732,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 32,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 224
   },
   {
     "name": "Duke University",
@@ -723,7 +755,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 33,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 220
   },
   {
     "name": "King's College London",
@@ -745,7 +778,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 34,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 102
   },
   {
     "name": "Fudan University",
@@ -767,7 +801,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 35,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 224
   },
   {
     "name": "University of Tokyo",
@@ -789,7 +824,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 36,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 36
   },
   {
     "name": "University of Sydney",
@@ -811,7 +847,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 37,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 41
   },
   {
     "name": "University of British Columbia",
@@ -833,7 +870,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 38,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 35
   },
   {
     "name": "Ecole Polytechnique Federale de Lausanne",
@@ -855,7 +893,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 39,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 13
   },
   {
     "name": "University of Manchester",
@@ -877,7 +916,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 40,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 102
   },
   {
     "name": "McGill University",
@@ -899,7 +939,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 41,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 35
   },
   {
     "name": "Monash University",
@@ -921,7 +962,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 42,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 41
   },
   {
     "name": "Chinese University of Hong Kong",
@@ -943,7 +985,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 43,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 9
   },
   {
     "name": "University of New South Wales Sydney",
@@ -965,7 +1008,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 44,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 41
   },
   {
     "name": "Universite PSL",
@@ -987,7 +1031,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 45,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 60
   },
   {
     "name": "University of Queensland",
@@ -1009,7 +1054,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 46,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 41
   },
   {
     "name": "KU Leuven",
@@ -1031,7 +1077,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 47,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 14
   },
   {
     "name": "University of Texas Austin",
@@ -1053,7 +1100,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 48,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 220
   },
   {
     "name": "Ruprecht Karls University Heidelberg",
@@ -1075,7 +1123,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 49,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 84
   },
   {
     "name": "University of Amsterdam",
@@ -1097,7 +1146,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 50,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 14
   },
   {
     "name": "Sorbonne Universite",
@@ -1119,7 +1169,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 51,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 60
   },
   {
     "name": "University of Copenhagen",
@@ -1141,7 +1192,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 52,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 7
   },
   {
     "name": "University of Wisconsin Madison",
@@ -1163,7 +1215,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 53,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 220
   },
   {
     "name": "University of Illinois Urbana-Champaign",
@@ -1185,7 +1238,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 54,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 220
   },
   {
     "name": "University of Hong Kong",
@@ -1207,7 +1261,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 55,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 9
   },
   {
     "name": "Washington University (WUSTL)",
@@ -1229,7 +1284,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 56,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 220
   },
   {
     "name": "Australian National University",
@@ -1251,7 +1307,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 57,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 41
   },
   {
     "name": "University of Science & Technology of China, CAS",
@@ -1273,7 +1330,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 58,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 224
   },
   {
     "name": "Carnegie Mellon University",
@@ -1295,7 +1353,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 59,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 220
   },
   {
     "name": "University of North Carolina Chapel Hill",
@@ -1317,7 +1376,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 60,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 220
   },
   {
     "name": "Seoul National University (SNU)",
@@ -1339,7 +1399,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 61,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 37
   },
   {
     "name": "University of Glasgow",
@@ -1361,7 +1422,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 62,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 102
   },
   {
     "name": "University of Bristol",
@@ -1383,7 +1445,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 63,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 102
   },
   {
     "name": "Hong Kong Polytechnic University",
@@ -1405,7 +1468,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 64,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 9
   },
   {
     "name": "Leiden University",
@@ -1427,7 +1491,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 65,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 14
   },
   {
     "name": "Kyoto University",
@@ -1449,7 +1514,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 66,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 36
   },
   {
     "name": "Boston University",
@@ -1471,7 +1537,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 67,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 220
   },
   {
     "name": "University of Southern California",
@@ -1493,7 +1560,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 68,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 220
   },
   {
     "name": "University of California Davis",
@@ -1515,7 +1583,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 69,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 220
   },
   {
     "name": "University of Groningen",
@@ -1537,7 +1606,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 70,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 14
   },
   {
     "name": "Pennsylvania State University",
@@ -1559,7 +1629,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 71,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 220
   },
   {
     "name": "Brown University",
@@ -1581,7 +1652,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 72,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 220
   },
   {
     "name": "Lund University",
@@ -1603,7 +1675,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 73,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 18
   },
   {
     "name": "Georgia Institute of Technology",
@@ -1625,7 +1698,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 74,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 220
   },
   {
     "name": "Hong Kong University of Science & Technology",
@@ -1647,7 +1721,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 75,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 9
   },
   {
     "name": "University of California Santa Barbara",
@@ -1669,7 +1744,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 76,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 220
   },
   {
     "name": "University of Oslo",
@@ -1691,7 +1767,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 77,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 8
   },
   {
     "name": "University of Birmingham",
@@ -1713,7 +1790,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 78,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 102
   },
   {
     "name": "University of Minnesota Twin Cities",
@@ -1735,7 +1813,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 79,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 220
   },
   {
     "name": "Erasmus University Rotterdam",
@@ -1757,7 +1836,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 80,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 14
   },
   {
     "name": "University of Helsinki",
@@ -1779,7 +1859,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 81,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 10
   },
   {
     "name": "University of Western Australia",
@@ -1801,7 +1882,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 82,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 41
   },
   {
     "name": "Aarhus University",
@@ -1823,7 +1905,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 83,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 7
   },
   {
     "name": "Delft University of Technology",
@@ -1845,7 +1928,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 84,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 14
   },
   {
     "name": "Purdue University",
@@ -1867,7 +1951,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 85,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 220
   },
   {
     "name": "Ohio State University",
@@ -1889,7 +1974,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 86,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 220
   },
   {
     "name": "University of Maryland College Park",
@@ -1911,7 +1997,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 87,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 220
   },
   {
     "name": "Emory University",
@@ -1933,7 +2020,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 88,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 220
   },
   {
     "name": "Uppsala University",
@@ -1955,7 +2043,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 89,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 18
   },
   {
     "name": "Yonsei University",
@@ -1977,7 +2066,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 90,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 37
   },
   {
     "name": "University of Alberta",
@@ -1999,7 +2089,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 91,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 35
   },
   {
     "name": "Vanderbilt University",
@@ -2021,7 +2112,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 92,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 220
   },
   {
     "name": "University of Warwick",
@@ -2043,7 +2135,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 93,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 102
   },
   {
     "name": "Wuhan University",
@@ -2065,7 +2158,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 94,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 224
   },
   {
     "name": "University of Southampton",
@@ -2087,7 +2181,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 95,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 102
   },
   {
     "name": "Wageningen University & Research",
@@ -2109,7 +2204,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 96,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 14
   },
   {
     "name": "University of Leeds",
@@ -2131,7 +2227,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 97,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 102
   },
   {
     "name": "London School Economics & Political Science",
@@ -2153,7 +2250,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 98,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 102
   },
   {
     "name": "University of Nottingham",
@@ -2175,7 +2273,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 99,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 102
   },
   {
     "name": "Adelaide University",
@@ -2197,7 +2296,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 100,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 41
   },
   {
     "name": "University of Sheffield",
@@ -2219,7 +2319,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 101,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 102
   },
   {
     "name": "University of Technology Sydney",
@@ -2241,7 +2342,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 102,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 41
   },
   {
     "name": "University of Liverpool",
@@ -2263,7 +2365,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 103,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 102
   },
   {
     "name": "University of Bonn",
@@ -2285,7 +2388,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 104,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 84
   },
   {
     "name": "University of Geneva",
@@ -2307,7 +2411,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 105,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 13
   },
   {
     "name": "McMaster University",
@@ -2329,7 +2434,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 106,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 35
   },
   {
     "name": "University of Barcelona",
@@ -2351,7 +2457,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 107,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 53
   },
   {
     "name": "Queen Mary University London",
@@ -2373,7 +2480,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 108,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 102
   },
   {
     "name": "Rice University",
@@ -2395,7 +2503,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 109,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 220
   },
   {
     "name": "Tongji University",
@@ -2417,7 +2526,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 110,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 224
   },
   {
     "name": "University of Auckland",
@@ -2439,7 +2549,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 111,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 8
   },
   {
     "name": "Michigan State University",
@@ -2461,7 +2572,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 112,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 220
   },
   {
     "name": "University of Basel",
@@ -2483,7 +2595,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 113,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 13
   },
   {
     "name": "Universidade de Sao Paulo",
@@ -2505,7 +2618,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 114,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 26
   },
   {
     "name": "Technical University of Denmark",
@@ -2527,7 +2641,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 115,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 7
   },
   {
     "name": "University of Bern",
@@ -2549,7 +2664,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 116,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 13
   },
   {
     "name": "Sapienza University Rome",
@@ -2571,7 +2687,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 117,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 61
   },
   {
     "name": "University of Vienna",
@@ -2593,7 +2710,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 118,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 13
   },
   {
     "name": "University of California Irvine",
@@ -2615,7 +2733,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 119,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 220
   },
   {
     "name": "University of Pittsburgh",
@@ -2637,7 +2756,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 120,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 220
   },
   {
     "name": "University of Lausanne",
@@ -2659,7 +2779,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 121,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 13
   },
   {
     "name": "University of Exeter",
@@ -2681,7 +2802,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 122,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 102
   },
   {
     "name": "Stockholm University",
@@ -2703,7 +2825,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 123,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 18
   },
   {
     "name": "University of Florida",
@@ -2725,7 +2848,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 124,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 220
   },
   {
     "name": "University of Bologna",
@@ -2747,7 +2871,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 125,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 61
   },
   {
     "name": "Harbin Institute of Technology",
@@ -2769,7 +2894,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 126,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 224
   },
   {
     "name": "RWTH Aachen University",
@@ -2791,7 +2917,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 127,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 84
   },
   {
     "name": "Sun Yat Sen University",
@@ -2813,7 +2940,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 128,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 224
   },
   {
     "name": "University of Colorado Boulder",
@@ -2835,7 +2963,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 129,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 220
   },
   {
     "name": "Royal Institute of Technology",
@@ -2857,7 +2986,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 130,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 18
   },
   {
     "name": "University of Waterloo",
@@ -2879,7 +3009,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 131,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 35
   },
   {
     "name": "Institut Polytechnique de Paris",
@@ -2901,7 +3032,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 132,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 60
   },
   {
     "name": "Sungkyunkwan University (SKKU)",
@@ -2923,7 +3055,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 133,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 37
   },
   {
     "name": "University of Cape Town",
@@ -2945,7 +3078,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 134,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 9
   },
   {
     "name": "King Saud University",
@@ -2967,7 +3101,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 135,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 25
   },
   {
     "name": "National Taiwan University",
@@ -2989,7 +3124,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 136,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 18
   },
   {
     "name": "Newcastle University - UK",
@@ -3011,7 +3147,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 137,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 102
   },
   {
     "name": "University of Freiburg",
@@ -3033,7 +3170,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 138,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 84
   },
   {
     "name": "Beijing Normal University",
@@ -3055,7 +3193,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 139,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 224
   },
   {
     "name": "Trinity College Dublin",
@@ -3077,7 +3216,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 140,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 9
   },
   {
     "name": "Radboud University Nijmegen",
@@ -3099,7 +3239,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 141,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 14
   },
   {
     "name": "Huazhong University of Science & Technology",
@@ -3121,7 +3262,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 142,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 224
   },
   {
     "name": "University of Hamburg",
@@ -3143,7 +3285,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 143,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 84
   },
   {
     "name": "Macquarie University",
@@ -3165,7 +3308,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 144,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 41
   },
   {
     "name": "University of Arizona",
@@ -3187,7 +3331,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 145,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 220
   },
   {
     "name": "Korea University",
@@ -3209,7 +3354,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 146,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 37
   },
   {
     "name": "Arizona State University-Tempe",
@@ -3231,7 +3377,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 147,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 220
   },
   {
     "name": "Beijing Institute of Technology",
@@ -3253,7 +3400,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 148,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 224
   },
   {
     "name": "Tohoku University",
@@ -3275,7 +3423,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 149,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 36
   },
   {
     "name": "University of Padua",
@@ -3297,7 +3446,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 150,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 61
   },
   {
     "name": "University of Massachusetts Amherst",
@@ -3319,7 +3469,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 151,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 220
   },
   {
     "name": "Southern University of Science & Technology",
@@ -3341,7 +3492,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 152,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 224
   },
   {
     "name": "Xi'an Jiaotong University",
@@ -3363,7 +3515,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 153,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 224
   },
   {
     "name": "Tianjin University",
@@ -3385,7 +3538,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 154,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 224
   },
   {
     "name": "Osaka University",
@@ -3407,7 +3561,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 155,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 36
   },
   {
     "name": "Durham University",
@@ -3429,7 +3584,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 156,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 102
   },
   {
     "name": "University of Rochester",
@@ -3451,7 +3607,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 157,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 220
   },
   {
     "name": "University of Calgary",
@@ -3473,7 +3630,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 158,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 35
   },
   {
     "name": "Case Western Reserve University",
@@ -3495,7 +3653,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 159,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 220
   },
   {
     "name": "Indiana University Bloomington",
@@ -3517,7 +3676,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 160,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 220
   },
   {
     "name": "Cardiff University",
@@ -3539,7 +3699,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 161,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 102
   },
   {
     "name": "Technical University of Berlin",
@@ -3561,7 +3722,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 162,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 84
   },
   {
     "name": "University of Virginia",
@@ -3583,7 +3745,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 163,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 220
   },
   {
     "name": "Deakin University",
@@ -3605,7 +3768,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 164,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 41
   },
   {
     "name": "Autonomous University of Barcelona",
@@ -3627,7 +3791,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 165,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 53
   },
   {
     "name": "Curtin University",
@@ -3649,7 +3814,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 166,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 41
   },
   {
     "name": "Sichuan University",
@@ -3671,7 +3837,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 167,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 224
   },
   {
     "name": "University of Cologne",
@@ -3693,7 +3860,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 168,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 84
   },
   {
     "name": "Nagoya University",
@@ -3715,7 +3883,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 169,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 36
   },
   {
     "name": "Tel Aviv University",
@@ -3737,7 +3906,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 170,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 8
   },
   {
     "name": "University of York - UK",
@@ -3759,7 +3929,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 171,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 102
   },
   {
     "name": "Karlsruhe Institute of Technology",
@@ -3781,7 +3952,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 172,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 84
   },
   {
     "name": "University of Maastricht",
@@ -3803,7 +3975,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 173,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 14
   },
   {
     "name": "Hebrew University of Jerusalem",
@@ -3825,7 +3998,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 174,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 8
   },
   {
     "name": "Nanjing University",
@@ -3847,7 +4021,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 175,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 224
   },
   {
     "name": "Lomonosov Moscow State University",
@@ -3869,7 +4044,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 176,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 27
   },
   {
     "name": "University of Ottawa",
@@ -3891,7 +4067,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 177,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 35
   },
   {
     "name": "University College Dublin",
@@ -3913,7 +4090,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 178,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 9
   },
   {
     "name": "University of Milan",
@@ -3935,7 +4113,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 179,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 61
   },
   {
     "name": "Xiamen University",
@@ -3957,7 +4136,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 180,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 224
   },
   {
     "name": "Swinburne University of Technology",
@@ -3979,7 +4159,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 181,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 41
   },
   {
     "name": "University of Wollongong",
@@ -4001,7 +4182,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 182,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 41
   },
   {
     "name": "Southeast University",
@@ -4023,7 +4205,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 183,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 224
   },
   {
     "name": "Lancaster University",
@@ -4045,7 +4228,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 184,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 102
   },
   {
     "name": "Queensland University of Technology (QUT)",
@@ -4067,7 +4251,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 185,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 41
   },
   {
     "name": "Nankai University",
@@ -4089,7 +4274,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 186,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 224
   },
   {
     "name": "University of California Santa Cruz",
@@ -4111,7 +4297,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 187,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 220
   },
   {
     "name": "Pohang University of Science & Technology",
@@ -4133,7 +4320,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 188,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 37
   },
   {
     "name": "Queen's University Belfast",
@@ -4155,7 +4343,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 189,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 102
   },
   {
     "name": "Shandong University",
@@ -4177,7 +4366,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 190,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 224
   },
   {
     "name": "Polytechnic University of Milan",
@@ -4199,7 +4389,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 191,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 61
   },
   {
     "name": "University of Sussex",
@@ -4221,7 +4412,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 192,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 102
   },
   {
     "name": "Beihang University",
@@ -4243,7 +4435,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 193,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 224
   },
   {
     "name": "University of Antwerp",
@@ -4265,7 +4458,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 194,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 14
   },
   {
     "name": "University of Macau",
@@ -4287,7 +4481,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 195,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "Western University (University of Western Ontario)",
@@ -4309,7 +4504,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 196,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 35
   },
   {
     "name": "University of St. Andrews",
@@ -4331,7 +4527,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 197,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 102
   },
   {
     "name": "Aalto University",
@@ -4353,7 +4550,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 198,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 10
   },
   {
     "name": "Central South University",
@@ -4375,7 +4573,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 199,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 224
   },
   {
     "name": "University of Leicester",
@@ -4397,7 +4596,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 200,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 102
   },
   {
     "name": "University of Bergen",
@@ -4419,7 +4619,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 201,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 8
   },
   {
     "name": "Northeastern University",
@@ -4441,7 +4642,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 202,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 220
   },
   {
     "name": "Hunan University",
@@ -4463,7 +4665,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 203,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 224
   },
   {
     "name": "Chalmers University of Technology",
@@ -4485,7 +4688,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 204,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 18
   },
   {
     "name": "Tufts University",
@@ -4507,7 +4711,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 205,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 220
   },
   {
     "name": "Kyushu University",
@@ -4529,7 +4734,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 206,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 36
   },
   {
     "name": "Pompeu Fabra University",
@@ -4551,7 +4757,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 207,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 53
   },
   {
     "name": "University of Utah",
@@ -4573,7 +4780,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 208,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 220
   },
   {
     "name": "University of Aberdeen",
@@ -4595,7 +4803,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 209,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 102
   },
   {
     "name": "Eindhoven University of Technology",
@@ -4617,7 +4826,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 210,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 14
   },
   {
     "name": "North Carolina State University",
@@ -4639,7 +4849,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 211,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 220
   },
   {
     "name": "Hanyang University",
@@ -4661,7 +4872,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 212,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 37
   },
   {
     "name": "University of Miami",
@@ -4683,7 +4895,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 213,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 220
   },
   {
     "name": "Dartmouth College",
@@ -4705,7 +4918,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 214,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 220
   },
   {
     "name": "Griffith University",
@@ -4727,7 +4941,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 215,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 41
   },
   {
     "name": "University of Witwatersrand",
@@ -4749,7 +4964,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 216,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 9
   },
   {
     "name": "Northwestern Polytechnical University",
@@ -4771,7 +4987,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 217,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 224
   },
   {
     "name": "La Trobe University",
@@ -4793,7 +5010,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 218,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 41
   },
   {
     "name": "Universidade de Lisboa",
@@ -4815,7 +5033,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 219,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 9
   },
   {
     "name": "University of Naples Federico II",
@@ -4837,7 +5056,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 220,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 61
   },
   {
     "name": "Universite Grenoble Alpes (UGA)",
@@ -4859,7 +5079,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 221,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 60
   },
   {
     "name": "Virginia Polytechnic Institute & State University",
@@ -4881,7 +5102,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 222,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 220
   },
   {
     "name": "George Washington University",
@@ -4903,7 +5125,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 223,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 220
   },
   {
     "name": "University of Electronic Science & Technology of China",
@@ -4925,7 +5148,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 224,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 224
   },
   {
     "name": "Queens University",
@@ -4947,7 +5171,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 225,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 35
   },
   {
     "name": "Universidade do Porto",
@@ -4969,7 +5194,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 226,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 9
   },
   {
     "name": "University of Southern Denmark",
@@ -4991,7 +5217,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 227,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 7
   },
   {
     "name": "Linkoping University",
@@ -5013,7 +5240,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 228,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 18
   },
   {
     "name": "East China Normal University",
@@ -5035,7 +5263,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 229,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 224
   },
   {
     "name": "King Abdulaziz University",
@@ -5057,7 +5286,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 230,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 25
   },
   {
     "name": "University of Qatar",
@@ -5079,7 +5309,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 231,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Technion Israel Institute of Technology",
@@ -5101,7 +5332,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 232,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 8
   },
   {
     "name": "Aalborg University",
@@ -5123,7 +5355,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 233,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 7
   },
   {
     "name": "Autonomous University of Madrid",
@@ -5145,7 +5378,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 234,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 53
   },
   {
     "name": "Vrije Universiteit Brussel",
@@ -5167,7 +5401,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 235,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 14
   },
   {
     "name": "University of Tasmania",
@@ -5189,7 +5424,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 236,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 41
   },
   {
     "name": "University of Pisa",
@@ -5211,7 +5447,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 237,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 61
   },
   {
     "name": "Hokkaido University",
@@ -5233,7 +5470,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 238,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 36
   },
   {
     "name": "Shenzhen University",
@@ -5255,7 +5493,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 239,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 224
   },
   {
     "name": "University of Reading",
@@ -5277,7 +5516,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 240,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 102
   },
   {
     "name": "University of California Riverside",
@@ -5299,7 +5539,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 241,
-    "countryRank": 61
+    "countryRank": 61,
+    "countryTotal": 220
   },
   {
     "name": "University of Bath",
@@ -5321,7 +5562,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 242,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 102
   },
   {
     "name": "Georgetown University",
@@ -5343,7 +5585,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 243,
-    "countryRank": 62
+    "countryRank": 62,
+    "countryTotal": 220
   },
   {
     "name": "University of Surrey",
@@ -5365,7 +5608,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 244,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 102
   },
   {
     "name": "Universiti Malaya",
@@ -5387,7 +5631,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 245,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 26
   },
   {
     "name": "University of Notre Dame",
@@ -5409,7 +5654,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 246,
-    "countryRank": 63
+    "countryRank": 63,
+    "countryTotal": 220
   },
   {
     "name": "University of Illinois Chicago",
@@ -5431,7 +5677,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 247,
-    "countryRank": 64
+    "countryRank": 64,
+    "countryTotal": 220
   },
   {
     "name": "Charles University Prague",
@@ -5453,7 +5700,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 248,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 8
   },
   {
     "name": "Ulsan National Institute of Science & Technology (UNIST)",
@@ -5475,7 +5723,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 249,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 37
   },
   {
     "name": "Chongqing University",
@@ -5497,7 +5746,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 250,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 224
   },
   {
     "name": "University of Turin",
@@ -5519,7 +5769,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 251,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 61
   },
   {
     "name": "University of Otago",
@@ -5541,7 +5792,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 252,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 8
   },
   {
     "name": "King Fahd University of Petroleum & Minerals",
@@ -5563,7 +5815,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 253,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 25
   },
   {
     "name": "University of Western Sydney",
@@ -5585,7 +5838,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 254,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 41
   },
   {
     "name": "Stony Brook University",
@@ -5607,7 +5861,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 255,
-    "countryRank": 65
+    "countryRank": 65,
+    "countryTotal": 220
   },
   {
     "name": "Sejong University",
@@ -5629,7 +5884,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 256,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 37
   },
   {
     "name": "Dalian University of Technology",
@@ -5651,7 +5907,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 257,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 224
   },
   {
     "name": "University College Cork",
@@ -5673,7 +5930,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 258,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 9
   },
   {
     "name": "University of Florence",
@@ -5695,7 +5953,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 259,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 61
   },
   {
     "name": "University of Potsdam",
@@ -5717,7 +5976,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 260,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 84
   },
   {
     "name": "University Complutense Madrid",
@@ -5739,7 +5999,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 261,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 53
   },
   {
     "name": "Dalhousie University",
@@ -5761,7 +6022,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 262,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 35
   },
   {
     "name": "University of Twente",
@@ -5783,7 +6045,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 263,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 14
   },
   {
     "name": "University of Stellenbosch",
@@ -5805,7 +6068,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 264,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 9
   },
   {
     "name": "Vita-Salute San Raffaele University",
@@ -5827,7 +6091,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 265,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 61
   },
   {
     "name": "University of Innsbruck",
@@ -5849,7 +6114,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 266,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 13
   },
   {
     "name": "University of East Anglia",
@@ -5871,7 +6137,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 267,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 102
   },
   {
     "name": "Universidade Estadual de Campinas",
@@ -5893,7 +6160,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 268,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 26
   },
   {
     "name": "Kyung Hee University",
@@ -5915,7 +6183,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 269,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 37
   },
   {
     "name": "University of Iowa",
@@ -5937,7 +6206,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 270,
-    "countryRank": 66
+    "countryRank": 66,
+    "countryTotal": 220
   },
   {
     "name": "University of Connecticut",
@@ -5959,7 +6229,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 271,
-    "countryRank": 67
+    "countryRank": 67,
+    "countryTotal": 220
   },
   {
     "name": "University of Navarra",
@@ -5981,7 +6252,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 272,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 53
   },
   {
     "name": "University of Oulu",
@@ -6003,7 +6275,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 273,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 10
   },
   {
     "name": "University of Valencia",
@@ -6025,7 +6298,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 274,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 53
   },
   {
     "name": "University of Tartu",
@@ -6047,7 +6321,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 275,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "University of Tehran",
@@ -6069,7 +6344,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 276,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 37
   },
   {
     "name": "Pontificia Universidad Catolica de Chile",
@@ -6091,7 +6367,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 277,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 7
   },
   {
     "name": "Tsukuba University",
@@ -6113,7 +6390,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 278,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 36
   },
   {
     "name": "University of Turku",
@@ -6135,7 +6413,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 279,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 10
   },
   {
     "name": "University of Dundee",
@@ -6157,7 +6436,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 280,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 102
   },
   {
     "name": "Simon Fraser University",
@@ -6179,7 +6459,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 281,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 35
   },
   {
     "name": "University of Rome Tor Vergata",
@@ -6201,7 +6482,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 282,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 61
   },
   {
     "name": "University of Kansas",
@@ -6223,7 +6505,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 283,
-    "countryRank": 68
+    "countryRank": 68,
+    "countryTotal": 220
   },
   {
     "name": "Florida State University",
@@ -6245,7 +6528,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 284,
-    "countryRank": 69
+    "countryRank": 69,
+    "countryTotal": 220
   },
   {
     "name": "Shanghai University",
@@ -6267,7 +6551,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 285,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 224
   },
   {
     "name": "United Arab Emirates University",
@@ -6289,7 +6574,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 286,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 13
   },
   {
     "name": "University of Trento",
@@ -6311,7 +6597,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 287,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 61
   },
   {
     "name": "University of Johannesburg",
@@ -6333,7 +6620,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 288,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 9
   },
   {
     "name": "National Tsing Hua University",
@@ -6355,7 +6643,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 289,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 18
   },
   {
     "name": "Hong Kong Baptist University",
@@ -6377,7 +6666,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 290,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 9
   },
   {
     "name": "University of Tennessee Knoxville",
@@ -6399,7 +6689,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 291,
-    "countryRank": 70
+    "countryRank": 70,
+    "countryTotal": 220
   },
   {
     "name": "University of Milano-Bicocca",
@@ -6421,7 +6712,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 292,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 61
   },
   {
     "name": "University of Kiel",
@@ -6443,7 +6735,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 293,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 84
   },
   {
     "name": "University of Pavia",
@@ -6465,7 +6758,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 294,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 61
   },
   {
     "name": "University of Georgia",
@@ -6487,7 +6781,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 295,
-    "countryRank": 71
+    "countryRank": 71,
+    "countryTotal": 220
   },
   {
     "name": "Flinders University",
@@ -6509,7 +6804,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 296,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 41
   },
   {
     "name": "King Khalid University",
@@ -6531,7 +6827,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 297,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 25
   },
   {
     "name": "Victoria University of Wellington",
@@ -6553,7 +6850,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 298,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 8
   },
   {
     "name": "Technical University of Darmstadt",
@@ -6575,7 +6873,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 299,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 84
   },
   {
     "name": "Universidad Nacional Autonoma de Mexico",
@@ -6597,7 +6896,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 300,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 9
   },
   {
     "name": "Keio University",
@@ -6619,7 +6919,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 301,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 36
   },
   {
     "name": "University of Houston",
@@ -6641,7 +6942,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 302,
-    "countryRank": 72
+    "countryRank": 72,
+    "countryTotal": 220
   },
   {
     "name": "University of Munich",
@@ -6660,7 +6962,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 303,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 84
   },
   {
     "name": "University at Buffalo, SUNY",
@@ -6682,7 +6985,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 304,
-    "countryRank": 73
+    "countryRank": 73,
+    "countryTotal": 220
   },
   {
     "name": "University of Genoa",
@@ -6704,7 +7008,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 305,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 61
   },
   {
     "name": "University of Hawaii Manoa",
@@ -6726,7 +7031,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 306,
-    "countryRank": 74
+    "countryRank": 74,
+    "countryTotal": 220
   },
   {
     "name": "Technical University of Munich",
@@ -6745,7 +7051,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 307,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 84
   },
   {
     "name": "North China University of Technology",
@@ -6767,7 +7074,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 308,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 224
   },
   {
     "name": "Karolinska Institutet",
@@ -6786,7 +7094,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 309,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 18
   },
   {
     "name": "Colorado State University",
@@ -6808,7 +7117,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 310,
-    "countryRank": 75
+    "countryRank": 75,
+    "countryTotal": 220
   },
   {
     "name": "Universite Paris Saclay",
@@ -6827,7 +7137,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 311,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 60
   },
   {
     "name": "James Cook University",
@@ -6849,7 +7160,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 312,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 41
   },
   {
     "name": "University of Delaware",
@@ -6871,7 +7183,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 313,
-    "countryRank": 76
+    "countryRank": 76,
+    "countryTotal": 220
   },
   {
     "name": "Umea University",
@@ -6893,7 +7206,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 314,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 18
   },
   {
     "name": "Beijing University of Chemical Technology",
@@ -6915,7 +7229,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 315,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 224
   },
   {
     "name": "Laval University",
@@ -6937,7 +7252,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 316,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 35
   },
   {
     "name": "National Yang Ming Chiao Tung University",
@@ -6959,7 +7275,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 317,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 18
   },
   {
     "name": "Iowa State University",
@@ -6981,7 +7298,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 318,
-    "countryRank": 77
+    "countryRank": 77,
+    "countryTotal": 220
   },
   {
     "name": "University of Southern Queensland",
@@ -7003,7 +7321,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 319,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 41
   },
   {
     "name": "Washington State University",
@@ -7025,7 +7344,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 320,
-    "countryRank": 78
+    "countryRank": 78,
+    "countryTotal": 220
   },
   {
     "name": "Utrecht University",
@@ -7044,7 +7364,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 321,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 14
   },
   {
     "name": "University of Stuttgart",
@@ -7066,7 +7387,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 322,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 84
   },
   {
     "name": "University of Zurich",
@@ -7085,7 +7407,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 323,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 13
   },
   {
     "name": "University of Konstanz",
@@ -7107,7 +7430,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 324,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 84
   },
   {
     "name": "University of Granada",
@@ -7129,7 +7453,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 325,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 53
   },
   {
     "name": "Free University of Berlin",
@@ -7148,7 +7473,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 326,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 84
   },
   {
     "name": "University of Tampere",
@@ -7170,7 +7496,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 327,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 10
   },
   {
     "name": "Humboldt University of Berlin",
@@ -7189,7 +7516,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 328,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 84
   },
   {
     "name": "University of Saskatchewan",
@@ -7211,7 +7539,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 329,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 35
   },
   {
     "name": "University of Duisburg Essen",
@@ -7233,7 +7562,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 330,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 84
   },
   {
     "name": "University of Luxembourg",
@@ -7255,7 +7585,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 331,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Swansea University",
@@ -7277,7 +7608,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 332,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 102
   },
   {
     "name": "Universite Paris Cite",
@@ -7296,7 +7628,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 333,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 60
   },
   {
     "name": "University of Strathclyde",
@@ -7318,7 +7651,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 334,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 102
   },
   {
     "name": "Jagiellonian University",
@@ -7340,7 +7674,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 335,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 13
   },
   {
     "name": "University of Warsaw",
@@ -7362,7 +7697,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 336,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 13
   },
   {
     "name": "Victoria University",
@@ -7384,7 +7720,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 337,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 35
   },
   {
     "name": "University of South Florida",
@@ -7406,7 +7743,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 338,
-    "countryRank": 79
+    "countryRank": 79,
+    "countryTotal": 220
   },
   {
     "name": "University of Sharjah",
@@ -7428,7 +7766,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 339,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 13
   },
   {
     "name": "University of Essex",
@@ -7450,7 +7789,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 340,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 102
   },
   {
     "name": "Macau University of Science & Technology",
@@ -7472,7 +7812,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 341,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "Boston College",
@@ -7494,7 +7835,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 342,
-    "countryRank": 80
+    "countryRank": 80,
+    "countryTotal": 220
   },
   {
     "name": "Cairo University",
@@ -7516,7 +7858,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 343,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 10
   },
   {
     "name": "University of Canterbury",
@@ -7538,7 +7881,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 344,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 8
   },
   {
     "name": "University of South Carolina Columbia",
@@ -7560,7 +7904,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 345,
-    "countryRank": 81
+    "countryRank": 81,
+    "countryTotal": 220
   },
   {
     "name": "Koc University",
@@ -7582,7 +7927,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 346,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 21
   },
   {
     "name": "University of Pretoria",
@@ -7604,7 +7950,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 347,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 9
   },
   {
     "name": "Murdoch University",
@@ -7626,7 +7973,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 348,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 41
   },
   {
     "name": "University of Colorado Denver",
@@ -7648,7 +7996,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 349,
-    "countryRank": 82
+    "countryRank": 82,
+    "countryTotal": 220
   },
   {
     "name": "Loughborough University",
@@ -7670,7 +8019,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 350,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 102
   },
   {
     "name": "University of Montreal",
@@ -7689,7 +8039,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 351,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 35
   },
   {
     "name": "University of Gottingen",
@@ -7708,7 +8059,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 352,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 84
   },
   {
     "name": "Chulalongkorn University",
@@ -7730,7 +8082,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 353,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 8
   },
   {
     "name": "Tokyo Institute of Technology",
@@ -7749,7 +8102,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 354,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 36
   },
   {
     "name": "Texas A&M University",
@@ -7768,7 +8122,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 355,
-    "countryRank": 83
+    "countryRank": 83,
+    "countryTotal": 220
   },
   {
     "name": "Temple University",
@@ -7790,7 +8145,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 356,
-    "countryRank": 84
+    "countryRank": 84,
+    "countryTotal": 220
   },
   {
     "name": "University of Manitoba",
@@ -7812,7 +8168,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 357,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 35
   },
   {
     "name": "University of Kentucky",
@@ -7834,7 +8191,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 358,
-    "countryRank": 85
+    "countryRank": 85,
+    "countryTotal": 220
   },
   {
     "name": "Tulane University",
@@ -7856,7 +8214,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 359,
-    "countryRank": 86
+    "countryRank": 86,
+    "countryTotal": 220
   },
   {
     "name": "VU University Amsterdam",
@@ -7875,7 +8234,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 360,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 14
   },
   {
     "name": "Ben-Gurion University of the Negev",
@@ -7897,7 +8257,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 361,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 8
   },
   {
     "name": "University of Bremen",
@@ -7919,7 +8280,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 362,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 84
   },
   {
     "name": "University of Texas at Dallas",
@@ -7941,7 +8303,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 363,
-    "countryRank": 87
+    "countryRank": 87,
+    "countryTotal": 220
   },
   {
     "name": "University of Central Florida",
@@ -7963,7 +8326,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 364,
-    "countryRank": 88
+    "countryRank": 88,
+    "countryTotal": 220
   },
   {
     "name": "Korea Advanced Institute of Science & Technology (KAIST)",
@@ -7982,7 +8346,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 365,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 37
   },
   {
     "name": "Catholic University of Louvain",
@@ -8001,7 +8366,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 366,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 14
   },
   {
     "name": "Universite Libre de Bruxelles",
@@ -8020,7 +8386,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 367,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 14
   },
   {
     "name": "Nanjing University of Science & Technology",
@@ -8042,7 +8409,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 368,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 224
   },
   {
     "name": "Princess Nourah bint Abdulrahman University",
@@ -8064,7 +8432,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 369,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 25
   },
   {
     "name": "Technical University of Dresden",
@@ -8083,7 +8452,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 370,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 84
   },
   {
     "name": "Medical University of Vienna",
@@ -8102,7 +8472,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 371,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 13
   },
   {
     "name": "University of Guelph",
@@ -8124,7 +8495,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 372,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 35
   },
   {
     "name": "University of Munster",
@@ -8143,7 +8515,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 373,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 84
   },
   {
     "name": "University of Bayreuth",
@@ -8165,7 +8538,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 374,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 84
   },
   {
     "name": "University of Wurzburg",
@@ -8184,7 +8558,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 375,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 84
   },
   {
     "name": "Nanjing University of Aeronautics & Astronautics",
@@ -8206,7 +8581,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 376,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 224
   },
   {
     "name": "Tilburg University",
@@ -8228,7 +8604,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 377,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 14
   },
   {
     "name": "University of Nebraska Lincoln",
@@ -8250,7 +8627,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 378,
-    "countryRank": 89
+    "countryRank": 89,
+    "countryTotal": 220
   },
   {
     "name": "East China University of Science & Technology",
@@ -8272,7 +8650,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 379,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 224
   },
   {
     "name": "University of the Basque Country",
@@ -8294,7 +8673,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 380,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 53
   },
   {
     "name": "Universiti Putra Malaysia",
@@ -8316,7 +8696,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 381,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 26
   },
   {
     "name": "Virginia Commonwealth University",
@@ -8338,7 +8719,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 382,
-    "countryRank": 90
+    "countryRank": 90,
+    "countryTotal": 220
   },
   {
     "name": "Masaryk University",
@@ -8360,7 +8742,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 383,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 8
   },
   {
     "name": "University of Aveiro",
@@ -8382,7 +8765,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 384,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 9
   },
   {
     "name": "University of Frankfurt am Main",
@@ -8401,7 +8785,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 385,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 84
   },
   {
     "name": "RMIT University",
@@ -8420,7 +8805,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 386,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 41
   },
   {
     "name": "Moscow Institute of Physics & Technology",
@@ -8442,7 +8828,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 387,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 27
   },
   {
     "name": "Vienna University of Technology",
@@ -8461,7 +8848,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 388,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 13
   },
   {
     "name": "Verona University",
@@ -8483,7 +8871,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 389,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 61
   },
   {
     "name": "George Mason University",
@@ -8505,7 +8894,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 390,
-    "countryRank": 91
+    "countryRank": 91,
+    "countryTotal": 220
   },
   {
     "name": "University of Oregon",
@@ -8527,7 +8917,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 391,
-    "countryRank": 92
+    "countryRank": 92,
+    "countryTotal": 220
   },
   {
     "name": "University of Erlangen Nuremberg",
@@ -8546,7 +8937,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 392,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 84
   },
   {
     "name": "Universidade Estadual Paulista",
@@ -8568,7 +8960,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 393,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 26
   },
   {
     "name": "Norwegian University of Science & Technology (NTNU)",
@@ -8587,7 +8980,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 394,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 8
   },
   {
     "name": "University of Brescia",
@@ -8609,7 +9003,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 395,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 61
   },
   {
     "name": "Pusan National University",
@@ -8631,7 +9026,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 396,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 37
   },
   {
     "name": "University of Kwazulu Natal",
@@ -8653,7 +9049,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 397,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 9
   },
   {
     "name": "Florida International University",
@@ -8675,7 +9072,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 398,
-    "countryRank": 93
+    "countryRank": 93,
+    "countryTotal": 220
   },
   {
     "name": "Sharif University of Technology",
@@ -8697,7 +9095,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 399,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 37
   },
   {
     "name": "Universidade Nova de Lisboa",
@@ -8719,7 +9118,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 400,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 9
   },
   {
     "name": "University of Regensburg",
@@ -8741,7 +9141,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 401,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 84
   },
   {
     "name": "Edith Cowan University",
@@ -8763,7 +9164,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 402,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 41
   },
   {
     "name": "University of Mannheim",
@@ -8785,7 +9187,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 403,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 84
   },
   {
     "name": "University of Buenos Aires",
@@ -8804,7 +9207,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 404,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 8
   },
   {
     "name": "University of Waikato",
@@ -8826,7 +9230,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 405,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 8
   },
   {
     "name": "Drexel University",
@@ -8848,7 +9253,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 406,
-    "countryRank": 94
+    "countryRank": 94,
+    "countryTotal": 220
   },
   {
     "name": "Brandeis University",
@@ -8870,7 +9276,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 407,
-    "countryRank": 95
+    "countryRank": 95,
+    "countryTotal": 220
   },
   {
     "name": "Hiroshima University",
@@ -8892,7 +9299,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 408,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 36
   },
   {
     "name": "Oregon Health and Science University",
@@ -8911,7 +9319,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 409,
-    "countryRank": 96
+    "countryRank": 96,
+    "countryTotal": 220
   },
   {
     "name": "Rutgers University New Brunswick",
@@ -8933,7 +9342,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 410,
-    "countryRank": 97
+    "countryRank": 97,
+    "countryTotal": 220
   },
   {
     "name": "Jiangnan University",
@@ -8955,7 +9365,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 411,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 224
   },
   {
     "name": "University of Eastern Finland",
@@ -8977,7 +9388,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 412,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 10
   },
   {
     "name": "Mahidol University",
@@ -8999,7 +9411,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 413,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 8
   },
   {
     "name": "University of Jyvaskyla",
@@ -9021,7 +9434,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 414,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 10
   },
   {
     "name": "Aix-Marseille Universite",
@@ -9040,7 +9454,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 415,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 60
   },
   {
     "name": "Ocean University of China",
@@ -9062,7 +9477,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 416,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 224
   },
   {
     "name": "University of Bochum",
@@ -9081,7 +9497,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 417,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 84
   },
   {
     "name": "Kyungpook National University (KNU)",
@@ -9103,7 +9520,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 418,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 37
   },
   {
     "name": "University of Sevilla",
@@ -9125,7 +9543,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 419,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 53
   },
   {
     "name": "Wake Forest University",
@@ -9147,7 +9566,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 420,
-    "countryRank": 98
+    "countryRank": 98,
+    "countryTotal": 220
   },
   {
     "name": "Massey University",
@@ -9169,7 +9589,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 421,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 8
   },
   {
     "name": "Aristotle University of Thessaloniki",
@@ -9191,7 +9612,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 422,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 7
   },
   {
     "name": "Australian Catholic University",
@@ -9213,7 +9635,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 423,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 41
   },
   {
     "name": "University of Fribourg",
@@ -9235,7 +9658,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 424,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 13
   },
   {
     "name": "University of Newcastle - Australia",
@@ -9254,7 +9678,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 425,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 41
   },
   {
     "name": "University of Iceland",
@@ -9276,7 +9701,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 426,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Jilin University",
@@ -9295,7 +9721,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 427,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 224
   },
   {
     "name": "University of Mainz",
@@ -9314,7 +9741,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 428,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 84
   },
   {
     "name": "Louisiana State University",
@@ -9336,7 +9764,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 429,
-    "countryRank": 99
+    "countryRank": 99,
+    "countryTotal": 220
   },
   {
     "name": "University of Santiago de Compostela",
@@ -9358,7 +9787,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 430,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 53
   },
   {
     "name": "Indian Institute of Science",
@@ -9377,7 +9807,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 431,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 63
   },
   {
     "name": "Waseda University",
@@ -9399,7 +9830,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 432,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 36
   },
   {
     "name": "Istanbul Technical University",
@@ -9421,7 +9853,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 433,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 21
   },
   {
     "name": "Kobe University",
@@ -9443,7 +9876,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 434,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 36
   },
   {
     "name": "Khalifa University",
@@ -9462,7 +9896,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 435,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 13
   },
   {
     "name": "COMSATS University Islamabad (CUI)",
@@ -9484,7 +9919,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 436,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 29
   },
   {
     "name": "Ain Shams University",
@@ -9506,7 +9942,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 437,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 10
   },
   {
     "name": "University of Montpellier",
@@ -9525,7 +9962,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 438,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 60
   },
   {
     "name": "University of Siena",
@@ -9547,7 +9985,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 439,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 61
   },
   {
     "name": "University of Minho",
@@ -9569,7 +10008,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 440,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 9
   },
   {
     "name": "Prince Sattam Bin Abdulaziz University",
@@ -9591,7 +10031,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 441,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 25
   },
   {
     "name": "University of Trieste",
@@ -9613,7 +10054,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 442,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 61
   },
   {
     "name": "Zhengzhou University",
@@ -9632,7 +10074,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 443,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 224
   },
   {
     "name": "Medical University of Graz",
@@ -9651,7 +10094,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 444,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 13
   },
   {
     "name": "Heriot-Watt University",
@@ -9673,7 +10117,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 445,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 102
   },
   {
     "name": "Colorado School of Mines",
@@ -9695,7 +10140,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 446,
-    "countryRank": 100
+    "countryRank": 100,
+    "countryTotal": 220
   },
   {
     "name": "Catania University",
@@ -9717,7 +10163,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 447,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 61
   },
   {
     "name": "National Taiwan University of Science and Technology",
@@ -9739,7 +10186,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 448,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 18
   },
   {
     "name": "University of Ljubljana",
@@ -9761,7 +10209,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 449,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 3
   },
   {
     "name": "Southern Medical University China",
@@ -9780,7 +10229,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 450,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 224
   },
   {
     "name": "Wayne State University",
@@ -9802,7 +10252,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 451,
-    "countryRank": 101
+    "countryRank": 101,
+    "countryTotal": 220
   },
   {
     "name": "China Medical University (Taiwan)",
@@ -9821,7 +10272,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 452,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 18
   },
   {
     "name": "University of Delhi",
@@ -9843,7 +10295,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 453,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 63
   },
   {
     "name": "Leipzig University",
@@ -9862,7 +10315,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 454,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 84
   },
   {
     "name": "University of Science & Technology Beijing",
@@ -9881,7 +10335,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 455,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 224
   },
   {
     "name": "Catholic University of the Sacred Heart",
@@ -9900,7 +10355,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 456,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 61
   },
   {
     "name": "Medical University of Innsbruck",
@@ -9919,7 +10375,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 457,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 13
   },
   {
     "name": "University of Liege",
@@ -9938,7 +10395,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 458,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 14
   },
   {
     "name": "University of Cyprus",
@@ -9960,7 +10418,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 459,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 7
   },
   {
     "name": "Northumbria University at Newcastle",
@@ -9982,7 +10441,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 460,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 102
   },
   {
     "name": "Carleton University",
@@ -10004,7 +10464,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 461,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 35
   },
   {
     "name": "University of Bordeaux",
@@ -10023,7 +10484,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 462,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 60
   },
   {
     "name": "Syracuse University",
@@ -10045,7 +10507,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 463,
-    "countryRank": 102
+    "countryRank": 102,
+    "countryTotal": 220
   },
   {
     "name": "National University of Malaysia",
@@ -10064,7 +10527,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 464,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 26
   },
   {
     "name": "National University of Ireland - Galway",
@@ -10083,7 +10547,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 465,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 9
   },
   {
     "name": "Alexandria University",
@@ -10105,7 +10570,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 466,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 10
   },
   {
     "name": "Umm Al Qura University",
@@ -10127,7 +10593,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 467,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 25
   },
   {
     "name": "Northeastern University - China",
@@ -10146,7 +10613,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 468,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 224
   },
   {
     "name": "Georgia State University",
@@ -10168,7 +10636,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 469,
-    "countryRank": 103
+    "countryRank": 103,
+    "countryTotal": 220
   },
   {
     "name": "National Cheng Kung University",
@@ -10190,7 +10659,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 470,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 18
   },
   {
     "name": "University of Hannover",
@@ -10209,7 +10679,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 471,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 84
   },
   {
     "name": "Quaid I Azam University",
@@ -10228,7 +10699,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 472,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 29
   },
   {
     "name": "University of Plymouth",
@@ -10250,7 +10722,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 473,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 102
   },
   {
     "name": "Ewha Womans University",
@@ -10272,7 +10745,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 474,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 37
   },
   {
     "name": "University of Graz",
@@ -10294,7 +10768,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 475,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 13
   },
   {
     "name": "Liverpool John Moores University",
@@ -10316,7 +10791,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 476,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 102
   },
   {
     "name": "University of Kent at Canterbury",
@@ -10335,7 +10811,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 477,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 102
   },
   {
     "name": "University of Stirling",
@@ -10357,7 +10834,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 478,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 102
   },
   {
     "name": "University of Portsmouth",
@@ -10379,7 +10857,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 479,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 102
   },
   {
     "name": "Universite Toulouse III - Paul Sabatier",
@@ -10398,7 +10877,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 480,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 60
   },
   {
     "name": "University of Haifa",
@@ -10420,7 +10900,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 481,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 8
   },
   {
     "name": "Manchester Metropolitan University",
@@ -10442,7 +10923,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 482,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 102
   },
   {
     "name": "University of Salerno",
@@ -10464,7 +10946,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 483,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 61
   },
   {
     "name": "Scuola Normale Superiore di Pisa",
@@ -10483,7 +10966,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 484,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 61
   },
   {
     "name": "University of Science - Malaysia",
@@ -10502,7 +10986,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 485,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 26
   },
   {
     "name": "Middle East Technical University",
@@ -10521,7 +11006,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 486,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 21
   },
   {
     "name": "Polytechnic University of Turin",
@@ -10540,7 +11026,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 487,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 61
   },
   {
     "name": "Oregon State University",
@@ -10559,7 +11046,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 488,
-    "countryRank": 104
+    "countryRank": 104,
+    "countryTotal": 220
   },
   {
     "name": "Swedish University of Agricultural Sciences",
@@ -10578,7 +11066,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 489,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 18
   },
   {
     "name": "University of Coimbra",
@@ -10597,7 +11086,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 490,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 9
   },
   {
     "name": "University of Cincinnati",
@@ -10616,7 +11106,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 491,
-    "countryRank": 105
+    "countryRank": 105,
+    "countryTotal": 220
   },
   {
     "name": "Nottingham Trent University",
@@ -10638,7 +11129,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 492,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 102
   },
   {
     "name": "Taif University",
@@ -10660,7 +11152,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 493,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 25
   },
   {
     "name": "Marche Polytechnic University",
@@ -10682,7 +11175,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 494,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 61
   },
   {
     "name": "Ecole Normale Superieure de Lyon (ENS de LYON)",
@@ -10701,7 +11195,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 495,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 60
   },
   {
     "name": "University of Hull",
@@ -10723,7 +11218,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 496,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 102
   },
   {
     "name": "Bogazici University",
@@ -10742,7 +11238,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 497,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 21
   },
   {
     "name": "Memorial University Newfoundland",
@@ -10764,7 +11261,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 498,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 35
   },
   {
     "name": "Renmin University of China",
@@ -10783,7 +11281,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 499,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 224
   },
   {
     "name": "Bar Ilan University",
@@ -10805,7 +11304,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 500,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 8
   },
   {
     "name": "China University of Geosciences",
@@ -10824,7 +11324,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 501,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 224
   },
   {
     "name": "Ulsan University",
@@ -10846,7 +11347,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 502,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 37
   },
   {
     "name": "University of Athens",
@@ -10865,7 +11367,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 503,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 7
   },
   {
     "name": "Jiangsu University",
@@ -10884,7 +11387,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 504,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 224
   },
   {
     "name": "Qingdao University",
@@ -10903,7 +11407,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 505,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 224
   },
   {
     "name": "Royal Holloway, University of London",
@@ -10925,7 +11430,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 506,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 102
   },
   {
     "name": "Auburn University",
@@ -10947,7 +11453,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 507,
-    "countryRank": 106
+    "countryRank": 106,
+    "countryTotal": 220
   },
   {
     "name": "Sunway University",
@@ -10966,7 +11473,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 508,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 26
   },
   {
     "name": "University of Lugano",
@@ -10985,7 +11493,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 509,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 13
   },
   {
     "name": "York University",
@@ -11004,7 +11513,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 510,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 35
   },
   {
     "name": "University of Ferrara",
@@ -11026,7 +11536,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 511,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 61
   },
   {
     "name": "University of Palermo",
@@ -11048,7 +11559,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 512,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 61
   },
   {
     "name": "Jinan University - Guangdong",
@@ -11067,7 +11579,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 513,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 224
   },
   {
     "name": "Zhejiang University of Technology",
@@ -11086,7 +11599,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 514,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 224
   },
   {
     "name": "University of Giessen",
@@ -11105,7 +11619,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 515,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 84
   },
   {
     "name": "University of Salamanca",
@@ -11127,7 +11642,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 516,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 53
   },
   {
     "name": "Prince Sultan University",
@@ -11146,7 +11662,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 517,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 25
   },
   {
     "name": "King Faisal University",
@@ -11168,7 +11685,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 518,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 25
   },
   {
     "name": "Humanitas University",
@@ -11187,7 +11705,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 519,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 61
   },
   {
     "name": "China Agricultural University",
@@ -11206,7 +11725,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 520,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 224
   },
   {
     "name": "Xidian University",
@@ -11225,7 +11745,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 521,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 224
   },
   {
     "name": "Nanjing Normal University",
@@ -11247,7 +11768,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 522,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 224
   },
   {
     "name": "University of Messina",
@@ -11269,7 +11791,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 523,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 61
   },
   {
     "name": "Brunel University",
@@ -11288,7 +11811,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 524,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 102
   },
   {
     "name": "Lebanese American University",
@@ -11307,7 +11831,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 525,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 6
   },
   {
     "name": "University Claude Bernard - Lyon I",
@@ -11326,7 +11851,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 526,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 60
   },
   {
     "name": "Lappeenranta University of Technology",
@@ -11345,7 +11871,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 527,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 10
   },
   {
     "name": "Duy Tan University",
@@ -11364,7 +11891,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 528,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 6
   },
   {
     "name": "Guangdong University of Technology",
@@ -11383,7 +11911,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 529,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 224
   },
   {
     "name": "University of Missouri - Columbia",
@@ -11402,7 +11931,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 530,
-    "countryRank": 107
+    "countryRank": 107,
+    "countryTotal": 220
   },
   {
     "name": "Soochow University",
@@ -11421,7 +11951,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 531,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 224
   },
   {
     "name": "University of California San Francisco",
@@ -11437,7 +11968,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 532,
-    "countryRank": 108
+    "countryRank": 108,
+    "countryTotal": 220
   },
   {
     "name": "Aston University",
@@ -11456,7 +11988,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 533,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 102
   },
   {
     "name": "Federal University of Rio de Janeiro",
@@ -11475,7 +12008,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 534,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 26
   },
   {
     "name": "Polytechnic University of Valencia",
@@ -11494,7 +12028,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 535,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 53
   },
   {
     "name": "Wuhan University of Technology",
@@ -11513,7 +12048,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 536,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 224
   },
   {
     "name": "University of Crete",
@@ -11535,7 +12071,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 537,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 7
   },
   {
     "name": "Semmelweis University",
@@ -11554,7 +12091,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 538,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 9
   },
   {
     "name": "Sultan Qaboos University",
@@ -11573,7 +12111,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 539,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "Indian Institute of Technology (IIT) - Delhi",
@@ -11592,7 +12131,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 540,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 63
   },
   {
     "name": "Huazhong Agricultural University",
@@ -11611,7 +12151,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 541,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 224
   },
   {
     "name": "Lanzhou University",
@@ -11630,7 +12171,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 542,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 224
   },
   {
     "name": "University of Marburg",
@@ -11649,7 +12191,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 543,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 84
   },
   {
     "name": "Nanjing Agricultural University",
@@ -11668,7 +12211,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 544,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 224
   },
   {
     "name": "Hacettepe University",
@@ -11690,7 +12234,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 545,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 21
   },
   {
     "name": "Rockefeller University",
@@ -11706,7 +12251,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 546,
-    "countryRank": 109
+    "countryRank": 109,
+    "countryTotal": 220
   },
   {
     "name": "Sabanci University",
@@ -11725,7 +12271,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 547,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 21
   },
   {
     "name": "Icahn School of Medicine at Mount Sinai",
@@ -11741,7 +12288,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 548,
-    "countryRank": 110
+    "countryRank": 110,
+    "countryTotal": 220
   },
   {
     "name": "Nanjing Forestry University",
@@ -11760,7 +12308,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 549,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 224
   },
   {
     "name": "Yeungnam University",
@@ -11782,7 +12331,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 550,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 37
   },
   {
     "name": "University of Texas Southwestern Medical Center Dallas",
@@ -11798,7 +12348,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 551,
-    "countryRank": 111
+    "countryRank": 111,
+    "countryTotal": 220
   },
   {
     "name": "University Hohenheim",
@@ -11820,7 +12371,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 552,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 84
   },
   {
     "name": "Rush University",
@@ -11839,7 +12391,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 553,
-    "countryRank": 112
+    "countryRank": 112,
+    "countryTotal": 220
   },
   {
     "name": "Nanjing University of Information Science & Technology",
@@ -11858,7 +12411,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 554,
-    "countryRank": 61
+    "countryRank": 61,
+    "countryTotal": 224
   },
   {
     "name": "Saarland University",
@@ -11877,7 +12431,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 555,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 84
   },
   {
     "name": "Beijing University of Technology",
@@ -11896,7 +12451,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 556,
-    "countryRank": 62
+    "countryRank": 62,
+    "countryTotal": 224
   },
   {
     "name": "National Sun Yat-Sen University",
@@ -11915,7 +12471,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 557,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 18
   },
   {
     "name": "Amirkabir University of Technology",
@@ -11934,7 +12491,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 558,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 37
   },
   {
     "name": "Indian Institute of Technology (IIT) - Madras",
@@ -11953,7 +12511,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 559,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 63
   },
   {
     "name": "Weizmann Institute of Science",
@@ -11969,7 +12528,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 560,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 8
   },
   {
     "name": "Kansas State University",
@@ -11991,7 +12551,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 561,
-    "countryRank": 113
+    "countryRank": 113,
+    "countryTotal": 220
   },
   {
     "name": "University of Punjab",
@@ -12013,7 +12574,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 562,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 29
   },
   {
     "name": "Ural Federal University",
@@ -12035,7 +12597,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 563,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 27
   },
   {
     "name": "Bangor University",
@@ -12054,7 +12617,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 564,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 102
   },
   {
     "name": "Prince Mohammad Bin Fahd University",
@@ -12073,7 +12637,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 565,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 25
   },
   {
     "name": "University of Tübingen",
@@ -12089,7 +12654,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 566,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 84
   },
   {
     "name": "Imam Abdulrahman Bin Faisal University",
@@ -12108,7 +12674,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 567,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 25
   },
   {
     "name": "Chung-Ang University",
@@ -12127,7 +12694,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 568,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 37
   },
   {
     "name": "Zhejiang Normal University",
@@ -12146,7 +12714,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 569,
-    "countryRank": 63
+    "countryRank": 63,
+    "countryTotal": 224
   },
   {
     "name": "Dublin City University",
@@ -12165,7 +12734,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 570,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 9
   },
   {
     "name": "Saint Petersburg State University",
@@ -12184,7 +12754,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 571,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 27
   },
   {
     "name": "University of Limerick",
@@ -12203,7 +12774,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 572,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 9
   },
   {
     "name": "Donghua University - Shanghai",
@@ -12222,7 +12794,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 573,
-    "countryRank": 64
+    "countryRank": 64,
+    "countryTotal": 224
   },
   {
     "name": "Free University of Bozen-Bolzano",
@@ -12244,7 +12817,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 574,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 61
   },
   {
     "name": "University of Oklahoma",
@@ -12263,7 +12837,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 575,
-    "countryRank": 114
+    "countryRank": 114,
+    "countryTotal": 220
   },
   {
     "name": "China University of Mining & Technology",
@@ -12282,7 +12857,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 576,
-    "countryRank": 65
+    "countryRank": 65,
+    "countryTotal": 224
   },
   {
     "name": "Graz University of Technology",
@@ -12301,7 +12877,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 577,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 13
   },
   {
     "name": "Southwest Jiaotong University",
@@ -12320,7 +12897,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 578,
-    "countryRank": 66
+    "countryRank": 66,
+    "countryTotal": 224
   },
   {
     "name": "University of Belgrade",
@@ -12339,7 +12917,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 579,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "King Abdullah University of Science & Technology",
@@ -12355,7 +12934,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 580,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 25
   },
   {
     "name": "London School of Hygiene & Tropical Medicine",
@@ -12371,7 +12951,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 581,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 102
   },
   {
     "name": "University of Lille",
@@ -12390,7 +12971,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 582,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 60
   },
   {
     "name": "Göteborg University",
@@ -12406,7 +12988,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 583,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 18
   },
   {
     "name": "Baylor College of Medicine",
@@ -12422,7 +13005,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 584,
-    "countryRank": 115
+    "countryRank": 115,
+    "countryTotal": 220
   },
   {
     "name": "Concordia University",
@@ -12441,7 +13025,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 585,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 35
   },
   {
     "name": "Ulster University",
@@ -12463,7 +13048,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 586,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 102
   },
   {
     "name": "Nanjing Medical University",
@@ -12482,7 +13068,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 587,
-    "countryRank": 67
+    "countryRank": 67,
+    "countryTotal": 224
   },
   {
     "name": "University of Linz",
@@ -12501,7 +13088,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 588,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 13
   },
   {
     "name": "Czech University of Life Sciences Prague",
@@ -12523,7 +13111,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 589,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 8
   },
   {
     "name": "Jordan University",
@@ -12542,7 +13131,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 590,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 11
   },
   {
     "name": "Hasselt University",
@@ -12561,7 +13151,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 591,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 14
   },
   {
     "name": "University of California Merced",
@@ -12580,7 +13171,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 592,
-    "countryRank": 116
+    "countryRank": 116,
+    "countryTotal": 220
   },
   {
     "name": "China University of Petroleum (Beijing)",
@@ -12599,7 +13191,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 593,
-    "countryRank": 68
+    "countryRank": 68,
+    "countryTotal": 224
   },
   {
     "name": "Ton Duc Thang University",
@@ -12618,7 +13211,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 594,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 6
   },
   {
     "name": "Indian Institute of Technology (IIT) - Kanpur",
@@ -12637,7 +13231,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 595,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 63
   },
   {
     "name": "Polytechnic University of Catalonia",
@@ -12656,7 +13251,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 596,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 53
   },
   {
     "name": "Illinois Institute of Technology",
@@ -12675,7 +13271,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 597,
-    "countryRank": 117
+    "countryRank": 117,
+    "countryTotal": 220
   },
   {
     "name": "New Jersey Institute of Technology",
@@ -12697,7 +13294,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 598,
-    "countryRank": 118
+    "countryRank": 118,
+    "countryTotal": 220
   },
   {
     "name": "University of Rennes I",
@@ -12716,7 +13314,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 599,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 60
   },
   {
     "name": "University of New Mexico",
@@ -12735,7 +13334,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 600,
-    "countryRank": 119
+    "countryRank": 119,
+    "countryTotal": 220
   },
   {
     "name": "University of Maryland Baltimore",
@@ -12757,7 +13357,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 601,
-    "countryRank": 120
+    "countryRank": 120,
+    "countryTotal": 220
   },
   {
     "name": "Mansoura University",
@@ -12776,7 +13377,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 602,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 10
   },
   {
     "name": "University of Chinese Academy of Sciences, CAS",
@@ -12792,7 +13394,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 603,
-    "countryRank": 69
+    "countryRank": 69,
+    "countryTotal": 224
   },
   {
     "name": "Higher School of Economics",
@@ -12811,7 +13414,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 604,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 27
   },
   {
     "name": "University of Parma",
@@ -12830,7 +13434,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 605,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 61
   },
   {
     "name": "University of Technology - Petronas",
@@ -12846,7 +13451,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 606,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 26
   },
   {
     "name": "University of Düsseldorf",
@@ -12862,7 +13468,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 607,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 84
   },
   {
     "name": "Vilnius University",
@@ -12881,7 +13488,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 608,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "Central Queensland University",
@@ -12900,7 +13508,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 609,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 41
   },
   {
     "name": "University of Canberra",
@@ -12919,7 +13528,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 610,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 41
   },
   {
     "name": "Yangzhou University",
@@ -12938,7 +13548,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 611,
-    "countryRank": 70
+    "countryRank": 70,
+    "countryTotal": 224
   },
   {
     "name": "Technical University of Dortmund",
@@ -12957,7 +13568,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 612,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 84
   },
   {
     "name": "University of Alabama Birmingham",
@@ -12973,7 +13585,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 613,
-    "countryRank": 121
+    "countryRank": 121,
+    "countryTotal": 220
   },
   {
     "name": "National Technical University of Athens",
@@ -12992,7 +13605,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 614,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 7
   },
   {
     "name": "University of Tabriz",
@@ -13011,7 +13625,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 615,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 37
   },
   {
     "name": "Rensselaer Polytechnic Institute",
@@ -13030,7 +13645,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 616,
-    "countryRank": 122
+    "countryRank": 122,
+    "countryTotal": 220
   },
   {
     "name": "Taipei Medical University",
@@ -13049,7 +13665,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 617,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 18
   },
   {
     "name": "Indian Institute of Technology (IIT) - Kharagpur",
@@ -13068,7 +13685,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 618,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 63
   },
   {
     "name": "University of Bari",
@@ -13087,7 +13705,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 619,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 61
   },
   {
     "name": "Charles Darwin University",
@@ -13106,7 +13725,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 620,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 41
   },
   {
     "name": "University of Strasbourg",
@@ -13122,7 +13742,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 621,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 60
   },
   {
     "name": "Al Azhar University",
@@ -13141,7 +13762,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 622,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 10
   },
   {
     "name": "Eotvos Lorand University",
@@ -13160,7 +13782,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 623,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 9
   },
   {
     "name": "Harbin Engineering University",
@@ -13179,7 +13802,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 624,
-    "countryRank": 71
+    "countryRank": 71,
+    "countryTotal": 224
   },
   {
     "name": "Vellore Institute of Technology (include only VIT Vellore and VIT Chennai campuses)",
@@ -13198,7 +13822,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 625,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 63
   },
   {
     "name": "University of Texas Health Science Center Houston",
@@ -13214,7 +13839,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 626,
-    "countryRank": 123
+    "countryRank": 123,
+    "countryTotal": 220
   },
   {
     "name": "University of Lahore",
@@ -13236,7 +13862,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 627,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 29
   },
   {
     "name": "University of New Brunswick",
@@ -13258,7 +13885,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 628,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 35
   },
   {
     "name": "University of Ulsan",
@@ -13274,7 +13902,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 629,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 84
   },
   {
     "name": "Texas Technical University",
@@ -13293,7 +13922,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 630,
-    "countryRank": 124
+    "countryRank": 124,
+    "countryTotal": 220
   },
   {
     "name": "University of Technology - Malaysia",
@@ -13309,7 +13939,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 631,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 26
   },
   {
     "name": "University of Szeged",
@@ -13328,7 +13959,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 632,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 9
   },
   {
     "name": "Asia University",
@@ -13347,7 +13979,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 633,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 18
   },
   {
     "name": "University of Alabama",
@@ -13369,7 +14002,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 634,
-    "countryRank": 125
+    "countryRank": 125,
+    "countryTotal": 220
   },
   {
     "name": "Saveetha Institute of Medical and Technical Sciences",
@@ -13388,7 +14022,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 635,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 63
   },
   {
     "name": "St. Louis University",
@@ -13407,7 +14042,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 636,
-    "countryRank": 126
+    "countryRank": 126,
+    "countryTotal": 220
   },
   {
     "name": "South China Normal University",
@@ -13426,7 +14062,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 637,
-    "countryRank": 72
+    "countryRank": 72,
+    "countryTotal": 224
   },
   {
     "name": "Baylor University",
@@ -13445,7 +14082,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 638,
-    "countryRank": 127
+    "countryRank": 127,
+    "countryTotal": 220
   },
   {
     "name": "Perugia University",
@@ -13464,7 +14102,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 639,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 61
   },
   {
     "name": "Ajou University",
@@ -13483,7 +14122,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 640,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 37
   },
   {
     "name": "Iran University of Medical Sciences",
@@ -13502,7 +14142,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 641,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 37
   },
   {
     "name": "Abu Dhabi University",
@@ -13518,7 +14159,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 642,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 13
   },
   {
     "name": "Chang Gung University",
@@ -13537,7 +14179,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 643,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 18
   },
   {
     "name": "University of Nevada Las Vegas",
@@ -13556,7 +14199,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 644,
-    "countryRank": 128
+    "countryRank": 128,
+    "countryTotal": 220
   },
   {
     "name": "Bilkent University",
@@ -13575,7 +14219,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 645,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 21
   },
   {
     "name": "University of Zagreb",
@@ -13594,7 +14239,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 646,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "National Taiwan Normal University",
@@ -13613,7 +14259,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 647,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 18
   },
   {
     "name": "University of Indonesia",
@@ -13632,7 +14279,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 648,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 11
   },
   {
     "name": "Bauman Moscow State Technical University",
@@ -13648,7 +14296,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 649,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 27
   },
   {
     "name": "Federal University of Rio Grande do Sul",
@@ -13667,7 +14316,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 650,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 26
   },
   {
     "name": "Federal University of Minas Gerais",
@@ -13686,7 +14336,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 651,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 26
   },
   {
     "name": "Westlake University",
@@ -13702,7 +14353,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 652,
-    "countryRank": 73
+    "countryRank": 73,
+    "countryTotal": 224
   },
   {
     "name": "Lingnan University",
@@ -13721,7 +14373,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 653,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 9
   },
   {
     "name": "Auckland University of Technology",
@@ -13740,7 +14393,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 654,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 8
   },
   {
     "name": "Peking Union Medical College",
@@ -13756,7 +14410,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 655,
-    "countryRank": 74
+    "countryRank": 74,
+    "countryTotal": 224
   },
   {
     "name": "Technical University of Braunschweig",
@@ -13775,7 +14430,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 656,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 84
   },
   {
     "name": "Qassim University",
@@ -13797,7 +14453,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 657,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 25
   },
   {
     "name": "University of Calabria",
@@ -13819,7 +14476,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 658,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 61
   },
   {
     "name": "Beijing Jiaotong University",
@@ -13838,7 +14496,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 659,
-    "countryRank": 75
+    "countryRank": 75,
+    "countryTotal": 224
   },
   {
     "name": "The American University in Cairo",
@@ -13857,7 +14516,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 660,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 10
   },
   {
     "name": "ShanghaiTech University",
@@ -13873,7 +14533,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 661,
-    "countryRank": 76
+    "countryRank": 76,
+    "countryTotal": 224
   },
   {
     "name": "Wenzhou University",
@@ -13892,7 +14553,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 662,
-    "countryRank": 77
+    "countryRank": 77,
+    "countryTotal": 224
   },
   {
     "name": "University of Chile",
@@ -13908,7 +14570,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 663,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 7
   },
   {
     "name": "University of Windsor",
@@ -13927,7 +14590,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 664,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 35
   },
   {
     "name": "University of Texas at San Antonio (UTSA)",
@@ -13946,7 +14610,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 665,
-    "countryRank": 129
+    "countryRank": 129,
+    "countryTotal": 220
   },
   {
     "name": "University of Zaragoza",
@@ -13965,7 +14630,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 666,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 53
   },
   {
     "name": "University of Nantes",
@@ -13984,7 +14650,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 667,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 60
   },
   {
     "name": "Konkuk University",
@@ -14003,7 +14670,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 668,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 37
   },
   {
     "name": "American University",
@@ -14022,7 +14690,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 669,
-    "countryRank": 130
+    "countryRank": 130,
+    "countryTotal": 220
   },
   {
     "name": "Peoples Friendship University of Russia",
@@ -14041,7 +14710,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 670,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 27
   },
   {
     "name": "Istanbul University",
@@ -14060,7 +14730,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 671,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 21
   },
   {
     "name": "Rovira i Virgili University",
@@ -14079,7 +14750,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 672,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 53
   },
   {
     "name": "University of Brunei Darussalam",
@@ -14095,7 +14767,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 673,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Daegu Gyeongbuk Institute of Science and Technology",
@@ -14111,7 +14784,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 674,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 37
   },
   {
     "name": "Education University of Hong Kong (EdUHK)",
@@ -14130,7 +14804,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 675,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 9
   },
   {
     "name": "Missouri University of Science and Technology",
@@ -14149,7 +14824,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 676,
-    "countryRank": 131
+    "countryRank": 131,
+    "countryTotal": 220
   },
   {
     "name": "Tomsk State University",
@@ -14168,7 +14844,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 677,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 27
   },
   {
     "name": "Hamad Bin Khalifa University",
@@ -14184,7 +14861,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 678,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "University of Missouri Kansas City",
@@ -14203,7 +14881,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 679,
-    "countryRank": 132
+    "countryRank": 132,
+    "countryTotal": 220
   },
   {
     "name": "University of Hertfordshire",
@@ -14225,7 +14904,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 680,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 102
   },
   {
     "name": "University of Dhaka",
@@ -14244,7 +14924,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 681,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 6
   },
   {
     "name": "Fuzhou University",
@@ -14263,7 +14944,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 682,
-    "countryRank": 78
+    "countryRank": 78,
+    "countryTotal": 224
   },
   {
     "name": "Bournemouth University",
@@ -14282,7 +14964,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 683,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 102
   },
   {
     "name": "Guangzhou Medical University",
@@ -14301,7 +14984,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 684,
-    "countryRank": 79
+    "countryRank": 79,
+    "countryTotal": 224
   },
   {
     "name": "Gwangju Institute of Science and Technology",
@@ -14317,7 +15001,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 685,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 37
   },
   {
     "name": "Monterrey Institute of Technology and Higher Education",
@@ -14333,7 +15018,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 686,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 9
   },
   {
     "name": "Mississippi State University",
@@ -14352,7 +15038,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 687,
-    "countryRank": 133
+    "countryRank": 133,
+    "countryTotal": 220
   },
   {
     "name": "Indian Institute of Technology (IIT) - Roorkee",
@@ -14371,7 +15058,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 688,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 63
   },
   {
     "name": "Chiang Mai University",
@@ -14390,7 +15078,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 689,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 8
   },
   {
     "name": "Inha University",
@@ -14409,7 +15098,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 690,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 37
   },
   {
     "name": "Symbiosis International University",
@@ -14428,7 +15118,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 691,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 63
   },
   {
     "name": "Capital University of Medical Sciences",
@@ -14444,7 +15135,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 692,
-    "countryRank": 80
+    "countryRank": 80,
+    "countryTotal": 224
   },
   {
     "name": "University of Vigo",
@@ -14466,7 +15158,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 693,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 53
   },
   {
     "name": "Roma Tre University",
@@ -14488,7 +15181,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 694,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 61
   },
   {
     "name": "Jordan University of Science & Technology",
@@ -14507,7 +15201,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 695,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 11
   },
   {
     "name": "Tarbiat Modares University",
@@ -14526,7 +15221,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 696,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 37
   },
   {
     "name": "China University of Petroleum",
@@ -14542,7 +15238,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 697,
-    "countryRank": 81
+    "countryRank": 81,
+    "countryTotal": 224
   },
   {
     "name": "University of Cagliari",
@@ -14561,7 +15258,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 698,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 61
   },
   {
     "name": "Imam Mohammad Ibn Saud Islamic University (IMSIU)",
@@ -14583,7 +15281,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 699,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 25
   },
   {
     "name": "American University of Beirut",
@@ -14599,7 +15298,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 700,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 6
   },
   {
     "name": "Indian Institute of Technology (IIT) - Bombay",
@@ -14615,7 +15315,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 701,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 63
   },
   {
     "name": "Hannover Medical School",
@@ -14631,7 +15332,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 702,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 84
   },
   {
     "name": "National University of Ireland - Maynooth",
@@ -14650,7 +15352,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 703,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 9
   },
   {
     "name": "Ajman University of Science & Technology",
@@ -14666,7 +15369,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 704,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 13
   },
   {
     "name": "Singapore University of Technology & Design",
@@ -14682,7 +15386,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 705,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "University of South Australia",
@@ -14698,7 +15403,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 706,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 41
   },
   {
     "name": "Nanchang University",
@@ -14714,7 +15420,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 707,
-    "countryRank": 82
+    "countryRank": 82,
+    "countryTotal": 224
   },
   {
     "name": "Isfahan University of Technology",
@@ -14733,7 +15440,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 708,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 37
   },
   {
     "name": "Taylor's University",
@@ -14749,7 +15457,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 709,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 26
   },
   {
     "name": "Polytechnic University of Bari",
@@ -14768,7 +15477,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 710,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 61
   },
   {
     "name": "University of Modena",
@@ -14787,7 +15497,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 711,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 61
   },
   {
     "name": "University of Greenwich",
@@ -14806,7 +15517,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 712,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 102
   },
   {
     "name": "University of the Philippines Manila",
@@ -14822,7 +15534,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 713,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "University of International Business & Economics",
@@ -14841,7 +15554,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 714,
-    "countryRank": 83
+    "countryRank": 83,
+    "countryTotal": 224
   },
   {
     "name": "University of Texas Arlington",
@@ -14860,7 +15574,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 715,
-    "countryRank": 134
+    "countryRank": 134,
+    "countryTotal": 220
   },
   {
     "name": "Northeast Normal University",
@@ -14879,7 +15594,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 716,
-    "countryRank": 84
+    "countryRank": 84,
+    "countryTotal": 224
   },
   {
     "name": "University of Texas Health Science Center at San Antonio",
@@ -14895,7 +15611,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 717,
-    "countryRank": 135
+    "countryRank": 135,
+    "countryTotal": 220
   },
   {
     "name": "University of Patras",
@@ -14917,7 +15634,8 @@
     },
     "appearances": 4,
     "aggregatedRank": 718,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 7
   },
   {
     "name": "Southwest University",
@@ -14933,7 +15651,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 719,
-    "countryRank": 85
+    "countryRank": 85,
+    "countryTotal": 224
   },
   {
     "name": "Iran University of Science and Technology",
@@ -14949,7 +15668,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 720,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 37
   },
   {
     "name": "Nanjing University of Technology",
@@ -14965,7 +15685,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 721,
-    "countryRank": 86
+    "countryRank": 86,
+    "countryTotal": 224
   },
   {
     "name": "Shoolini University of Biotechnology and Management Sciences",
@@ -14981,7 +15702,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 722,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 63
   },
   {
     "name": "Lincoln University",
@@ -14997,7 +15719,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 723,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 8
   },
   {
     "name": "Jouf University",
@@ -15016,7 +15739,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 724,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 25
   },
   {
     "name": "School of Oriental and African Studies - University of London",
@@ -15032,7 +15756,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 725,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 102
   },
   {
     "name": "Catholic University of Korea",
@@ -15051,7 +15776,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 726,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 37
   },
   {
     "name": "Keele University",
@@ -15070,7 +15796,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 727,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 102
   },
   {
     "name": "Xi'an Jiaotong-Liverpool University",
@@ -15089,7 +15816,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 728,
-    "countryRank": 87
+    "countryRank": 87,
+    "countryTotal": 224
   },
   {
     "name": "Oklahoma State University",
@@ -15108,7 +15836,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 729,
-    "countryRank": 136
+    "countryRank": 136,
+    "countryTotal": 220
   },
   {
     "name": "Technical University of Madrid",
@@ -15124,7 +15853,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 730,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 53
   },
   {
     "name": "Lehigh University",
@@ -15143,7 +15873,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 731,
-    "countryRank": 137
+    "countryRank": 137,
+    "countryTotal": 220
   },
   {
     "name": "Czech Technical University Prague",
@@ -15162,7 +15893,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 732,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 8
   },
   {
     "name": "University of Lorraine",
@@ -15178,7 +15910,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 733,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 60
   },
   {
     "name": "University of Ulm",
@@ -15194,7 +15927,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 734,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 84
   },
   {
     "name": "University of Jena",
@@ -15213,7 +15947,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 735,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 84
   },
   {
     "name": "Al Ain University",
@@ -15229,7 +15964,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 736,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 13
   },
   {
     "name": "Addis Ababa University",
@@ -15248,7 +15984,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 737,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Yeshiva University",
@@ -15264,7 +16001,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 738,
-    "countryRank": 138
+    "countryRank": 138,
+    "countryTotal": 220
   },
   {
     "name": "Sciences Po - Paris",
@@ -15280,7 +16018,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 739,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 60
   },
   {
     "name": "State University of New York at Albany",
@@ -15299,7 +16038,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 740,
-    "countryRank": 139
+    "countryRank": 139,
+    "countryTotal": 220
   },
   {
     "name": "University of Rostock",
@@ -15318,7 +16058,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 741,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 84
   },
   {
     "name": "Bond University",
@@ -15334,7 +16075,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 742,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 41
   },
   {
     "name": "University of Vermont",
@@ -15350,7 +16092,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 743,
-    "countryRank": 140
+    "countryRank": 140,
+    "countryTotal": 220
   },
   {
     "name": "Medical University of South Carolina",
@@ -15366,7 +16109,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 744,
-    "countryRank": 141
+    "countryRank": 141,
+    "countryTotal": 220
   },
   {
     "name": "Northeast Agricultural University - China",
@@ -15385,7 +16129,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 745,
-    "countryRank": 88
+    "countryRank": 88,
+    "countryTotal": 224
   },
   {
     "name": "Northwest Agriculture and Forestry University",
@@ -15401,7 +16146,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 746,
-    "countryRank": 89
+    "countryRank": 89,
+    "countryTotal": 224
   },
   {
     "name": "University of Côte d'Azur",
@@ -15417,7 +16163,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 747,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 60
   },
   {
     "name": "Rochester Institute of Technology",
@@ -15436,7 +16183,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 748,
-    "countryRank": 142
+    "countryRank": 142,
+    "countryTotal": 220
   },
   {
     "name": "Ankara University",
@@ -15455,7 +16203,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 749,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 21
   },
   {
     "name": "University of Bradford",
@@ -15471,7 +16220,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 750,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 102
   },
   {
     "name": "Jazan University",
@@ -15490,7 +16240,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 751,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 25
   },
   {
     "name": "University of Shanghai for Science & Technology",
@@ -15506,7 +16257,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 752,
-    "countryRank": 90
+    "countryRank": 90,
+    "countryTotal": 224
   },
   {
     "name": "Ohio University",
@@ -15525,7 +16277,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 753,
-    "countryRank": 143
+    "countryRank": 143,
+    "countryTotal": 220
   },
   {
     "name": "University of North Texas Denton",
@@ -15544,7 +16297,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 754,
-    "countryRank": 144
+    "countryRank": 144,
+    "countryTotal": 220
   },
   {
     "name": "Yunnan University",
@@ -15560,7 +16314,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 755,
-    "countryRank": 91
+    "countryRank": 91,
+    "countryTotal": 224
   },
   {
     "name": "University of Huddersfield",
@@ -15576,7 +16331,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 756,
-    "countryRank": 61
+    "countryRank": 61,
+    "countryTotal": 102
   },
   {
     "name": "Clemson University",
@@ -15595,7 +16351,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 757,
-    "countryRank": 145
+    "countryRank": 145,
+    "countryTotal": 220
   },
   {
     "name": "Southern Cross University",
@@ -15611,7 +16368,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 758,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 41
   },
   {
     "name": "Novosibirsk State University",
@@ -15630,7 +16388,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 759,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 27
   },
   {
     "name": "Manipal University",
@@ -15649,7 +16408,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 760,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 63
   },
   {
     "name": "Institut Agro",
@@ -15665,7 +16425,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 761,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 60
   },
   {
     "name": "St George's - University of London",
@@ -15681,7 +16442,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 762,
-    "countryRank": 62
+    "countryRank": 62,
+    "countryTotal": 102
   },
   {
     "name": "Indian Institute of Technology Indore",
@@ -15697,7 +16459,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 763,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 63
   },
   {
     "name": "National University of Colombia",
@@ -15713,7 +16476,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 764,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 9
   },
   {
     "name": "Chiba University",
@@ -15732,7 +16496,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 765,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 36
   },
   {
     "name": "Medical College of Wisconsin",
@@ -15748,7 +16513,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 766,
-    "countryRank": 146
+    "countryRank": 146,
+    "countryTotal": 220
   },
   {
     "name": "Shahid Beheshti University Medical Sciences",
@@ -15767,7 +16533,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 767,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 37
   },
   {
     "name": "University of the Western Cape",
@@ -15786,7 +16553,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 768,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 9
   },
   {
     "name": "Henan University",
@@ -15802,7 +16570,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 769,
-    "countryRank": 92
+    "countryRank": 92,
+    "countryTotal": 224
   },
   {
     "name": "Hainan University",
@@ -15818,7 +16587,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 770,
-    "countryRank": 93
+    "countryRank": 93,
+    "countryTotal": 224
   },
   {
     "name": "Fujian Agriculture & Forestry University",
@@ -15834,7 +16604,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 771,
-    "countryRank": 94
+    "countryRank": 94,
+    "countryTotal": 224
   },
   {
     "name": "Cankaya University",
@@ -15850,7 +16621,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 772,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 21
   },
   {
     "name": "Norwegian University of Life Sciences",
@@ -15869,7 +16641,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 773,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 8
   },
   {
     "name": "University of Wyoming",
@@ -15888,7 +16661,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 774,
-    "countryRank": 147
+    "countryRank": 147,
+    "countryTotal": 220
   },
   {
     "name": "Panjab University",
@@ -15907,7 +16681,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 775,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 63
   },
   {
     "name": "Northern Arizona University",
@@ -15923,7 +16698,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 776,
-    "countryRank": 148
+    "countryRank": 148,
+    "countryTotal": 220
   },
   {
     "name": "Federal University of Sao Paulo",
@@ -15942,7 +16718,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 777,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 26
   },
   {
     "name": "Chonnam National University",
@@ -15961,7 +16738,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 778,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 37
   },
   {
     "name": "Birkbeck College - University of London",
@@ -15977,7 +16755,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 779,
-    "countryRank": 63
+    "countryRank": 63,
+    "countryTotal": 102
   },
   {
     "name": "University of Arkansas at Fayetteville",
@@ -15993,7 +16772,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 780,
-    "countryRank": 149
+    "countryRank": 149,
+    "countryTotal": 220
   },
   {
     "name": "Uit the Arctic University of Norway",
@@ -16009,7 +16789,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 781,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 8
   },
   {
     "name": "City University of New York - City College",
@@ -16025,7 +16806,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 782,
-    "countryRank": 150
+    "countryRank": 150,
+    "countryTotal": 220
   },
   {
     "name": "University of Wuppertal",
@@ -16044,7 +16826,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 783,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 84
   },
   {
     "name": "Edinburgh Napier University",
@@ -16063,7 +16846,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 784,
-    "countryRank": 64
+    "countryRank": 64,
+    "countryTotal": 102
   },
   {
     "name": "Jefferson University",
@@ -16079,7 +16863,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 785,
-    "countryRank": 151
+    "countryRank": 151,
+    "countryTotal": 220
   },
   {
     "name": "Okinawa Institute of Science & Technology Graduate University",
@@ -16095,7 +16880,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 786,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 36
   },
   {
     "name": "Kafrelsheikh University",
@@ -16111,7 +16897,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 787,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 10
   },
   {
     "name": "Singapore Management University",
@@ -16127,7 +16914,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 788,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "University of Petroleum & Energy Studies (UPES)",
@@ -16146,7 +16934,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 789,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 63
   },
   {
     "name": "University of Lagos",
@@ -16162,7 +16951,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 790,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "University of Tenaga Nasional",
@@ -16178,7 +16968,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 791,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 26
   },
   {
     "name": "Royal College of Surgeons",
@@ -16194,7 +16985,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 792,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 9
   },
   {
     "name": "Hangzhou Normal University",
@@ -16210,7 +17002,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 793,
-    "countryRank": 95
+    "countryRank": 95,
+    "countryTotal": 224
   },
   {
     "name": "Peter the Great St. Petersburg Polytechnic University",
@@ -16229,7 +17022,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 794,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 27
   },
   {
     "name": "Coventry University",
@@ -16245,7 +17039,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 795,
-    "countryRank": 65
+    "countryRank": 65,
+    "countryTotal": 102
   },
   {
     "name": "Ca' Foscari University of Venice",
@@ -16261,7 +17056,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 796,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 61
   },
   {
     "name": "University of Nizwa",
@@ -16277,7 +17073,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 797,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "Jamia Millia Islamia University",
@@ -16293,7 +17090,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 798,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 63
   },
   {
     "name": "Al-Ahliyya Amman University",
@@ -16309,7 +17107,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 799,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 11
   },
   {
     "name": "American University of the Middle East",
@@ -16325,7 +17124,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 800,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 3
   },
   {
     "name": "Orebro University",
@@ -16344,7 +17144,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 801,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 18
   },
   {
     "name": "Ege University",
@@ -16363,7 +17164,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 802,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 29
   },
   {
     "name": "UCSI University",
@@ -16379,7 +17181,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 803,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 26
   },
   {
     "name": "Stevens Institute of Technology",
@@ -16395,7 +17198,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 804,
-    "countryRank": 152
+    "countryRank": 152,
+    "countryTotal": 220
   },
   {
     "name": "University of Luebeck",
@@ -16411,7 +17215,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 805,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 84
   },
   {
     "name": "Oxford Brookes University",
@@ -16427,7 +17232,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 806,
-    "countryRank": 66
+    "countryRank": 66,
+    "countryTotal": 102
   },
   {
     "name": "University of Technology Brunei",
@@ -16443,7 +17249,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 807,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "University of Ibadan",
@@ -16459,7 +17266,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 808,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "Cyprus University of Technology",
@@ -16475,7 +17283,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 809,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 7
   },
   {
     "name": "West Virginia University",
@@ -16491,7 +17300,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 810,
-    "countryRank": 153
+    "countryRank": 153,
+    "countryTotal": 220
   },
   {
     "name": "Guangxi University",
@@ -16507,7 +17317,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 811,
-    "countryRank": 96
+    "countryRank": 96,
+    "countryTotal": 224
   },
   {
     "name": "Southwestern University of Finance & Economics - China",
@@ -16523,7 +17334,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 812,
-    "countryRank": 97
+    "countryRank": 97,
+    "countryTotal": 224
   },
   {
     "name": "Applied Science Private University of Jordan",
@@ -16539,7 +17351,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 813,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 11
   },
   {
     "name": "Arak University of Medical Sciences",
@@ -16558,7 +17371,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 814,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 37
   },
   {
     "name": "University of Texas Medical Branch Galveston",
@@ -16574,7 +17388,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 815,
-    "countryRank": 154
+    "countryRank": 154,
+    "countryTotal": 220
   },
   {
     "name": "Management and Science University",
@@ -16590,7 +17405,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 816,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 26
   },
   {
     "name": "Anhui University",
@@ -16606,7 +17422,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 817,
-    "countryRank": 98
+    "countryRank": 98,
+    "countryTotal": 224
   },
   {
     "name": "Gachon University",
@@ -16622,7 +17439,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 818,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 37
   },
   {
     "name": "Binghamton University",
@@ -16638,7 +17456,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 819,
-    "countryRank": 155
+    "countryRank": 155,
+    "countryTotal": 220
   },
   {
     "name": "University of Toledo",
@@ -16654,7 +17473,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 820,
-    "countryRank": 156
+    "countryRank": 156,
+    "countryTotal": 220
   },
   {
     "name": "University of Malaysia - Pahang",
@@ -16670,7 +17490,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 821,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 26
   },
   {
     "name": "University of Rhode Island",
@@ -16689,7 +17510,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 822,
-    "countryRank": 157
+    "countryRank": 157,
+    "countryTotal": 220
   },
   {
     "name": "Goldsmiths College - University of London",
@@ -16705,7 +17527,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 823,
-    "countryRank": 67
+    "countryRank": 67,
+    "countryTotal": 102
   },
   {
     "name": "University of Alaska - Fairbanks",
@@ -16724,7 +17547,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 824,
-    "countryRank": 158
+    "countryRank": 158,
+    "countryTotal": 220
   },
   {
     "name": "North China Electric Power University",
@@ -16740,7 +17564,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 825,
-    "countryRank": 99
+    "countryRank": 99,
+    "countryTotal": 224
   },
   {
     "name": "Comenius University Bratislava",
@@ -16759,7 +17584,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 826,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Technical University of M�nchen",
@@ -16772,7 +17598,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 827,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 84
   },
   {
     "name": "Zagazig University",
@@ -16788,7 +17615,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 828,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 10
   },
   {
     "name": "Ramon Llull University",
@@ -16804,7 +17632,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 829,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 53
   },
   {
     "name": "Victoria University - Melbourne",
@@ -16820,7 +17649,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 830,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 41
   },
   {
     "name": "University of Halle-Wittenberg",
@@ -16836,7 +17666,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 831,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 84
   },
   {
     "name": "Kazan Federal University",
@@ -16852,7 +17683,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 832,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 27
   },
   {
     "name": "University of Salzburg",
@@ -16868,7 +17700,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 833,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 13
   },
   {
     "name": "Charles Sturt University",
@@ -16887,7 +17720,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 834,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 41
   },
   {
     "name": "Hebei University of Technology",
@@ -16903,7 +17737,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 835,
-    "countryRank": 100
+    "countryRank": 100,
+    "countryTotal": 224
   },
   {
     "name": "University of M�nchen",
@@ -16916,7 +17751,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 836,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 84
   },
   {
     "name": "Anna University",
@@ -16932,7 +17768,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 837,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 63
   },
   {
     "name": "University of Agriculture Faisalabad",
@@ -16948,7 +17785,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 838,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 29
   },
   {
     "name": "Universit� Paris-Saclay",
@@ -16961,7 +17799,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 839,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 60
   },
   {
     "name": "North-West University",
@@ -16980,7 +17819,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 840,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 9
   },
   {
     "name": "Beirut Arab University",
@@ -16996,7 +17836,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 841,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 6
   },
   {
     "name": "University of Texas MD Anderson Cancer Center",
@@ -17009,7 +17850,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 842,
-    "countryRank": 159
+    "countryRank": 159,
+    "countryTotal": 220
   },
   {
     "name": "University of Louisville",
@@ -17025,7 +17867,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 843,
-    "countryRank": 160
+    "countryRank": 160,
+    "countryTotal": 220
   },
   {
     "name": "Universite Paris-Est-Creteil-Val-de-Marne (UPEC)",
@@ -17041,7 +17884,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 844,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 60
   },
   {
     "name": "National Research Nuclear University MEPhI (Moscow Engineering Physics Institute)",
@@ -17057,7 +17901,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 845,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 27
   },
   {
     "name": "Charité - University Medicine Berlin",
@@ -17070,7 +17915,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 846,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 84
   },
   {
     "name": "Beijing Forestry University",
@@ -17086,7 +17932,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 847,
-    "countryRank": 101
+    "countryRank": 101,
+    "countryTotal": 224
   },
   {
     "name": "University of Klagenfurt",
@@ -17102,7 +17949,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 848,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 13
   },
   {
     "name": "Aligarh Muslim University",
@@ -17118,7 +17966,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 849,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 63
   },
   {
     "name": "Osaka Metropolitan University",
@@ -17134,7 +17983,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 850,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 36
   },
   {
     "name": "Mayo Medical School",
@@ -17147,7 +17997,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 851,
-    "countryRank": 161
+    "countryRank": 161,
+    "countryTotal": 220
   },
   {
     "name": "Vrije Universiteit Amsterdam",
@@ -17160,7 +18011,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 852,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 14
   },
   {
     "name": "Middlesex University",
@@ -17176,7 +18028,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 853,
-    "countryRank": 68
+    "countryRank": 68,
+    "countryTotal": 102
   },
   {
     "name": "University of the Sunshine Coast",
@@ -17192,7 +18045,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 854,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 41
   },
   {
     "name": "University of Nebraska Medical Center",
@@ -17208,7 +18062,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 855,
-    "countryRank": 162
+    "countryRank": 162,
+    "countryTotal": 220
   },
   {
     "name": "Royal Veterinary College",
@@ -17224,7 +18079,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 856,
-    "countryRank": 69
+    "countryRank": 69,
+    "countryTotal": 102
   },
   {
     "name": "Zayed University",
@@ -17240,7 +18096,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 857,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 13
   },
   {
     "name": "Near East University",
@@ -17256,7 +18113,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 858,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 7
   },
   {
     "name": "Dongguk University",
@@ -17275,7 +18133,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 859,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 37
   },
   {
     "name": "Future University in Egypt",
@@ -17294,7 +18153,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 860,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 10
   },
   {
     "name": "University of Malta",
@@ -17313,7 +18173,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 861,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Fujian Normal University",
@@ -17329,7 +18190,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 862,
-    "countryRank": 102
+    "countryRank": 102,
+    "countryTotal": 224
   },
   {
     "name": "University of Ha'il",
@@ -17345,7 +18207,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 863,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 25
   },
   {
     "name": "South Ural State University",
@@ -17361,7 +18224,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 864,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 27
   },
   {
     "name": "University of the West of England - Bristol",
@@ -17377,7 +18241,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 865,
-    "countryRank": 70
+    "countryRank": 70,
+    "countryTotal": 102
   },
   {
     "name": "Copenhagen Business School",
@@ -17393,7 +18258,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 866,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 7
   },
   {
     "name": "Shaanxi Normal University",
@@ -17409,7 +18275,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 867,
-    "countryRank": 103
+    "countryRank": 103,
+    "countryTotal": 224
   },
   {
     "name": "Ghent University",
@@ -17422,7 +18289,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 868,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 14
   },
   {
     "name": "University of Nevada Reno",
@@ -17438,7 +18306,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 869,
-    "countryRank": 163
+    "countryRank": 163,
+    "countryTotal": 220
   },
   {
     "name": "Yildiz Technical University",
@@ -17454,7 +18323,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 870,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 21
   },
   {
     "name": "Guizhou University",
@@ -17470,7 +18340,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 871,
-    "countryRank": 104
+    "countryRank": 104,
+    "countryTotal": 224
   },
   {
     "name": "Changsha University of Science & Technology",
@@ -17486,7 +18357,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 872,
-    "countryRank": 105
+    "countryRank": 105,
+    "countryTotal": 224
   },
   {
     "name": "University of North Carolina - Charlotte",
@@ -17502,7 +18374,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 873,
-    "countryRank": 164
+    "countryRank": 164,
+    "countryTotal": 220
   },
   {
     "name": "Aberystwyth University",
@@ -17518,7 +18391,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 874,
-    "countryRank": 71
+    "countryRank": 71,
+    "countryTotal": 102
   },
   {
     "name": "Chandigarh University",
@@ -17534,7 +18408,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 875,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 63
   },
   {
     "name": "University of Massachusetts Medical School",
@@ -17547,7 +18422,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 876,
-    "countryRank": 165
+    "countryRank": 165,
+    "countryTotal": 220
   },
   {
     "name": "San Diego State University",
@@ -17563,7 +18439,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 877,
-    "countryRank": 166
+    "countryRank": 166,
+    "countryTotal": 220
   },
   {
     "name": "Utah State University",
@@ -17579,7 +18456,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 878,
-    "countryRank": 167
+    "countryRank": 167,
+    "countryTotal": 220
   },
   {
     "name": "National Polytechnic Institute",
@@ -17595,7 +18473,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 879,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 9
   },
   {
     "name": "University of Quebec",
@@ -17611,7 +18490,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 880,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 35
   },
   {
     "name": "University of Gent",
@@ -17624,7 +18504,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 881,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 14
   },
   {
     "name": "Chang'an University",
@@ -17640,7 +18521,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 882,
-    "countryRank": 106
+    "countryRank": 106,
+    "countryTotal": 224
   },
   {
     "name": "Al-Farabi Kazakh National University",
@@ -17653,7 +18535,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 883,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 10
   },
   {
     "name": "Lahore University of Management Sciences",
@@ -17669,7 +18552,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 884,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 29
   },
   {
     "name": "Qingdao University of Science & Technology",
@@ -17685,7 +18569,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 885,
-    "countryRank": 107
+    "countryRank": 107,
+    "countryTotal": 224
   },
   {
     "name": "Jawaharlal Nehru University",
@@ -17701,7 +18586,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 886,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 63
   },
   {
     "name": "Sogang University",
@@ -17717,7 +18603,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 887,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 37
   },
   {
     "name": "University of Debrecen",
@@ -17733,7 +18620,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 888,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 9
   },
   {
     "name": "University of Tabuk",
@@ -17749,7 +18637,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 889,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 25
   },
   {
     "name": "Sechenov First Moscow State Medical University",
@@ -17765,7 +18654,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 890,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 27
   },
   {
     "name": "Savitribai Phule Pune University",
@@ -17781,7 +18671,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 891,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 63
   },
   {
     "name": "Palacky University",
@@ -17797,7 +18688,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 892,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 8
   },
   {
     "name": "Pontifical Catholic University of Rio de Janeiro",
@@ -17813,7 +18705,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 893,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 26
   },
   {
     "name": "Thapar University",
@@ -17829,7 +18722,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 894,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 63
   },
   {
     "name": "University of Gothenburg",
@@ -17842,7 +18736,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 895,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 18
   },
   {
     "name": "University of Colorado Anschutz Medical Campus",
@@ -17855,7 +18750,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 896,
-    "countryRank": 168
+    "countryRank": 168,
+    "countryTotal": 220
   },
   {
     "name": "Education University of Hong Kong",
@@ -17868,7 +18764,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 897,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 9
   },
   {
     "name": "University of Alicante",
@@ -17884,7 +18781,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 898,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 53
   },
   {
     "name": "University of Mons-Hainaut",
@@ -17900,7 +18798,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 899,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 14
   },
   {
     "name": "G�teborg University",
@@ -17913,7 +18812,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 900,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 18
   },
   {
     "name": "Sant'Anna School of Advanced Studies",
@@ -17926,7 +18826,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 901,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 61
   },
   {
     "name": "University of Udine",
@@ -17942,7 +18843,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 902,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 61
   },
   {
     "name": "Warsaw University of Technology",
@@ -17958,7 +18860,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 903,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 13
   },
   {
     "name": "National Central University",
@@ -17974,7 +18877,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 904,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 18
   },
   {
     "name": "Ecole Normale Sup�rieure de Lyon",
@@ -17987,7 +18891,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 905,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 60
   },
   {
     "name": "Dalian Maritime University",
@@ -18003,7 +18908,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 906,
-    "countryRank": 108
+    "countryRank": 108,
+    "countryTotal": 224
   },
   {
     "name": "Texas A&M University College Station",
@@ -18016,7 +18922,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 907,
-    "countryRank": 169
+    "countryRank": 169,
+    "countryTotal": 220
   },
   {
     "name": "University of Los Andes",
@@ -18029,7 +18936,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 908,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 9
   },
   {
     "name": "Anglia Ruskin University",
@@ -18045,7 +18953,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 909,
-    "countryRank": 72
+    "countryRank": 72,
+    "countryTotal": 102
   },
   {
     "name": "Universite de Montreal",
@@ -18058,7 +18967,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 910,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 35
   },
   {
     "name": "University of T�bingen",
@@ -18071,7 +18981,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 911,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 84
   },
   {
     "name": "University of New Hampshire",
@@ -18087,7 +18998,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 912,
-    "countryRank": 170
+    "countryRank": 170,
+    "countryTotal": 220
   },
   {
     "name": "Eastern Mediterranean University",
@@ -18103,7 +19015,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 913,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 7
   },
   {
     "name": "Royal Melbourne Institute of Technology (RMIT)",
@@ -18116,7 +19029,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 914,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 41
   },
   {
     "name": "Federal University of Santa Catarina",
@@ -18132,7 +19046,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 915,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 26
   },
   {
     "name": "De Montfort University",
@@ -18148,7 +19063,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 916,
-    "countryRank": 73
+    "countryRank": 73,
+    "countryTotal": 102
   },
   {
     "name": "University of Brighton",
@@ -18164,7 +19080,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 917,
-    "countryRank": 74
+    "countryRank": 74,
+    "countryTotal": 102
   },
   {
     "name": "University of Lincoln (England)",
@@ -18180,7 +19097,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 918,
-    "countryRank": 75
+    "countryRank": 75,
+    "countryTotal": 102
   },
   {
     "name": "Lovely Professional University",
@@ -18196,7 +19114,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 919,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 63
   },
   {
     "name": "Juntendo University",
@@ -18212,7 +19131,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 920,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 36
   },
   {
     "name": "Hamburg University of Technology",
@@ -18228,7 +19148,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 921,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 84
   },
   {
     "name": "University of Magdeburg",
@@ -18244,7 +19165,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 922,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 84
   },
   {
     "name": "Eberhard Karls University of Tubingen",
@@ -18257,7 +19179,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 923,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 84
   },
   {
     "name": "Universite Clermont Auvergne (UCA)",
@@ -18273,7 +19196,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 924,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 60
   },
   {
     "name": "Gadjah Mada University",
@@ -18286,7 +19210,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 925,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 11
   },
   {
     "name": "Tabriz University of Medical Science",
@@ -18302,7 +19227,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 926,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 37
   },
   {
     "name": "Universit� Libre de Bruxelles",
@@ -18315,7 +19241,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 927,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 14
   },
   {
     "name": "Universite Catholique Louvain",
@@ -18328,7 +19255,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 928,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 14
   },
   {
     "name": "University of Bielefeld",
@@ -18344,7 +19272,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 929,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 84
   },
   {
     "name": "University of Erlangen-N�rnberg",
@@ -18357,7 +19286,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 930,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 84
   },
   {
     "name": "National & Kapodistrian University of Athens",
@@ -18370,7 +19300,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 931,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 61
   },
   {
     "name": "Technische Universitat Dresden",
@@ -18383,7 +19314,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 932,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 84
   },
   {
     "name": "University of G�ttingen",
@@ -18396,7 +19328,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 933,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 84
   },
   {
     "name": "Goethe University Frankfurt",
@@ -18409,7 +19342,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 934,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 84
   },
   {
     "name": "Johannes Gutenberg Universität Mainz",
@@ -18422,7 +19356,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 935,
-    "countryRank": 61
+    "countryRank": 61,
+    "countryTotal": 84
   },
   {
     "name": "Central European University",
@@ -18435,7 +19370,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 936,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 9
   },
   {
     "name": "National Chung Hsing University - Taipei",
@@ -18451,7 +19387,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 937,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 18
   },
   {
     "name": "University of Ghana",
@@ -18470,7 +19407,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 938,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Institute of Technology Bandung",
@@ -18483,7 +19421,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 939,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 11
   },
   {
     "name": "Universite de Montpellier",
@@ -18496,7 +19435,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 940,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 60
   },
   {
     "name": "University Panth�on-Sorbonne (Paris I)",
@@ -18509,7 +19449,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 941,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 60
   },
   {
     "name": "Adam Mickiewicz University",
@@ -18528,7 +19469,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 942,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 13
   },
   {
     "name": "Beijing University of Posts & Telecommunications",
@@ -18544,7 +19486,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 943,
-    "countryRank": 109
+    "countryRank": 109,
+    "countryTotal": 224
   },
   {
     "name": "University of Newcastle",
@@ -18557,7 +19500,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 944,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 41
   },
   {
     "name": "University of South Africa",
@@ -18576,7 +19520,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 945,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 9
   },
   {
     "name": "University of Murcia",
@@ -18592,7 +19537,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 946,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 53
   },
   {
     "name": "Norwegian University of Science and Technology",
@@ -18605,7 +19551,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 947,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 8
   },
   {
     "name": "American University of Sharjah",
@@ -18618,7 +19565,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 948,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 13
   },
   {
     "name": "Shanxi University",
@@ -18634,7 +19582,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 949,
-    "countryRank": 110
+    "countryRank": 110,
+    "countryTotal": 224
   },
   {
     "name": "Okayama University",
@@ -18650,7 +19599,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 950,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 36
   },
   {
     "name": "Dhofar University",
@@ -18666,7 +19616,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 951,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "Yarmouk University",
@@ -18682,7 +19633,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 952,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 11
   },
   {
     "name": "Worcester Polytechnic Institute",
@@ -18698,7 +19650,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 953,
-    "countryRank": 171
+    "countryRank": 171,
+    "countryTotal": 220
   },
   {
     "name": "Tuscia University",
@@ -18714,7 +19667,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 954,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 61
   },
   {
     "name": "Sultan Idris Education University",
@@ -18730,7 +19684,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 955,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 26
   },
   {
     "name": "University of Management & Technology (UMT)",
@@ -18746,7 +19701,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 956,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 29
   },
   {
     "name": "Beijing Technology & Business University",
@@ -18762,7 +19718,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 957,
-    "countryRank": 111
+    "countryRank": 111,
+    "countryTotal": 224
   },
   {
     "name": "Airlangga University",
@@ -18775,7 +19732,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 958,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 11
   },
   {
     "name": "Kingston University",
@@ -18791,7 +19749,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 959,
-    "countryRank": 76
+    "countryRank": 76,
+    "countryTotal": 102
   },
   {
     "name": "Lulea University of Technology",
@@ -18807,7 +19766,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 960,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 18
   },
   {
     "name": "Open University - UK",
@@ -18826,7 +19786,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 961,
-    "countryRank": 77
+    "countryRank": 77,
+    "countryTotal": 102
   },
   {
     "name": "Paris Cit� University",
@@ -18839,7 +19800,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 962,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 60
   },
   {
     "name": "University Carlos III de Madrid",
@@ -18852,7 +19814,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 963,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 53
   },
   {
     "name": "Fujian Medical University",
@@ -18865,7 +19828,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 964,
-    "countryRank": 112
+    "countryRank": 112,
+    "countryTotal": 224
   },
   {
     "name": "Albert Einstein College of Medicine - Yeshiva University",
@@ -18878,7 +19842,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 965,
-    "countryRank": 172
+    "countryRank": 172,
+    "countryTotal": 220
   },
   {
     "name": "Kunming University of Science and Technology",
@@ -18891,7 +19856,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 966,
-    "countryRank": 113
+    "countryRank": 113,
+    "countryTotal": 224
   },
   {
     "name": "Birla Institute of Technology and Science",
@@ -18907,7 +19873,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 967,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 63
   },
   {
     "name": "City St.George’s - University London",
@@ -18920,7 +19887,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 968,
-    "countryRank": 78
+    "countryRank": 78,
+    "countryTotal": 102
   },
   {
     "name": "Northwest A&F University - China",
@@ -18933,7 +19901,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 969,
-    "countryRank": 114
+    "countryRank": 114,
+    "countryTotal": 224
   },
   {
     "name": "Abdul Wali Khan University",
@@ -18949,7 +19918,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 970,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 29
   },
   {
     "name": "Universite de Bordeaux",
@@ -18962,7 +19932,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 971,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 60
   },
   {
     "name": "Soochow University - China",
@@ -18975,7 +19946,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 972,
-    "countryRank": 115
+    "countryRank": 115,
+    "countryTotal": 224
   },
   {
     "name": "L.N. Gumilyov Eurasian National University",
@@ -18988,7 +19960,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 973,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 10
   },
   {
     "name": "Tomsk Polytechnic University",
@@ -19004,7 +19977,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 974,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 27
   },
   {
     "name": "Satbayev Kazakh National Technical University",
@@ -19017,7 +19991,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 975,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 10
   },
   {
     "name": "University of Tennessee Health Science Center",
@@ -19033,7 +20008,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 976,
-    "countryRank": 173
+    "countryRank": 173,
+    "countryTotal": 220
   },
   {
     "name": "Indian Institute of Technology - Guwahati",
@@ -19046,7 +20022,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 977,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 63
   },
   {
     "name": "Universidad de la Laguna",
@@ -19062,7 +20039,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 978,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 53
   },
   {
     "name": "University of Oviedo",
@@ -19078,7 +20056,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 979,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 53
   },
   {
     "name": "City St George’s, University of London",
@@ -19091,7 +20070,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 980,
-    "countryRank": 79
+    "countryRank": 79,
+    "countryTotal": 102
   },
   {
     "name": "Tallinn University of Technology",
@@ -19107,7 +20087,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 981,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "Shiraz University of Technology",
@@ -19123,7 +20104,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 982,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 37
   },
   {
     "name": "London South Bank University",
@@ -19139,7 +20121,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 983,
-    "countryRank": 80
+    "countryRank": 80,
+    "countryTotal": 102
   },
   {
     "name": "University of Beira Interior",
@@ -19155,7 +20138,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 984,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 9
   },
   {
     "name": "University of Eastern Piedmont",
@@ -19171,7 +20155,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 985,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 61
   },
   {
     "name": "University of Alcalá de Henares",
@@ -19187,7 +20172,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 986,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 53
   },
   {
     "name": "University of the Balearic Islands",
@@ -19203,7 +20189,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 987,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 53
   },
   {
     "name": "Jeonbuk National University (formerly known as Chonbuk National University)",
@@ -19219,7 +20206,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 988,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 37
   },
   {
     "name": "Shanghai University of Finance & Economics",
@@ -19235,7 +20223,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 989,
-    "countryRank": 116
+    "countryRank": 116,
+    "countryTotal": 224
   },
   {
     "name": "Pontifical Catholic University of Per�",
@@ -19248,7 +20237,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 990,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "University of M�nster",
@@ -19261,7 +20251,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 991,
-    "countryRank": 62
+    "countryRank": 62,
+    "countryTotal": 84
   },
   {
     "name": "University of St.Gallen",
@@ -19274,7 +20265,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 992,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 13
   },
   {
     "name": "Mohammed VI Polytechnic University",
@@ -19287,7 +20279,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 993,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 3
   },
   {
     "name": "Budapest University of Technology and Economics",
@@ -19303,7 +20296,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 994,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 9
   },
   {
     "name": "Universita Cattolica del Sacro Cuore",
@@ -19316,7 +20310,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 995,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 61
   },
   {
     "name": "Universite de Strasbourg",
@@ -19329,7 +20324,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 996,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 60
   },
   {
     "name": "Universite Claude Bernard Lyon 1",
@@ -19342,7 +20338,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 997,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 60
   },
   {
     "name": "University of Oklahoma Health Sciences Center",
@@ -19358,7 +20355,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 998,
-    "countryRank": 174
+    "countryRank": 174,
+    "countryTotal": 220
   },
   {
     "name": "National University of Science and Technology MISiS",
@@ -19374,7 +20372,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 999,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 27
   },
   {
     "name": "Jinan University",
@@ -19387,7 +20386,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1000,
-    "countryRank": 117
+    "countryRank": 117,
+    "countryTotal": 224
   },
   {
     "name": "Pontificia Universidad Javeriana",
@@ -19400,7 +20400,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1001,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 9
   },
   {
     "name": "National University of Sciences and Technology - Islamabad",
@@ -19413,7 +20414,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1002,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 29
   },
   {
     "name": "Universite de Lille",
@@ -19426,7 +20428,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1003,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 60
   },
   {
     "name": "University of Tunis El Manar",
@@ -19442,7 +20445,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1004,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "National Institute of Technology Tiruchirappalli",
@@ -19458,7 +20462,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1005,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 63
   },
   {
     "name": "University of Li�ge",
@@ -19471,7 +20476,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1006,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 14
   },
   {
     "name": "Universite Cote d'Azur",
@@ -19484,7 +20490,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1007,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 60
   },
   {
     "name": "Brigham Young University",
@@ -19500,7 +20507,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1008,
-    "countryRank": 175
+    "countryRank": 175,
+    "countryTotal": 220
   },
   {
     "name": "Birkbeck - University of London",
@@ -19513,7 +20521,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1009,
-    "countryRank": 81
+    "countryRank": 81,
+    "countryTotal": 102
   },
   {
     "name": "Shahid Beheshti University",
@@ -19529,7 +20538,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1010,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 37
   },
   {
     "name": "Ruhr University Bochum",
@@ -19542,7 +20552,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1011,
-    "countryRank": 63
+    "countryRank": 63,
+    "countryTotal": 84
   },
   {
     "name": "University of Wisconsin Milwaukee",
@@ -19558,7 +20569,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1012,
-    "countryRank": 176
+    "countryRank": 176,
+    "countryTotal": 220
   },
   {
     "name": "Institute of Science Tokyo",
@@ -19571,7 +20583,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1013,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 36
   },
   {
     "name": "Universiti Teknologi Malaysia",
@@ -19584,7 +20597,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1014,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 61
   },
   {
     "name": "Bahauddin Zakariya University",
@@ -19600,7 +20614,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1015,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 29
   },
   {
     "name": "Bogor Agricultural University (IPB University)",
@@ -19613,7 +20628,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1016,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 11
   },
   {
     "name": "Chungnam National University",
@@ -19629,7 +20645,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1017,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 37
   },
   {
     "name": "Anhui Medical University",
@@ -19642,7 +20659,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1018,
-    "countryRank": 118
+    "countryRank": 118,
+    "countryTotal": 224
   },
   {
     "name": "Nanjing University of Traditional Chinese Medicine",
@@ -19655,7 +20673,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1019,
-    "countryRank": 119
+    "countryRank": 119,
+    "countryTotal": 224
   },
   {
     "name": "National University of Defense Technology",
@@ -19668,7 +20687,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1020,
-    "countryRank": 120
+    "countryRank": 120,
+    "countryTotal": 224
   },
   {
     "name": "Ningbo University",
@@ -19681,7 +20701,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1021,
-    "countryRank": 121
+    "countryRank": 121,
+    "countryTotal": 224
   },
   {
     "name": "Toulouse 1 University Capitole",
@@ -19694,7 +20715,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1022,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 60
   },
   {
     "name": "Indiana University-Purdue University of Indianapolis",
@@ -19707,7 +20729,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1023,
-    "countryRank": 177
+    "countryRank": 177,
+    "countryTotal": 220
   },
   {
     "name": "The Graduate Center - CUNY",
@@ -19720,7 +20743,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1024,
-    "countryRank": 178
+    "countryRank": 178,
+    "countryTotal": 220
   },
   {
     "name": "Wenzhou Medical University",
@@ -19733,7 +20757,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1025,
-    "countryRank": 122
+    "countryRank": 122,
+    "countryTotal": 224
   },
   {
     "name": "China University of Geosciences - Beijing",
@@ -19746,7 +20771,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1026,
-    "countryRank": 123
+    "countryRank": 123,
+    "countryTotal": 224
   },
   {
     "name": "The Chinese University of Hong Kong - Shenzhen",
@@ -19759,7 +20785,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1027,
-    "countryRank": 124
+    "countryRank": 124,
+    "countryTotal": 224
   },
   {
     "name": "Espiritu Santo University",
@@ -19775,7 +20802,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1028,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 3
   },
   {
     "name": "Amity University",
@@ -19791,7 +20819,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1029,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 63
   },
   {
     "name": "Arabian Gulf University",
@@ -19804,7 +20833,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1030,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "University of Greifswald",
@@ -19817,7 +20847,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1031,
-    "countryRank": 64
+    "countryRank": 64,
+    "countryTotal": 84
   },
   {
     "name": "Roskilde University",
@@ -19830,7 +20861,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1032,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 7
   },
   {
     "name": "University of Vaasa",
@@ -19843,7 +20875,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1033,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 10
   },
   {
     "name": "University of Putra Malaysia",
@@ -19856,7 +20889,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1034,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 26
   },
   {
     "name": "IMT Atlantique",
@@ -19869,7 +20903,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1035,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 60
   },
   {
     "name": "Leuphana University Luneburg",
@@ -19882,7 +20917,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1036,
-    "countryRank": 65
+    "countryRank": 65,
+    "countryTotal": 84
   },
   {
     "name": "Nazarbayev University",
@@ -19895,7 +20931,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1037,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 10
   },
   {
     "name": "Alfaisal University",
@@ -19911,7 +20948,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1038,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 25
   },
   {
     "name": "Institut National des Sciences Appliqu�es de Lyon",
@@ -19924,7 +20962,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1039,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 60
   },
   {
     "name": "Islamia University of Bahawalpur",
@@ -19940,7 +20979,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1040,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 29
   },
   {
     "name": "University of W�rzburg",
@@ -19953,7 +20993,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1041,
-    "countryRank": 66
+    "countryRank": 66,
+    "countryTotal": 84
   },
   {
     "name": "Central China Normal University",
@@ -19966,7 +21007,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1042,
-    "countryRank": 125
+    "countryRank": 125,
+    "countryTotal": 224
   },
   {
     "name": "Friedrich Schiller University of Jena",
@@ -19979,7 +21021,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1043,
-    "countryRank": 67
+    "countryRank": 67,
+    "countryTotal": 84
   },
   {
     "name": "Babes-Bolyai University",
@@ -19995,7 +21038,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1044,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "National Taipei University of Technology",
@@ -20008,7 +21052,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1045,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 18
   },
   {
     "name": "Khalifa University of Science & Technology",
@@ -20021,7 +21066,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1046,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 61
   },
   {
     "name": "University of Quebec Montreal",
@@ -20037,7 +21083,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1047,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 35
   },
   {
     "name": "China Pharmaceutical University",
@@ -20053,7 +21100,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1048,
-    "countryRank": 126
+    "countryRank": 126,
+    "countryTotal": 224
   },
   {
     "name": "Makerere University",
@@ -20069,7 +21117,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1049,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Islamic Azad University",
@@ -20082,7 +21131,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1050,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 61
   },
   {
     "name": "Zhejiang Gongshang University",
@@ -20098,7 +21148,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1051,
-    "countryRank": 127
+    "countryRank": 127,
+    "countryTotal": 224
   },
   {
     "name": "Shandong University of Science & Technology",
@@ -20114,7 +21165,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1052,
-    "countryRank": 128
+    "countryRank": 128,
+    "countryTotal": 224
   },
   {
     "name": "Graduate University for Advanced Studies - Japan",
@@ -20130,7 +21182,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1053,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 36
   },
   {
     "name": "Catholic University of Portugal",
@@ -20146,7 +21199,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1054,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 9
   },
   {
     "name": "IE University",
@@ -20159,7 +21213,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1055,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 53
   },
   {
     "name": "Universiti Sains Malaysia",
@@ -20172,7 +21227,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1056,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 61
   },
   {
     "name": "Belarusian State University",
@@ -20185,7 +21241,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1057,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Wuhan University of Science & Technology",
@@ -20201,7 +21258,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1058,
-    "countryRank": 129
+    "countryRank": 129,
+    "countryTotal": 224
   },
   {
     "name": "Assiut University",
@@ -20214,7 +21272,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1059,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 61
   },
   {
     "name": "Michigan Technological University",
@@ -20233,7 +21292,8 @@
     },
     "appearances": 3,
     "aggregatedRank": 1060,
-    "countryRank": 179
+    "countryRank": 179,
+    "countryTotal": 220
   },
   {
     "name": "Heinrich Heine University Dusseldorf",
@@ -20246,7 +21306,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1061,
-    "countryRank": 68
+    "countryRank": 68,
+    "countryTotal": 84
   },
   {
     "name": "University of Mississippi",
@@ -20259,7 +21320,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1062,
-    "countryRank": 180
+    "countryRank": 180,
+    "countryTotal": 220
   },
   {
     "name": "Universita degli Studi di Bari Aldo Moro",
@@ -20272,7 +21334,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1063,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 61
   },
   {
     "name": "National University de La Plata",
@@ -20285,7 +21348,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1064,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 8
   },
   {
     "name": "Southern Methodist University",
@@ -20301,7 +21365,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1065,
-    "countryRank": 181
+    "countryRank": 181,
+    "countryTotal": 220
   },
   {
     "name": "Tokyo University of Science",
@@ -20317,7 +21382,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1066,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 36
   },
   {
     "name": "University of Sherbrooke",
@@ -20333,7 +21399,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1067,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 35
   },
   {
     "name": "Azerbaijan State University Economics",
@@ -20349,7 +21416,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1068,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 6
   },
   {
     "name": "German Jordanian University",
@@ -20365,7 +21433,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1069,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 11
   },
   {
     "name": "University of Westminster",
@@ -20381,7 +21450,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1070,
-    "countryRank": 82
+    "countryRank": 82,
+    "countryTotal": 102
   },
   {
     "name": "University of Namur",
@@ -20397,7 +21467,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1071,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 14
   },
   {
     "name": "Chengdu University of Technology",
@@ -20413,7 +21484,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1072,
-    "countryRank": 130
+    "countryRank": 130,
+    "countryTotal": 224
   },
   {
     "name": "University of Leiden",
@@ -20429,7 +21501,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1073,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 53
   },
   {
     "name": "Institut National des Sciences Appliquées de Toulouse",
@@ -20445,7 +21518,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1074,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 60
   },
   {
     "name": "Old Dominion University",
@@ -20461,7 +21535,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1075,
-    "countryRank": 182
+    "countryRank": 182,
+    "countryTotal": 220
   },
   {
     "name": "Universidad de la Republica, Uruguay",
@@ -20477,7 +21552,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1076,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 3
   },
   {
     "name": "Wuhan Institute of Technology",
@@ -20493,7 +21569,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1077,
-    "countryRank": 131
+    "countryRank": 131,
+    "countryTotal": 224
   },
   {
     "name": "Nantes Universite",
@@ -20506,7 +21583,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1078,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 60
   },
   {
     "name": "University of Massachusetts Worcester",
@@ -20519,7 +21597,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1079,
-    "countryRank": 183
+    "countryRank": 183,
+    "countryTotal": 220
   },
   {
     "name": "Tashkent Institute Irrigation and Agricultural Mechanization Engineers",
@@ -20532,7 +21611,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1080,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 4
   },
   {
     "name": "Universite de Lorraine",
@@ -20545,7 +21625,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1081,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 60
   },
   {
     "name": "Universitat Politecnica de Catalunya",
@@ -20558,7 +21639,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1082,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 53
   },
   {
     "name": "Donghua University",
@@ -20571,7 +21653,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1083,
-    "countryRank": 132
+    "countryRank": 132,
+    "countryTotal": 224
   },
   {
     "name": "Universidade Federal do Rio Grande do Sul",
@@ -20584,7 +21667,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1084,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 26
   },
   {
     "name": "Technical University of Bergakademie Freiberg",
@@ -20597,7 +21681,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1085,
-    "countryRank": 69
+    "countryRank": 69,
+    "countryTotal": 84
   },
   {
     "name": "University of Santiago de Chile",
@@ -20610,7 +21695,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1086,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 7
   },
   {
     "name": "University of Missouri",
@@ -20623,7 +21709,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1087,
-    "countryRank": 184
+    "countryRank": 184,
+    "countryTotal": 220
   },
   {
     "name": "University of Utara Malaysia",
@@ -20636,7 +21723,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1088,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 26
   },
   {
     "name": "Carol Davila University of Medicine & Pharmacy",
@@ -20652,7 +21740,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1089,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "Universidad de Chile",
@@ -20665,7 +21754,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1090,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 61
   },
   {
     "name": "University of Costa Rica",
@@ -20678,7 +21768,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1091,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Mashhad University of Medical Sciences",
@@ -20694,7 +21785,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1092,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 37
   },
   {
     "name": "Hohai University Changzhou",
@@ -20707,7 +21799,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1093,
-    "countryRank": 133
+    "countryRank": 133,
+    "countryTotal": 224
   },
   {
     "name": "Central China Normal University (Huazhong Normal University)",
@@ -20720,7 +21813,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1094,
-    "countryRank": 134
+    "countryRank": 134,
+    "countryTotal": 224
   },
   {
     "name": "Chongqing Medical University",
@@ -20733,7 +21827,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1095,
-    "countryRank": 135
+    "countryRank": 135,
+    "countryTotal": 224
   },
   {
     "name": "Shandong Agricultural University",
@@ -20746,7 +21841,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1096,
-    "countryRank": 136
+    "countryRank": 136,
+    "countryTotal": 224
   },
   {
     "name": "Tianjin Medical University",
@@ -20759,7 +21855,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1097,
-    "countryRank": 137
+    "countryRank": 137,
+    "countryTotal": 224
   },
   {
     "name": "Xi'an University of Technology",
@@ -20772,7 +21869,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1098,
-    "countryRank": 138
+    "countryRank": 138,
+    "countryTotal": 224
   },
   {
     "name": "University of Campania Luigi Vanvitelli",
@@ -20785,7 +21883,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1099,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 61
   },
   {
     "name": "University of Maine - Orono",
@@ -20798,7 +21897,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1100,
-    "countryRank": 185
+    "countryRank": 185,
+    "countryTotal": 220
   },
   {
     "name": "Yanshan University",
@@ -20811,7 +21911,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1101,
-    "countryRank": 139
+    "countryRank": 139,
+    "countryTotal": 224
   },
   {
     "name": "Zhejiang Science-Technology University",
@@ -20824,7 +21925,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1102,
-    "countryRank": 140
+    "countryRank": 140,
+    "countryTotal": 224
   },
   {
     "name": "Hangzhou Dianzi University",
@@ -20837,7 +21939,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1103,
-    "countryRank": 141
+    "countryRank": 141,
+    "countryTotal": 224
   },
   {
     "name": "Kaiserslautern University of Technology",
@@ -20850,7 +21953,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1104,
-    "countryRank": 70
+    "countryRank": 70,
+    "countryTotal": 84
   },
   {
     "name": "Mahatma Gandhi University",
@@ -20863,7 +21967,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1105,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 63
   },
   {
     "name": "Campus Bio-Medico University of Rome",
@@ -20876,7 +21981,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1106,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 61
   },
   {
     "name": "National Yunlin University of Science and Technology",
@@ -20889,7 +21995,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1107,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 18
   },
   {
     "name": "University of Denver",
@@ -20902,7 +22009,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1108,
-    "countryRank": 186
+    "countryRank": 186,
+    "countryTotal": 220
   },
   {
     "name": "University of Tulsa",
@@ -20915,7 +22023,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1109,
-    "countryRank": 187
+    "countryRank": 187,
+    "countryTotal": 220
   },
   {
     "name": "Federal University of Toulouse Midi-Pyrénées",
@@ -20928,7 +22037,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1110,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 60
   },
   {
     "name": "Wroclaw Medical University",
@@ -20941,7 +22051,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1111,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 13
   },
   {
     "name": "Federation University Australia",
@@ -20954,7 +22065,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1112,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 41
   },
   {
     "name": "University of Nicosia",
@@ -20967,7 +22079,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1113,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 7
   },
   {
     "name": "Tashkent Institute of Irrigation and Agricultural Mechanization Engineers - National Research University (TIIAME-NRU)",
@@ -20980,7 +22093,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1114,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "UEH University",
@@ -20993,7 +22107,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1115,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 6
   },
   {
     "name": "Constructor University Bremen",
@@ -21006,7 +22121,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1116,
-    "countryRank": 71
+    "countryRank": 71,
+    "countryTotal": 84
   },
   {
     "name": "KIIT University",
@@ -21019,7 +22135,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1117,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 63
   },
   {
     "name": "Bohai University",
@@ -21032,7 +22149,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1118,
-    "countryRank": 142
+    "countryRank": 142,
+    "countryTotal": 224
   },
   {
     "name": "Cranfield University",
@@ -21048,7 +22166,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1119,
-    "countryRank": 83
+    "countryRank": 83,
+    "countryTotal": 102
   },
   {
     "name": "ITMO University",
@@ -21064,7 +22183,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1120,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 27
   },
   {
     "name": "Sepuluh Nopember Institute of Technology",
@@ -21077,7 +22197,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1121,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 11
   },
   {
     "name": "INTI International University",
@@ -21090,7 +22211,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1122,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 26
   },
   {
     "name": "Ateneo de Manila University",
@@ -21103,7 +22225,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1123,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "Universidade de Coimbra",
@@ -21116,7 +22239,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1124,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 61
   },
   {
     "name": "Padjadjaran University",
@@ -21129,7 +22253,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1125,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 11
   },
   {
     "name": "Lebanese University Beirut",
@@ -21142,7 +22267,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1126,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 6
   },
   {
     "name": "Tanta University",
@@ -21155,7 +22281,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1127,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 61
   },
   {
     "name": "Pontifical Catholic University Argentina",
@@ -21168,7 +22295,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1128,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 8
   },
   {
     "name": "Austral University",
@@ -21181,7 +22309,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1129,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 8
   },
   {
     "name": "Anhui University of Finance & Economics",
@@ -21194,7 +22323,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1130,
-    "countryRank": 143
+    "countryRank": 143,
+    "countryTotal": 224
   },
   {
     "name": "Universite de Rennes",
@@ -21207,7 +22337,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1131,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 60
   },
   {
     "name": "International School for Advanced Studies (SISSA)",
@@ -21220,7 +22351,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1132,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 61
   },
   {
     "name": "Sichuan Agricultural University",
@@ -21236,7 +22368,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1133,
-    "countryRank": 144
+    "countryRank": 144,
+    "countryTotal": 224
   },
   {
     "name": "York University - Canada",
@@ -21249,7 +22382,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1134,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 35
   },
   {
     "name": "University of Technology - Mara",
@@ -21262,7 +22396,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1135,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 26
   },
   {
     "name": "Universiti Malaysia Terengganu",
@@ -21278,7 +22413,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1136,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 26
   },
   {
     "name": "University of Calcutta",
@@ -21294,7 +22430,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1137,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 63
   },
   {
     "name": "Brunel University London",
@@ -21307,7 +22444,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1138,
-    "countryRank": 84
+    "countryRank": 84,
+    "countryTotal": 102
   },
   {
     "name": "Politecnico di Torino",
@@ -21320,7 +22458,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1139,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 61
   },
   {
     "name": "Ollscoil na Gaillimhe-University of Galway",
@@ -21333,7 +22472,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1140,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 61
   },
   {
     "name": "Thammasat University",
@@ -21346,7 +22486,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1141,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 8
   },
   {
     "name": "Hitotsubashi University",
@@ -21359,7 +22500,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1142,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 36
   },
   {
     "name": "Universidade Federal do Rio de Janeiro",
@@ -21372,7 +22514,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1143,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 26
   },
   {
     "name": "Universita della Campania Vanvitelli",
@@ -21385,7 +22528,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1144,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 61
   },
   {
     "name": "Indian Institute of Technology (BHU) Varanasi",
@@ -21398,7 +22542,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1145,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 63
   },
   {
     "name": "Justus Liebig University Giessen",
@@ -21411,7 +22556,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1146,
-    "countryRank": 72
+    "countryRank": 72,
+    "countryTotal": 84
   },
   {
     "name": "Benha University",
@@ -21424,7 +22570,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1147,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 61
   },
   {
     "name": "Bocconi University",
@@ -21437,7 +22584,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1148,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 61
   },
   {
     "name": "Universidade Federal de Minas Gerais",
@@ -21450,7 +22598,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1149,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 26
   },
   {
     "name": "USI - Universita della Svizzera italiana",
@@ -21463,7 +22612,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1150,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 13
   },
   {
     "name": "Zhongnan University of Economics & Law",
@@ -21479,7 +22629,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1151,
-    "countryRank": 145
+    "countryRank": 145,
+    "countryTotal": 224
   },
   {
     "name": "Brno University of Technology",
@@ -21492,7 +22643,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1152,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 8
   },
   {
     "name": "Banaras Hindu University (BHU)",
@@ -21508,7 +22660,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1153,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 63
   },
   {
     "name": "University Adolfo Ib��ez",
@@ -21521,7 +22674,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1154,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 7
   },
   {
     "name": "Nanjing Tech University",
@@ -21534,7 +22688,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1155,
-    "countryRank": 146
+    "countryRank": 146,
+    "countryTotal": 224
   },
   {
     "name": "Leibniz University Hannover",
@@ -21547,7 +22702,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1156,
-    "countryRank": 73
+    "countryRank": 73,
+    "countryTotal": 84
   },
   {
     "name": "Kanazawa University",
@@ -21563,7 +22719,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1157,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 36
   },
   {
     "name": "Nagasaki University",
@@ -21579,7 +22736,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1158,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 36
   },
   {
     "name": "University Pontificia Comillas",
@@ -21592,7 +22750,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1159,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 53
   },
   {
     "name": "King Mongkut's University of Technology Thonburi",
@@ -21608,7 +22767,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1160,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 8
   },
   {
     "name": "University of Salford",
@@ -21624,7 +22784,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1161,
-    "countryRank": 85
+    "countryRank": 85,
+    "countryTotal": 102
   },
   {
     "name": "University of Regina",
@@ -21640,7 +22801,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1162,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 35
   },
   {
     "name": "Universidad Carlos III de Madrid",
@@ -21656,7 +22818,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1163,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 53
   },
   {
     "name": "University of Córdoba",
@@ -21672,7 +22835,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1164,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 53
   },
   {
     "name": "Ataturk University",
@@ -21688,7 +22852,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1165,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 21
   },
   {
     "name": "Kaohsiung Medical University",
@@ -21704,7 +22869,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1166,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 18
   },
   {
     "name": "Gabriele D'Annunzio University",
@@ -21720,7 +22886,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1167,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 61
   },
   {
     "name": "E�tv�s Lorand University",
@@ -21733,7 +22900,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1168,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 9
   },
   {
     "name": "Philipps University Marburg",
@@ -21746,7 +22914,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1169,
-    "countryRank": 74
+    "countryRank": 74,
+    "countryTotal": 84
   },
   {
     "name": "Texas Tech University",
@@ -21759,7 +22928,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1170,
-    "countryRank": 188
+    "countryRank": 188,
+    "countryTotal": 220
   },
   {
     "name": "National Research Nuclear University",
@@ -21772,7 +22942,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1171,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 27
   },
   {
     "name": "American University of Ras al Khaimah",
@@ -21785,7 +22956,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1172,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 13
   },
   {
     "name": "University of Bucharest",
@@ -21801,7 +22973,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1173,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "Universiti Kebangsaan Malaysia",
@@ -21814,7 +22987,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1174,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 61
   },
   {
     "name": "Gorgan University of Agricultural Sciences & Natural Resources",
@@ -21830,7 +23004,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1175,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 37
   },
   {
     "name": "Asia Pacific University of Technology and Innovation",
@@ -21843,7 +23018,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1176,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 26
   },
   {
     "name": "UiT The Arctic University of Tromso",
@@ -21856,7 +23032,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1177,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 61
   },
   {
     "name": "Second Military Medical University",
@@ -21869,7 +23046,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1178,
-    "countryRank": 147
+    "countryRank": 147,
+    "countryTotal": 224
   },
   {
     "name": "Air Force Medical University",
@@ -21882,7 +23060,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1179,
-    "countryRank": 148
+    "countryRank": 148,
+    "countryTotal": 224
   },
   {
     "name": "China Medical University",
@@ -21895,7 +23074,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1180,
-    "countryRank": 149
+    "countryRank": 149,
+    "countryTotal": 224
   },
   {
     "name": "China University of Mining Technology - Beijing",
@@ -21908,7 +23088,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1181,
-    "countryRank": 150
+    "countryRank": 150,
+    "countryTotal": 224
   },
   {
     "name": "Shanghai Normal University",
@@ -21921,7 +23102,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1182,
-    "countryRank": 151
+    "countryRank": 151,
+    "countryTotal": 224
   },
   {
     "name": "Taiyuan University of Technology",
@@ -21934,7 +23116,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1183,
-    "countryRank": 152
+    "countryRank": 152,
+    "countryTotal": 224
   },
   {
     "name": "University of Oldenburg",
@@ -21947,7 +23130,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1184,
-    "countryRank": 75
+    "countryRank": 75,
+    "countryTotal": 84
   },
   {
     "name": "University of Augsburg",
@@ -21960,7 +23144,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1185,
-    "countryRank": 76
+    "countryRank": 76,
+    "countryTotal": 84
   },
   {
     "name": "University of Burgundy",
@@ -21973,7 +23158,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1186,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 60
   },
   {
     "name": "University of Natural Resources and Life Sciences",
@@ -21986,7 +23172,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1187,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 13
   },
   {
     "name": "Nantong University",
@@ -21999,7 +23186,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1188,
-    "countryRank": 153
+    "countryRank": 153,
+    "countryTotal": 224
   },
   {
     "name": "Northeast Forestry University",
@@ -22012,7 +23200,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1189,
-    "countryRank": 154
+    "countryRank": 154,
+    "countryTotal": 224
   },
   {
     "name": "Southwest Petroleum University",
@@ -22025,7 +23214,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1190,
-    "countryRank": 155
+    "countryRank": 155,
+    "countryTotal": 224
   },
   {
     "name": "Henan University of Science & Technology",
@@ -22038,7 +23228,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1191,
-    "countryRank": 156
+    "countryRank": 156,
+    "countryTotal": 224
   },
   {
     "name": "Lanzhou University of Technology",
@@ -22051,7 +23242,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1192,
-    "countryRank": 157
+    "countryRank": 157,
+    "countryTotal": 224
   },
   {
     "name": "Shanghai Ocean University",
@@ -22064,7 +23256,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1193,
-    "countryRank": 158
+    "countryRank": 158,
+    "countryTotal": 224
   },
   {
     "name": "Zhejiang Chinese Medical University",
@@ -22077,7 +23270,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1194,
-    "countryRank": 159
+    "countryRank": 159,
+    "countryTotal": 224
   },
   {
     "name": "Qilu University of Technology",
@@ -22090,7 +23284,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1195,
-    "countryRank": 160
+    "countryRank": 160,
+    "countryTotal": 224
   },
   {
     "name": "Shandong First Medical University",
@@ -22103,7 +23298,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1196,
-    "countryRank": 161
+    "countryRank": 161,
+    "countryTotal": 224
   },
   {
     "name": "University of Health Sciences Turkey",
@@ -22116,7 +23312,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1197,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 21
   },
   {
     "name": "Homi Bhabha National Institute",
@@ -22129,7 +23326,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1198,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 63
   },
   {
     "name": "City University of Macau",
@@ -22142,7 +23340,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1199,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "Graphic Era University",
@@ -22155,7 +23354,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1200,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 63
   },
   {
     "name": "Sharda University",
@@ -22168,7 +23368,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1201,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 63
   },
   {
     "name": "Toronto Metropolitan University (formerly Ryerson University)",
@@ -22181,7 +23382,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1202,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 35
   },
   {
     "name": "University of Neuchatel",
@@ -22194,7 +23396,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1203,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 13
   },
   {
     "name": "University of Paderborn",
@@ -22207,7 +23410,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1204,
-    "countryRank": 77
+    "countryRank": 77,
+    "countryTotal": 84
   },
   {
     "name": "University of Passau",
@@ -22220,7 +23424,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1205,
-    "countryRank": 78
+    "countryRank": 78,
+    "countryTotal": 84
   },
   {
     "name": "Ecole Centrale de Nantes",
@@ -22233,7 +23438,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1206,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 60
   },
   {
     "name": "Ecole Nationale des Travaux Publics de l'Etat",
@@ -22246,7 +23452,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1207,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 60
   },
   {
     "name": "Harokopio University",
@@ -22259,7 +23466,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1208,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 7
   },
   {
     "name": "Bharathiar University",
@@ -22272,7 +23480,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1209,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 63
   },
   {
     "name": "Babol University of Medical Sciences",
@@ -22285,7 +23494,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1210,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 37
   },
   {
     "name": "Qazvin University of Medical Sciences",
@@ -22298,7 +23508,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1211,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 37
   },
   {
     "name": "Urmia University of Medical Sciences",
@@ -22311,7 +23522,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1212,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 37
   },
   {
     "name": "University of Aquila",
@@ -22324,7 +23536,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1213,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 61
   },
   {
     "name": "University of Aizu",
@@ -22337,7 +23550,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1214,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 36
   },
   {
     "name": "Air University",
@@ -22350,7 +23564,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1215,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 29
   },
   {
     "name": "National University of Sciences And Technology (NUST) Islamabad",
@@ -22363,7 +23578,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1216,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 29
   },
   {
     "name": "University of Veterinary and Animal Sciences",
@@ -22376,7 +23592,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1217,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 29
   },
   {
     "name": "Kadir Has University",
@@ -22389,7 +23606,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1218,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 21
   },
   {
     "name": "Yuan Ze University",
@@ -22402,7 +23620,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1219,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 18
   },
   {
     "name": "London Metropolitan University",
@@ -22415,7 +23634,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1220,
-    "countryRank": 86
+    "countryRank": 86,
+    "countryTotal": 102
   },
   {
     "name": "University of Derby",
@@ -22428,7 +23648,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1221,
-    "countryRank": 87
+    "countryRank": 87,
+    "countryTotal": 102
   },
   {
     "name": "University of Teesside",
@@ -22441,7 +23662,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1222,
-    "countryRank": 88
+    "countryRank": 88,
+    "countryTotal": 102
   },
   {
     "name": "New Mexico State University",
@@ -22454,7 +23676,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1223,
-    "countryRank": 189
+    "countryRank": 189,
+    "countryTotal": 220
   },
   {
     "name": "National Institute of Technology Rourkela",
@@ -22467,7 +23690,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1224,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 63
   },
   {
     "name": "University of the West Scotland",
@@ -22480,7 +23704,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1225,
-    "countryRank": 89
+    "countryRank": 89,
+    "countryTotal": 102
   },
   {
     "name": "Babol Noshirvani University of Technology",
@@ -22493,7 +23718,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1226,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 37
   },
   {
     "name": "École des Mines de Saint-Étienne",
@@ -22506,7 +23732,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1227,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 60
   },
   {
     "name": "University of Insubria",
@@ -22519,7 +23746,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1228,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 61
   },
   {
     "name": "Indian Institute of Technology - Patna",
@@ -22532,7 +23760,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1229,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 63
   },
   {
     "name": "Parthenope University of Naples",
@@ -22545,7 +23774,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1230,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 61
   },
   {
     "name": "Scotland's Rural College",
@@ -22558,7 +23788,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1231,
-    "countryRank": 90
+    "countryRank": 90,
+    "countryTotal": 102
   },
   {
     "name": "Óbuda University",
@@ -22571,7 +23802,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1232,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 9
   },
   {
     "name": "Alborz University of Medical Sciences",
@@ -22584,7 +23816,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1233,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 37
   },
   {
     "name": "Golestan University",
@@ -22597,7 +23830,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1234,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 37
   },
   {
     "name": "Lorestan University of Medical Sciences",
@@ -22610,7 +23844,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1235,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 37
   },
   {
     "name": "Sukkur IBA University",
@@ -22623,7 +23858,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1236,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 29
   },
   {
     "name": "Chitkara University",
@@ -22636,7 +23872,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1237,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 63
   },
   {
     "name": "Egypt-Japan University of Science and Technology",
@@ -22649,7 +23886,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1238,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 10
   },
   {
     "name": "Majmaah University",
@@ -22662,7 +23900,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1239,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 25
   },
   {
     "name": "Malaviya National Institute of Technology",
@@ -22675,7 +23914,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1240,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 63
   },
   {
     "name": "International Institute of Information Technology Hyderabad",
@@ -22688,7 +23928,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1241,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 63
   },
   {
     "name": "University of Salento",
@@ -22704,7 +23945,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1242,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 61
   },
   {
     "name": "National Chung Cheng University",
@@ -22717,7 +23959,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1243,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 18
   },
   {
     "name": "Canadian University Dubai",
@@ -22730,7 +23973,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1244,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 13
   },
   {
     "name": "National University of Sciences & Technology - Pakistan",
@@ -22743,7 +23987,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1245,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 61
   },
   {
     "name": "Skolkovo Institute of Science & Technology",
@@ -22759,7 +24004,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1246,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 27
   },
   {
     "name": "Technische Universitat Wien",
@@ -22772,7 +24018,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1247,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 61
   },
   {
     "name": "Institut National Polytechnique de Grenoble",
@@ -22785,7 +24032,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1248,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 60
   },
   {
     "name": "North West University - South Africa",
@@ -22798,7 +24046,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1249,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 61
   },
   {
     "name": "University of Concepci�n",
@@ -22811,7 +24060,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1250,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 7
   },
   {
     "name": "International Islamic University Malaysia",
@@ -22824,7 +24074,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1251,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 26
   },
   {
     "name": "Applied Science University Bahrain",
@@ -22837,7 +24088,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1252,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "Government College University Faisalabad",
@@ -22850,7 +24102,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1253,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 61
   },
   {
     "name": "Saint Joseph University of Beirut",
@@ -22863,7 +24116,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1254,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 6
   },
   {
     "name": "University of Cape Coast",
@@ -22879,7 +24133,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1255,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "Diponegoro University",
@@ -22892,7 +24147,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1256,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 11
   },
   {
     "name": "Kazakh National Pedagogical University",
@@ -22905,7 +24161,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1257,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 10
   },
   {
     "name": "HSE University (National Research University Higher School of Economics)",
@@ -22918,7 +24175,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1258,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 61
   },
   {
     "name": "Liverpool School of Tropical Medicine",
@@ -22931,7 +24189,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1259,
-    "countryRank": 91
+    "countryRank": 91,
+    "countryTotal": 102
   },
   {
     "name": "Capital Medical University",
@@ -22944,7 +24203,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1260,
-    "countryRank": 162
+    "countryRank": 162,
+    "countryTotal": 224
   },
   {
     "name": "Lincoln University College Malaysia",
@@ -22957,7 +24217,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1261,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 26
   },
   {
     "name": "University of Chemistry and Technology - Prague",
@@ -22970,7 +24231,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1262,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 8
   },
   {
     "name": "Hassan II University of Casablanca",
@@ -22986,7 +24248,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1263,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 3
   },
   {
     "name": "University of Kent",
@@ -22999,7 +24262,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1264,
-    "countryRank": 92
+    "countryRank": 92,
+    "countryTotal": 102
   },
   {
     "name": "Martin Luther University Halle Wittenberg",
@@ -23012,7 +24276,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1265,
-    "countryRank": 79
+    "countryRank": 79,
+    "countryTotal": 84
   },
   {
     "name": "Tokyo University of Agriculture and Technology",
@@ -23028,7 +24293,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1266,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 36
   },
   {
     "name": "Wroclaw University of Science and Technology",
@@ -23044,7 +24310,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1267,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 13
   },
   {
     "name": "North South University",
@@ -23060,7 +24327,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1268,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 6
   },
   {
     "name": "Guru Gobind Singh Indraprastha University",
@@ -23076,7 +24344,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1269,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 63
   },
   {
     "name": "Ferdowsi University of Mashhad",
@@ -23092,7 +24361,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1270,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 37
   },
   {
     "name": "The Robert Gordon University",
@@ -23108,7 +24378,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1271,
-    "countryRank": 93
+    "countryRank": 93,
+    "countryTotal": 102
   },
   {
     "name": "Abo Akademi University",
@@ -23121,7 +24392,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1272,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 10
   },
   {
     "name": "Saint Louis University",
@@ -23134,7 +24406,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1273,
-    "countryRank": 190
+    "countryRank": 190,
+    "countryTotal": 220
   },
   {
     "name": "University of Tromso",
@@ -23147,7 +24420,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1274,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 8
   },
   {
     "name": "Moscow State Institute of International Relations",
@@ -23160,7 +24434,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1275,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 27
   },
   {
     "name": "Mekelle University",
@@ -23173,7 +24448,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1276,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 61
   },
   {
     "name": "Universita di Modena e Reggio Emilia",
@@ -23186,7 +24462,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1277,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 61
   },
   {
     "name": "De La Salle University",
@@ -23199,7 +24476,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1278,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "Universidade Federal de Sao Paulo (UNIFESP)",
@@ -23212,7 +24490,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1279,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 26
   },
   {
     "name": "Indian Institute of Science (IISC) - Bangalore",
@@ -23225,7 +24504,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1280,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 61
   },
   {
     "name": "University at Albany, SUNY",
@@ -23238,7 +24518,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1281,
-    "countryRank": 191
+    "countryRank": 191,
+    "countryTotal": 220
   },
   {
     "name": "University of Rajshahi",
@@ -23251,7 +24532,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1282,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 61
   },
   {
     "name": "Southwest University of Science & Technology - China",
@@ -23267,7 +24549,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1283,
-    "countryRank": 163
+    "countryRank": 163,
+    "countryTotal": 224
   },
   {
     "name": "Menofia University",
@@ -23280,7 +24563,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1284,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 61
   },
   {
     "name": "Minia University",
@@ -23293,7 +24577,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1285,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 61
   },
   {
     "name": "University of Mumbai",
@@ -23306,7 +24591,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1286,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 63
   },
   {
     "name": "Indian Institute of Technology - Hyderabad",
@@ -23319,7 +24605,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1287,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 63
   },
   {
     "name": "Rutgers University Newark",
@@ -23332,7 +24619,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1288,
-    "countryRank": 192
+    "countryRank": 192,
+    "countryTotal": 220
   },
   {
     "name": "Tecnologico de Monterrey",
@@ -23345,7 +24633,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1289,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 61
   },
   {
     "name": "Chengdu University",
@@ -23358,7 +24647,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1290,
-    "countryRank": 164
+    "countryRank": 164,
+    "countryTotal": 224
   },
   {
     "name": "Ahmadu Bello University",
@@ -23371,7 +24661,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1291,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 61
   },
   {
     "name": "AgroParisTech",
@@ -23384,7 +24675,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1292,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 60
   },
   {
     "name": "BOKU University",
@@ -23397,7 +24689,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1293,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 61
   },
   {
     "name": "Suez Canal University",
@@ -23410,7 +24703,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1294,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 61
   },
   {
     "name": "Jadavpur University",
@@ -23423,7 +24717,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1295,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 63
   },
   {
     "name": "American University in Dubai",
@@ -23436,7 +24731,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1296,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 13
   },
   {
     "name": "Ritsumeikan University",
@@ -23449,7 +24745,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1297,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 36
   },
   {
     "name": "Hankuk University of Foreign Studies",
@@ -23462,7 +24759,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1298,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 37
   },
   {
     "name": "University of Brawijaya",
@@ -23475,7 +24773,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1299,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 11
   },
   {
     "name": "Tata Institute of Fundamental Research (TIFR)",
@@ -23488,7 +24787,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1300,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 61
   },
   {
     "name": "Baku State University",
@@ -23501,7 +24801,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1301,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 6
   },
   {
     "name": "University of C�te d'Azur",
@@ -23514,7 +24815,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1302,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 60
   },
   {
     "name": "Shoolini University",
@@ -23527,7 +24829,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1303,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 61
   },
   {
     "name": "Universitat Politecnica de Valencia",
@@ -23540,7 +24843,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1304,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 53
   },
   {
     "name": "Vellore Institute of Technology",
@@ -23553,7 +24857,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1305,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 63
   },
   {
     "name": "University of Alcal� de Henares",
@@ -23566,7 +24871,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1306,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 53
   },
   {
     "name": "Tokyo Medical and Dental University",
@@ -23579,7 +24885,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1307,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 36
   },
   {
     "name": "Kazakh National Agrarian University",
@@ -23592,7 +24899,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1308,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 10
   },
   {
     "name": "Beni-Suef University",
@@ -23605,7 +24913,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1309,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 61
   },
   {
     "name": "University of Massachusetts Boston",
@@ -23621,7 +24930,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1310,
-    "countryRank": 193
+    "countryRank": 193,
+    "countryTotal": 220
   },
   {
     "name": "Gazi University Ankara",
@@ -23637,7 +24947,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1311,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 21
   },
   {
     "name": "Chonbuk National University",
@@ -23650,7 +24961,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1312,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 37
   },
   {
     "name": "Panamerican University",
@@ -23663,7 +24975,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1313,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 9
   },
   {
     "name": "Kasetsart University",
@@ -23676,7 +24989,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1314,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 8
   },
   {
     "name": "Henan Normal University",
@@ -23689,7 +25003,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1315,
-    "countryRank": 165
+    "countryRank": 165,
+    "countryTotal": 224
   },
   {
     "name": "Federal University of Santa Maria",
@@ -23702,7 +25017,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1316,
-    "countryRank": 14
+    "countryRank": 14,
+    "countryTotal": 26
   },
   {
     "name": "Federal University of Paraná",
@@ -23715,7 +25031,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1317,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 26
   },
   {
     "name": "University of Brasília",
@@ -23728,7 +25045,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1318,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 26
   },
   {
     "name": "Chongqing University of Posts and Telecommunications",
@@ -23741,7 +25059,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1319,
-    "countryRank": 166
+    "countryRank": 166,
+    "countryTotal": 224
   },
   {
     "name": "Guangxi Normal University",
@@ -23754,7 +25073,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1320,
-    "countryRank": 167
+    "countryRank": 167,
+    "countryTotal": 224
   },
   {
     "name": "Harbin Medical University",
@@ -23767,7 +25087,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1321,
-    "countryRank": 168
+    "countryRank": 168,
+    "countryTotal": 224
   },
   {
     "name": "Hebei Medical University",
@@ -23780,7 +25101,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1322,
-    "countryRank": 169
+    "countryRank": 169,
+    "countryTotal": 224
   },
   {
     "name": "Hubei University",
@@ -23793,7 +25115,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1323,
-    "countryRank": 170
+    "countryRank": 170,
+    "countryTotal": 224
   },
   {
     "name": "Jiangxi Normal University",
@@ -23806,7 +25129,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1324,
-    "countryRank": 171
+    "countryRank": 171,
+    "countryTotal": 224
   },
   {
     "name": "Shantou University",
@@ -23819,7 +25143,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1325,
-    "countryRank": 172
+    "countryRank": 172,
+    "countryTotal": 224
   },
   {
     "name": "Tianjin University of Technology",
@@ -23832,7 +25157,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1326,
-    "countryRank": 173
+    "countryRank": 173,
+    "countryTotal": 224
   },
   {
     "name": "Xiangtan University",
@@ -23845,7 +25171,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1327,
-    "countryRank": 174
+    "countryRank": 174,
+    "countryTotal": 224
   },
   {
     "name": "University of Cantabria",
@@ -23858,7 +25185,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1328,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 53
   },
   {
     "name": "University of Extremadura",
@@ -23871,7 +25199,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1329,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 53
   },
   {
     "name": "Kindai University",
@@ -23884,7 +25213,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1330,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 36
   },
   {
     "name": "Kitasato University",
@@ -23897,7 +25227,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1331,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 36
   },
   {
     "name": "Shinshu University",
@@ -23910,7 +25241,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1332,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 36
   },
   {
     "name": "Chungbuk National University",
@@ -23923,7 +25255,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1333,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 37
   },
   {
     "name": "Hallym University",
@@ -23936,7 +25269,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1334,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 37
   },
   {
     "name": "Kangwon National University",
@@ -23949,7 +25283,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1335,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 37
   },
   {
     "name": "Stockholm School of Economics",
@@ -23962,7 +25297,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1336,
-    "countryRank": 15
+    "countryRank": 15,
+    "countryTotal": 18
   },
   {
     "name": "Kent State University",
@@ -23975,7 +25311,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1337,
-    "countryRank": 194
+    "countryRank": 194,
+    "countryTotal": 220
   },
   {
     "name": "University of Jinan - Shandong",
@@ -23988,7 +25325,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1338,
-    "countryRank": 175
+    "countryRank": 175,
+    "countryTotal": 224
   },
   {
     "name": "Tiangong University",
@@ -24001,7 +25339,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1339,
-    "countryRank": 176
+    "countryRank": 176,
+    "countryTotal": 224
   },
   {
     "name": "Army Medical University",
@@ -24014,7 +25353,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1340,
-    "countryRank": 177
+    "countryRank": 177,
+    "countryTotal": 224
   },
   {
     "name": "Anhui Agricultural University",
@@ -24027,7 +25367,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1341,
-    "countryRank": 178
+    "countryRank": 178,
+    "countryTotal": 224
   },
   {
     "name": "Xuzhou Medical College",
@@ -24040,7 +25381,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1342,
-    "countryRank": 179
+    "countryRank": 179,
+    "countryTotal": 224
   },
   {
     "name": "Shanxi Medical University",
@@ -24053,7 +25395,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1343,
-    "countryRank": 180
+    "countryRank": 180,
+    "countryTotal": 224
   },
   {
     "name": "Istanbul University Cerrahpasa",
@@ -24066,7 +25409,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1344,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 21
   },
   {
     "name": "SUNY Downstate Health Sciences University",
@@ -24079,7 +25423,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1345,
-    "countryRank": 195
+    "countryRank": 195,
+    "countryTotal": 220
   },
   {
     "name": "Suzhou University of Science and Technology",
@@ -24092,7 +25437,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1346,
-    "countryRank": 181
+    "countryRank": 181,
+    "countryTotal": 224
   },
   {
     "name": "Universidad de Cantabria",
@@ -24105,7 +25451,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1347,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 53
   },
   {
     "name": "Universidad Politecnica de Madrid",
@@ -24118,7 +25465,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1348,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 53
   },
   {
     "name": "Toronto Metropolitan University",
@@ -24131,7 +25479,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1349,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 35
   },
   {
     "name": "ISCTE-University Institute of Lisbon",
@@ -24144,7 +25493,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1350,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 9
   },
   {
     "name": "National University of Uzbekistan",
@@ -24157,7 +25507,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1351,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "Taras Shevchenko National University of Kyiv",
@@ -24170,7 +25521,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1352,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 3
   },
   {
     "name": "Pakistan Institute of Engineering and Applied Sciences",
@@ -24183,7 +25535,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1353,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 29
   },
   {
     "name": "Jamia Millia Islamia",
@@ -24196,7 +25549,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1354,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 61
   },
   {
     "name": "University of Peshawar",
@@ -24212,7 +25566,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1355,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 29
   },
   {
     "name": "Segi University",
@@ -24225,7 +25580,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1356,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 26
   },
   {
     "name": "Sofia University",
@@ -24238,7 +25594,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1357,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Far Eastern Federal University",
@@ -24251,7 +25608,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1358,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 27
   },
   {
     "name": "University Central de Venezuela",
@@ -24264,7 +25622,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1359,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Auezov South Kazakhstan State University",
@@ -24277,7 +25636,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1360,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 10
   },
   {
     "name": "Universitetet i Stavanger",
@@ -24290,7 +25650,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1361,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 61
   },
   {
     "name": "Loyola University Chicago",
@@ -24306,7 +25667,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1362,
-    "countryRank": 196
+    "countryRank": 196,
+    "countryTotal": 220
   },
   {
     "name": "Universidad Peruana Cayetano Heredia",
@@ -24319,7 +25681,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1363,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 61
   },
   {
     "name": "University of Pecs",
@@ -24332,7 +25695,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1364,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 9
   },
   {
     "name": "Kaunas University of Technology",
@@ -24345,7 +25709,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1365,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 4
   },
   {
     "name": "Vytautas Magnus University",
@@ -24358,7 +25723,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1366,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "Plekhanov Russian University of Economics",
@@ -24371,7 +25737,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1367,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 27
   },
   {
     "name": "University of Baghdad",
@@ -24384,7 +25751,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1368,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "University of the Andes",
@@ -24397,7 +25765,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1369,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 61
   },
   {
     "name": "Taibah University",
@@ -24410,7 +25779,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1370,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 61
   },
   {
     "name": "Universidad Nacional de Colombia",
@@ -24423,7 +25793,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1371,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 61
   },
   {
     "name": "Politecnico di Bari",
@@ -24436,7 +25807,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1372,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 61
   },
   {
     "name": "Northwest University Xi'an",
@@ -24449,7 +25821,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1373,
-    "countryRank": 182
+    "countryRank": 182,
+    "countryTotal": 224
   },
   {
     "name": "Palacky University Olomouc",
@@ -24462,7 +25835,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1374,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 61
   },
   {
     "name": "Kumamoto University",
@@ -24478,7 +25852,8 @@
     },
     "appearances": 2,
     "aggregatedRank": 1375,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 36
   },
   {
     "name": "Bangladesh University of Engineering and Technology (BUET)",
@@ -24491,7 +25866,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1376,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 6
   },
   {
     "name": "Riga Technical University",
@@ -24504,7 +25880,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1377,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Vietnam National University Hanoi",
@@ -24517,7 +25894,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1378,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 6
   },
   {
     "name": "Khoja Akhmet Yassawi International Kazakh-Turkish University",
@@ -24530,7 +25908,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1379,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 10
   },
   {
     "name": "European University Institute",
@@ -24543,7 +25922,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1380,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 61
   },
   {
     "name": "Oklahoma State University - Stillwater",
@@ -24556,7 +25936,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1381,
-    "countryRank": 197
+    "countryRank": 197,
+    "countryTotal": 220
   },
   {
     "name": "Haramaya University",
@@ -24569,7 +25950,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1382,
-    "countryRank": 38
+    "countryRank": 38,
+    "countryTotal": 61
   },
   {
     "name": "Universidad de Palermo",
@@ -24582,7 +25964,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1383,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 8
   },
   {
     "name": "Holy Spirit University of Kaslik",
@@ -24595,7 +25978,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1384,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 6
   },
   {
     "name": "Concordia University - Canada",
@@ -24608,7 +25992,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1385,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 35
   },
   {
     "name": "Dortmund University of Technology",
@@ -24621,7 +26006,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1386,
-    "countryRank": 80
+    "countryRank": 80,
+    "countryTotal": 84
   },
   {
     "name": "Hong Kong Metropolitan University",
@@ -24634,7 +26020,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1387,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 9
   },
   {
     "name": "University of Antioqu�a",
@@ -24647,7 +26034,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1388,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 9
   },
   {
     "name": "University of Rosario",
@@ -24660,7 +26048,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1389,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 9
   },
   {
     "name": "Kuwait University",
@@ -24673,7 +26062,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1390,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 3
   },
   {
     "name": "V.N. Karazin Kharkiv National University",
@@ -24686,7 +26076,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1391,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 3
   },
   {
     "name": "Technological University Dublin",
@@ -24699,7 +26090,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1392,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 9
   },
   {
     "name": "University Djillali Liabes Sidi Bel Abbes",
@@ -24712,7 +26104,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1393,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 61
   },
   {
     "name": "Pontifical Catholic University of Valparaiso",
@@ -24725,7 +26118,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1394,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 7
   },
   {
     "name": "University of Tunku Abdul Rahman",
@@ -24738,7 +26132,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1395,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 26
   },
   {
     "name": "Al Ahlia University",
@@ -24751,7 +26146,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1396,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 4
   },
   {
     "name": "University of Bras�lia",
@@ -24764,7 +26160,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1397,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 26
   },
   {
     "name": "University of Havana",
@@ -24777,7 +26174,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1398,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "University San Francisco de Quito",
@@ -24790,7 +26188,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1399,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 3
   },
   {
     "name": "University of Hyderabad",
@@ -24803,7 +26202,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1400,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 63
   },
   {
     "name": "University of Latvia",
@@ -24816,7 +26216,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1401,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "M�xico Autonomous Institute of Technology",
@@ -24829,7 +26230,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1402,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 9
   },
   {
     "name": "University of Engineering and Technology Lahore",
@@ -24842,7 +26244,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1403,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 29
   },
   {
     "name": "AGH University of Science and Technology",
@@ -24855,7 +26258,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1404,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 13
   },
   {
     "name": "University of Wroclaw",
@@ -24868,7 +26272,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1405,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 13
   },
   {
     "name": "National Technical University of Ukraine",
@@ -24881,7 +26286,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1406,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 3
   },
   {
     "name": "University of Montevideo",
@@ -24894,7 +26300,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1407,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 3
   },
   {
     "name": "The New School",
@@ -24907,7 +26314,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1408,
-    "countryRank": 198
+    "countryRank": 198,
+    "countryTotal": 220
   },
   {
     "name": "Gda�sk University of Technology",
@@ -24920,7 +26328,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1409,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 13
   },
   {
     "name": "Vietnam National University Hochiminh City",
@@ -24933,7 +26342,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1410,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 6
   },
   {
     "name": "Indian Institute of Technology Gandhinagar",
@@ -24946,7 +26356,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1411,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 63
   },
   {
     "name": "Zurich University of Applied Sciences",
@@ -24959,7 +26370,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1412,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 13
   },
   {
     "name": "SRM Institute Of Science and Technology ( Deemed University)",
@@ -24972,7 +26384,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1413,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 63
   },
   {
     "name": "Federal University of São Carlos",
@@ -24985,7 +26398,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1414,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 26
   },
   {
     "name": "Federal University of Viçosa",
@@ -24998,7 +26412,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1415,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 26
   },
   {
     "name": "Brock University",
@@ -25011,7 +26426,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1416,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 35
   },
   {
     "name": "Anhui Normal University",
@@ -25024,7 +26440,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1417,
-    "countryRank": 183
+    "countryRank": 183,
+    "countryTotal": 224
   },
   {
     "name": "Capital Normal University",
@@ -25037,7 +26454,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1418,
-    "countryRank": 184
+    "countryRank": 184,
+    "countryTotal": 224
   },
   {
     "name": "Central University of Finance and Economics",
@@ -25050,7 +26468,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1419,
-    "countryRank": 185
+    "countryRank": 185,
+    "countryTotal": 224
   },
   {
     "name": "Guangzhou University of Traditional Chinese Medicine",
@@ -25063,7 +26482,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1420,
-    "countryRank": 186
+    "countryRank": 186,
+    "countryTotal": 224
   },
   {
     "name": "Heilongjiang University",
@@ -25076,7 +26496,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1421,
-    "countryRank": 187
+    "countryRank": 187,
+    "countryTotal": 224
   },
   {
     "name": "Shandong Normal University",
@@ -25089,7 +26510,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1422,
-    "countryRank": 188
+    "countryRank": 188,
+    "countryTotal": 224
   },
   {
     "name": "Shanghai University of Traditional Chinese Medicine and Pharmacology",
@@ -25102,7 +26524,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1423,
-    "countryRank": 189
+    "countryRank": 189,
+    "countryTotal": 224
   },
   {
     "name": "Shenyang Pharmaceutical University",
@@ -25115,7 +26538,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1424,
-    "countryRank": 190
+    "countryRank": 190,
+    "countryTotal": 224
   },
   {
     "name": "Xi'an University of Architecture and Technology",
@@ -25128,7 +26552,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1425,
-    "countryRank": 191
+    "countryRank": 191,
+    "countryTotal": 224
   },
   {
     "name": "Yantai University",
@@ -25141,7 +26566,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1426,
-    "countryRank": 192
+    "countryRank": 192,
+    "countryTotal": 224
   },
   {
     "name": "University of Antioquía",
@@ -25154,7 +26580,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1427,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 9
   },
   {
     "name": "University of Kassel",
@@ -25167,7 +26594,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1428,
-    "countryRank": 81
+    "countryRank": 81,
+    "countryTotal": 84
   },
   {
     "name": "University of Malaya",
@@ -25180,7 +26608,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1429,
-    "countryRank": 39
+    "countryRank": 39,
+    "countryTotal": 53
   },
   {
     "name": "University of Poitiers",
@@ -25193,7 +26622,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1430,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 60
   },
   {
     "name": "Universite Savoie Mont Blanc",
@@ -25206,7 +26636,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1431,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 60
   },
   {
     "name": "University of Versailles Saint-Quentin-en-Yvelines",
@@ -25219,7 +26650,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1432,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 60
   },
   {
     "name": "Indian Institute of Technology - Bombay",
@@ -25232,7 +26664,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1433,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 63
   },
   {
     "name": "Augusta State University",
@@ -25245,7 +26678,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1434,
-    "countryRank": 199
+    "countryRank": 199,
+    "countryTotal": 220
   },
   {
     "name": "Montana State University",
@@ -25258,7 +26692,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1435,
-    "countryRank": 200
+    "countryRank": 200,
+    "countryTotal": 220
   },
   {
     "name": "University of Texas at El Paso",
@@ -25271,7 +26706,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1436,
-    "countryRank": 201
+    "countryRank": 201,
+    "countryTotal": 220
   },
   {
     "name": "Guangxi Medical University",
@@ -25284,7 +26720,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1437,
-    "countryRank": 193
+    "countryRank": 193,
+    "countryTotal": 224
   },
   {
     "name": "Qingdao Agricultural University",
@@ -25297,7 +26734,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1438,
-    "countryRank": 194
+    "countryRank": 194,
+    "countryTotal": 224
   },
   {
     "name": "Yangtze University",
@@ -25310,7 +26748,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1439,
-    "countryRank": 195
+    "countryRank": 195,
+    "countryTotal": 224
   },
   {
     "name": "Zhejiang A & F University",
@@ -25323,7 +26762,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1440,
-    "countryRank": 196
+    "countryRank": 196,
+    "countryTotal": 224
   },
   {
     "name": "Dongguan University of Technology",
@@ -25336,7 +26776,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1441,
-    "countryRank": 197
+    "countryRank": 197,
+    "countryTotal": 224
   },
   {
     "name": "New York University of Abu Dhabi",
@@ -25349,7 +26790,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1442,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 13
   },
   {
     "name": "North China University of Water Resources and Electric Power",
@@ -25362,7 +26804,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1443,
-    "countryRank": 198
+    "countryRank": 198,
+    "countryTotal": 224
   },
   {
     "name": "Kermanshah University of Medical Sciences",
@@ -25375,7 +26818,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1444,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 37
   },
   {
     "name": "Abdullah Gul University",
@@ -25388,7 +26832,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1445,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 21
   },
   {
     "name": "Ahvaz Jundishapur University Medical Sciences",
@@ -25401,7 +26846,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1446,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 37
   },
   {
     "name": "An-Najah National University",
@@ -25414,7 +26860,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1447,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Gazipur Agricultural University",
@@ -25427,7 +26874,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1448,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 6
   },
   {
     "name": "Imt Nord Europe",
@@ -25440,7 +26888,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1449,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 60
   },
   {
     "name": "International University of Rabat",
@@ -25453,7 +26902,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1450,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 3
   },
   {
     "name": "Iqra University",
@@ -25466,7 +26916,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1451,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 29
   },
   {
     "name": "Istanbul Medipol University",
@@ -25479,7 +26930,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1452,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 21
   },
   {
     "name": "Mahsa University",
@@ -25492,7 +26944,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1453,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 26
   },
   {
     "name": "Marie and Louis Pasteur University",
@@ -25505,7 +26958,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1454,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 60
   },
   {
     "name": "Shahroud University Medical Sciences",
@@ -25518,7 +26972,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1455,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 37
   },
   {
     "name": "Sr University",
@@ -25531,7 +26986,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1456,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 63
   },
   {
     "name": "University of Leoben",
@@ -25544,7 +27000,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1457,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 13
   },
   {
     "name": "University of Notre Dame Australia",
@@ -25557,7 +27014,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1458,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 41
   },
   {
     "name": "Daffodil International University",
@@ -25570,7 +27028,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1459,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 6
   },
   {
     "name": "Jahangirnagar University",
@@ -25583,7 +27042,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1460,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 6
   },
   {
     "name": "University of Ontario Institute of Technology",
@@ -25596,7 +27056,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1461,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 35
   },
   {
     "name": "University of Gesamthochschule Hagen",
@@ -25609,7 +27070,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1462,
-    "countryRank": 82
+    "countryRank": 82,
+    "countryTotal": 84
   },
   {
     "name": "University Pablo de Olavide",
@@ -25622,7 +27084,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1463,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 53
   },
   {
     "name": "Ecole Centrale de Lyon",
@@ -25635,7 +27098,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1464,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 60
   },
   {
     "name": "Arts et Métiers",
@@ -25648,7 +27112,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1465,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 60
   },
   {
     "name": "National Veterinary School of Alfort",
@@ -25661,7 +27126,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1466,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 60
   },
   {
     "name": "University Panthéon-Sorbonne (Paris I)",
@@ -25674,7 +27140,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1467,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 60
   },
   {
     "name": "University of Western Brittany",
@@ -25687,7 +27154,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1468,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 60
   },
   {
     "name": "Alagappa University",
@@ -25700,7 +27168,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1469,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 63
   },
   {
     "name": "Jamia Hamdard University",
@@ -25713,7 +27182,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1470,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 63
   },
   {
     "name": "Birjand University of Medical Sciences",
@@ -25726,7 +27196,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1471,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 37
   },
   {
     "name": "Guilan University of Medical Sciences",
@@ -25739,7 +27210,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1472,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 37
   },
   {
     "name": "K.N.Toosi University of Technology",
@@ -25752,7 +27224,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1473,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 37
   },
   {
     "name": "Kurdistan University of Medical Sciences",
@@ -25765,7 +27238,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1474,
-    "countryRank": 30
+    "countryRank": 30,
+    "countryTotal": 37
   },
   {
     "name": "Mazandaran University of Medical Sciences",
@@ -25778,7 +27252,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1475,
-    "countryRank": 31
+    "countryRank": 31,
+    "countryTotal": 37
   },
   {
     "name": "Rafsanjan University of Medical Sciences",
@@ -25791,7 +27266,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1476,
-    "countryRank": 32
+    "countryRank": 32,
+    "countryTotal": 37
   },
   {
     "name": "Urmia University",
@@ -25804,7 +27280,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1477,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 37
   },
   {
     "name": "Zahedan University of Medical Sciences",
@@ -25817,7 +27294,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1478,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 37
   },
   {
     "name": "Zanjan University of Medical Sciences",
@@ -25830,7 +27308,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1479,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 37
   },
   {
     "name": "Reykjavík University",
@@ -25843,7 +27322,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1480,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "University of Foggia",
@@ -25856,7 +27336,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1481,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 61
   },
   {
     "name": "Al al-Bayt University",
@@ -25869,7 +27350,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1482,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 11
   },
   {
     "name": "Al-Isra University",
@@ -25882,7 +27364,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1483,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 11
   },
   {
     "name": "Al-Zaytoonah University of Jordan",
@@ -25895,7 +27378,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1484,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 11
   },
   {
     "name": "University of Petra",
@@ -25908,7 +27392,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1485,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 11
   },
   {
     "name": "Wakayama Medical University",
@@ -25921,7 +27406,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1486,
-    "countryRank": 33
+    "countryRank": 33,
+    "countryTotal": 36
   },
   {
     "name": "Ghulam Ishaq Khan Institute of Engineering Sciences and Technology",
@@ -25934,7 +27420,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1487,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 29
   },
   {
     "name": "University of Central Punjab",
@@ -25947,7 +27434,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1488,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 29
   },
   {
     "name": "University of Engineering and Technology Taxila",
@@ -25960,7 +27448,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1489,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 29
   },
   {
     "name": "University of Gujrat",
@@ -25973,7 +27462,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1490,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 29
   },
   {
     "name": "Medical University of Lodz",
@@ -25986,7 +27476,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1491,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 13
   },
   {
     "name": "St. Petersburg State Mining Institute (Technical University)",
@@ -25999,7 +27490,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1492,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 27
   },
   {
     "name": "King Saud bin Abdulaziz University for Health Sciences",
@@ -26012,7 +27504,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1493,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 25
   },
   {
     "name": "Halmstad University College",
@@ -26025,7 +27518,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1494,
-    "countryRank": 16
+    "countryRank": 16,
+    "countryTotal": 18
   },
   {
     "name": "Jönköping University College",
@@ -26038,7 +27532,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1495,
-    "countryRank": 17
+    "countryRank": 17,
+    "countryTotal": 18
   },
   {
     "name": "Bahcesehir University",
@@ -26051,7 +27546,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1496,
-    "countryRank": 19
+    "countryRank": 19,
+    "countryTotal": 21
   },
   {
     "name": "Glasgow Caledonian University",
@@ -26064,7 +27560,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1497,
-    "countryRank": 94
+    "countryRank": 94,
+    "countryTotal": 102
   },
   {
     "name": "Roehampton University of Surrey",
@@ -26077,7 +27574,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1498,
-    "countryRank": 95
+    "countryRank": 95,
+    "countryTotal": 102
   },
   {
     "name": "Sheffield Hallam University",
@@ -26090,7 +27588,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1499,
-    "countryRank": 96
+    "countryRank": 96,
+    "countryTotal": 102
   },
   {
     "name": "University of Wolverhampton",
@@ -26103,7 +27602,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1500,
-    "countryRank": 97
+    "countryRank": 97,
+    "countryTotal": 102
   },
   {
     "name": "Hanoi Medical University",
@@ -26116,7 +27616,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1501,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 6
   },
   {
     "name": "Catholic University of America",
@@ -26129,7 +27630,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1502,
-    "countryRank": 202
+    "countryRank": 202,
+    "countryTotal": 220
   },
   {
     "name": "Florida Atlantic University",
@@ -26142,7 +27644,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1503,
-    "countryRank": 203
+    "countryRank": 203,
+    "countryTotal": 220
   },
   {
     "name": "Northern Illinois University",
@@ -26155,7 +27658,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1504,
-    "countryRank": 204
+    "countryRank": 204,
+    "countryTotal": 220
   },
   {
     "name": "Southern Illinois University at Carbondale",
@@ -26168,7 +27672,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1505,
-    "countryRank": 205
+    "countryRank": 205,
+    "countryTotal": 220
   },
   {
     "name": "Clark University",
@@ -26181,7 +27686,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1506,
-    "countryRank": 206
+    "countryRank": 206,
+    "countryTotal": 220
   },
   {
     "name": "Portland State University",
@@ -26194,7 +27700,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1507,
-    "countryRank": 207
+    "countryRank": 207,
+    "countryTotal": 220
   },
   {
     "name": "College of William and Mary",
@@ -26207,7 +27714,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1508,
-    "countryRank": 208
+    "countryRank": 208,
+    "countryTotal": 220
   },
   {
     "name": "Leeds Beckett University",
@@ -26220,7 +27728,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1509,
-    "countryRank": 98
+    "countryRank": 98,
+    "countryTotal": 102
   },
   {
     "name": "Siberian Federal University",
@@ -26233,7 +27742,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1510,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 27
   },
   {
     "name": "Open University of Catalonia",
@@ -26246,7 +27756,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1511,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 53
   },
   {
     "name": "Birmingham City University",
@@ -26259,7 +27770,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1512,
-    "countryRank": 99
+    "countryRank": 99,
+    "countryTotal": 102
   },
   {
     "name": "Bucharest University of Economic Studies",
@@ -26272,7 +27784,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1513,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "International Islamic University Islamabad",
@@ -26285,7 +27798,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1514,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 29
   },
   {
     "name": "JSS Academy of Higher Education and Research",
@@ -26298,7 +27812,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1515,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 63
   },
   {
     "name": "Delhi Technological University",
@@ -26311,7 +27826,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1516,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 63
   },
   {
     "name": "National Institute of Technology Silchar",
@@ -26324,7 +27840,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1517,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 63
   },
   {
     "name": "Ozyegin University",
@@ -26337,7 +27854,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1518,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 21
   },
   {
     "name": "Northern Border University",
@@ -26350,7 +27868,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1519,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 25
   },
   {
     "name": "Baqiyatallah University of Medical Sciences",
@@ -26363,7 +27882,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1520,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 37
   },
   {
     "name": "Innopolis University",
@@ -26376,7 +27896,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1521,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 27
   },
   {
     "name": "European University Cyprus",
@@ -26389,7 +27910,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1522,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 7
   },
   {
     "name": "Khwaja Fareed University of Engineering and Information Technology",
@@ -26402,7 +27924,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1523,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 29
   },
   {
     "name": "University of Nova Gorica",
@@ -26415,7 +27938,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1524,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 3
   },
   {
     "name": "Capital University of Science and Technology",
@@ -26428,7 +27952,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1525,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 29
   },
   {
     "name": "KL University",
@@ -26441,7 +27966,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1526,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 63
   },
   {
     "name": "University of Malakand",
@@ -26454,7 +27980,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1527,
-    "countryRank": 28
+    "countryRank": 28,
+    "countryTotal": 29
   },
   {
     "name": "Najran University",
@@ -26467,7 +27994,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1528,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 25
   },
   {
     "name": "Reichman University",
@@ -26480,7 +28008,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1529,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 8
   },
   {
     "name": "Shahrekord University of Medical Sciences",
@@ -26493,7 +28022,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1530,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 37
   },
   {
     "name": "Shri Mata Vaishno Devi University",
@@ -26506,7 +28036,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1531,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 63
   },
   {
     "name": "Siksha O Anusandhan",
@@ -26519,7 +28050,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1532,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 63
   },
   {
     "name": "Amity University Rajasthan - Jaipur",
@@ -26532,7 +28064,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1533,
-    "countryRank": 61
+    "countryRank": 61,
+    "countryTotal": 63
   },
   {
     "name": "Universidad de Antioquia",
@@ -26545,7 +28078,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1534,
-    "countryRank": 40
+    "countryRank": 40,
+    "countryTotal": 61
   },
   {
     "name": "Aga Khan University",
@@ -26558,7 +28092,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1535,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 61
   },
   {
     "name": "London Business School",
@@ -26571,7 +28106,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1536,
-    "countryRank": 100
+    "countryRank": 100,
+    "countryTotal": 102
   },
   {
     "name": "Universidade Federal de Santa Catarina (UFSC)",
@@ -26584,7 +28120,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1537,
-    "countryRank": 20
+    "countryRank": 20,
+    "countryTotal": 26
   },
   {
     "name": "Universitat Rovira i Virgili",
@@ -26597,7 +28134,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1538,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 53
   },
   {
     "name": "Manipal Academy of Higher Education",
@@ -26610,7 +28148,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1539,
-    "countryRank": 42
+    "countryRank": 42,
+    "countryTotal": 61
   },
   {
     "name": "University of Arkansas",
@@ -26623,7 +28162,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1540,
-    "countryRank": 209
+    "countryRank": 209,
+    "countryTotal": 220
   },
   {
     "name": "Nguyen Tat Thanh University (NTTU)",
@@ -26636,7 +28176,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1541,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 61
   },
   {
     "name": "Mohammed V University in Rabat",
@@ -26649,7 +28190,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1542,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 61
   },
   {
     "name": "Villanova University",
@@ -26662,7 +28204,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1543,
-    "countryRank": 210
+    "countryRank": 210,
+    "countryTotal": 220
   },
   {
     "name": "Universidad de Concepcion",
@@ -26675,7 +28218,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1544,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 61
   },
   {
     "name": "Universiti Teknologi Petronas",
@@ -26688,7 +28232,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1545,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 61
   },
   {
     "name": "University of Agder",
@@ -26701,7 +28246,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1546,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 61
   },
   {
     "name": "Azerbaijan State Oil and Industry University",
@@ -26714,7 +28260,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1547,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 6
   },
   {
     "name": "National University de C�rdoba",
@@ -26727,7 +28274,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1548,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 8
   },
   {
     "name": "Dubai University College",
@@ -26740,7 +28288,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1549,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 13
   },
   {
     "name": "Azerbaijan Technical University",
@@ -26753,7 +28302,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1550,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 6
   },
   {
     "name": "European University of Lefke",
@@ -26766,7 +28316,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1551,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 7
   },
   {
     "name": "Mendel University of Agriculture and Forestry",
@@ -26779,7 +28330,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1552,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 8
   },
   {
     "name": "University of D�sseldorf",
@@ -26792,7 +28344,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1553,
-    "countryRank": 83
+    "countryRank": 83,
+    "countryTotal": 84
   },
   {
     "name": "University of Franche-Comt�",
@@ -26805,7 +28358,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1554,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 60
   },
   {
     "name": "Bina Nusantara University",
@@ -26818,7 +28372,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1555,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 11
   },
   {
     "name": "Seoul University",
@@ -26831,7 +28386,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1556,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 37
   },
   {
     "name": "Vilnius Gediminas Technical University",
@@ -26844,7 +28400,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1557,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "An�huac University",
@@ -26857,7 +28414,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1558,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 9
   },
   {
     "name": "Multimedia University",
@@ -26870,7 +28428,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1559,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 26
   },
   {
     "name": "University of Stavanger",
@@ -26883,7 +28442,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1560,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 8
   },
   {
     "name": "University of Santo Tomas",
@@ -26896,7 +28456,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1561,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "University of Gdansk",
@@ -26909,7 +28470,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1562,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 13
   },
   {
     "name": "Altai State University",
@@ -26922,7 +28484,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1563,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 27
   },
   {
     "name": "Prince of Songkla University",
@@ -26935,7 +28498,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1564,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 8
   },
   {
     "name": "Belarusian National Technical University",
@@ -26948,7 +28512,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1565,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "O.P. Jindal Global University",
@@ -26961,7 +28526,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1566,
-    "countryRank": 62
+    "countryRank": 62,
+    "countryTotal": 63
   },
   {
     "name": "Effat University",
@@ -26974,7 +28540,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1567,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 25
   },
   {
     "name": "City College of New York (CUNY)",
@@ -26987,7 +28554,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1568,
-    "countryRank": 211
+    "countryRank": 211,
+    "countryTotal": 220
   },
   {
     "name": "Montana State University Bozeman",
@@ -27000,7 +28568,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1569,
-    "countryRank": 212
+    "countryRank": 212,
+    "countryTotal": 220
   },
   {
     "name": "Indiana University Indianapolis",
@@ -27013,7 +28582,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1570,
-    "countryRank": 213
+    "countryRank": 213,
+    "countryTotal": 220
   },
   {
     "name": "Universitat de les Illes Balears",
@@ -27026,7 +28596,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1571,
-    "countryRank": 43
+    "countryRank": 43,
+    "countryTotal": 53
   },
   {
     "name": "California State University Los Angeles",
@@ -27039,7 +28610,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1572,
-    "countryRank": 214
+    "countryRank": 214,
+    "countryTotal": 220
   },
   {
     "name": "AGH University of Krakow",
@@ -27052,7 +28624,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1573,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 61
   },
   {
     "name": "Iran University of Science & Technology",
@@ -27065,7 +28638,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1574,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 61
   },
   {
     "name": "Kwame Nkrumah University Science & Technology",
@@ -27078,7 +28652,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1575,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 61
   },
   {
     "name": "University of Ioannina",
@@ -27091,7 +28666,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1576,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 61
   },
   {
     "name": "Universidade de Brasilia",
@@ -27104,7 +28680,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1577,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 26
   },
   {
     "name": "Foshan University",
@@ -27117,7 +28694,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1578,
-    "countryRank": 199
+    "countryRank": 199,
+    "countryTotal": 224
   },
   {
     "name": "University of Alcala",
@@ -27130,7 +28708,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1579,
-    "countryRank": 44
+    "countryRank": 44,
+    "countryTotal": 53
   },
   {
     "name": "Sohag University",
@@ -27143,7 +28722,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1580,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 61
   },
   {
     "name": "American University of Central Asia",
@@ -27156,7 +28736,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1581,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 2
   },
   {
     "name": "Baku Engineering University",
@@ -27169,7 +28750,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1582,
-    "countryRank": 5
+    "countryRank": 5,
+    "countryTotal": 6
   },
   {
     "name": "Macao Polytechnic University",
@@ -27182,7 +28764,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1583,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "University of the Andes - Chile",
@@ -27195,7 +28778,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1584,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 7
   },
   {
     "name": "University of Valladolid",
@@ -27208,7 +28792,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1585,
-    "countryRank": 45
+    "countryRank": 45,
+    "countryTotal": 53
   },
   {
     "name": "Princess Sumaya University for Technology",
@@ -27221,7 +28806,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1586,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 11
   },
   {
     "name": "Gulf University for Science and Technology",
@@ -27234,7 +28820,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1587,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 3
   },
   {
     "name": "Karaganda State Buketov University",
@@ -27247,7 +28834,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1588,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 10
   },
   {
     "name": "University of Maribor",
@@ -27260,7 +28848,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1589,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 3
   },
   {
     "name": "Khon Kaen University",
@@ -27273,7 +28862,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1590,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 8
   },
   {
     "name": "Catholic University of Uruguay",
@@ -27286,7 +28876,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1591,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 3
   },
   {
     "name": "Tashkent State Technical University",
@@ -27299,7 +28890,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1592,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "Catholic University Andres Bello",
@@ -27312,7 +28904,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1593,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "The College of Mexico",
@@ -27325,7 +28918,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1594,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 9
   },
   {
     "name": "Ibero-American University",
@@ -27338,7 +28932,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1595,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 9
   },
   {
     "name": "European University of Madrid",
@@ -27351,7 +28946,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1596,
-    "countryRank": 46
+    "countryRank": 46,
+    "countryTotal": 53
   },
   {
     "name": "Federal University of Bahia",
@@ -27364,7 +28960,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1597,
-    "countryRank": 22
+    "countryRank": 22,
+    "countryTotal": 26
   },
   {
     "name": "Federal University of Pelotas",
@@ -27377,7 +28974,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1598,
-    "countryRank": 23
+    "countryRank": 23,
+    "countryTotal": 26
   },
   {
     "name": "Federal University of Pernambuco",
@@ -27390,7 +28988,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1599,
-    "countryRank": 24
+    "countryRank": 24,
+    "countryTotal": 26
   },
   {
     "name": "Federal University of Ceará",
@@ -27403,7 +29002,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1600,
-    "countryRank": 25
+    "countryRank": 25,
+    "countryTotal": 26
   },
   {
     "name": "Rio de Janeiro State University",
@@ -27416,7 +29016,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1601,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 26
   },
   {
     "name": "Chengdu University of Traditional Chinese Medicine",
@@ -27429,7 +29030,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1602,
-    "countryRank": 200
+    "countryRank": 200,
+    "countryTotal": 224
   },
   {
     "name": "Dalian Medical University",
@@ -27442,7 +29044,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1603,
-    "countryRank": 201
+    "countryRank": 201,
+    "countryTotal": 224
   },
   {
     "name": "Gansu Agricultural University",
@@ -27455,7 +29058,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1604,
-    "countryRank": 202
+    "countryRank": 202,
+    "countryTotal": 224
   },
   {
     "name": "Hebei Normal University",
@@ -27468,7 +29072,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1605,
-    "countryRank": 203
+    "countryRank": 203,
+    "countryTotal": 224
   },
   {
     "name": "Henan Agricultural University",
@@ -27481,7 +29086,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1606,
-    "countryRank": 204
+    "countryRank": 204,
+    "countryTotal": 224
   },
   {
     "name": "Liaocheng Teachers University",
@@ -27494,7 +29100,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1607,
-    "countryRank": 205
+    "countryRank": 205,
+    "countryTotal": 224
   },
   {
     "name": "Huaqiao University",
@@ -27507,7 +29114,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1608,
-    "countryRank": 206
+    "countryRank": 206,
+    "countryTotal": 224
   },
   {
     "name": "Ningxia University",
@@ -27520,7 +29128,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1609,
-    "countryRank": 207
+    "countryRank": 207,
+    "countryTotal": 224
   },
   {
     "name": "University of Castilla-La Mancha",
@@ -27533,7 +29142,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1610,
-    "countryRank": 47
+    "countryRank": 47,
+    "countryTotal": 53
   },
   {
     "name": "University of Cádiz",
@@ -27546,7 +29156,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1611,
-    "countryRank": 48
+    "countryRank": 48,
+    "countryTotal": 53
   },
   {
     "name": "University of Las Palmas de Gran Canaria",
@@ -27559,7 +29170,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1612,
-    "countryRank": 49
+    "countryRank": 49,
+    "countryTotal": 53
   },
   {
     "name": "Jaume I University",
@@ -27572,7 +29184,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1613,
-    "countryRank": 50
+    "countryRank": 50,
+    "countryTotal": 53
   },
   {
     "name": "Tokushima University",
@@ -27585,7 +29198,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1614,
-    "countryRank": 34
+    "countryRank": 34,
+    "countryTotal": 36
   },
   {
     "name": "Yokohama City University",
@@ -27598,7 +29212,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1615,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 36
   },
   {
     "name": "Gyeongsang National University",
@@ -27611,7 +29226,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1616,
-    "countryRank": 35
+    "countryRank": 35,
+    "countryTotal": 37
   },
   {
     "name": "Pukyong National University",
@@ -27624,7 +29240,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1617,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 37
   },
   {
     "name": "Islamia University Bahawalpur",
@@ -27637,7 +29254,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1618,
-    "countryRank": 29
+    "countryRank": 29,
+    "countryTotal": 29
   },
   {
     "name": "Nicolaus Copernicus University",
@@ -27650,7 +29268,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1619,
-    "countryRank": 12
+    "countryRank": 12,
+    "countryTotal": 13
   },
   {
     "name": "Marmara University",
@@ -27663,7 +29282,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1620,
-    "countryRank": 21
+    "countryRank": 21,
+    "countryTotal": 21
   },
   {
     "name": "University of Central Lancashire",
@@ -27676,7 +29296,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1621,
-    "countryRank": 101
+    "countryRank": 101,
+    "countryTotal": 102
   },
   {
     "name": "University of Arkansas for Medical Sciences",
@@ -27689,7 +29310,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1622,
-    "countryRank": 215
+    "countryRank": 215,
+    "countryTotal": 220
   },
   {
     "name": "Amherst College",
@@ -27702,7 +29324,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1623,
-    "countryRank": 216
+    "countryRank": 216,
+    "countryTotal": 220
   },
   {
     "name": "North Dakota State University",
@@ -27715,7 +29338,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1624,
-    "countryRank": 217
+    "countryRank": 217,
+    "countryTotal": 220
   },
   {
     "name": "University of Girona",
@@ -27728,7 +29352,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1625,
-    "countryRank": 51
+    "countryRank": 51,
+    "countryTotal": 53
   },
   {
     "name": "China Jiliang University",
@@ -27741,7 +29366,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1626,
-    "countryRank": 208
+    "countryRank": 208,
+    "countryTotal": 224
   },
   {
     "name": "Linnaeus University",
@@ -27754,7 +29380,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1627,
-    "countryRank": 18
+    "countryRank": 18,
+    "countryTotal": 18
   },
   {
     "name": "Hunan Agricultural University",
@@ -27767,7 +29394,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1628,
-    "countryRank": 209
+    "countryRank": 209,
+    "countryTotal": 224
   },
   {
     "name": "Shaanxi University of Science and Technology",
@@ -27780,7 +29408,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1629,
-    "countryRank": 210
+    "countryRank": 210,
+    "countryTotal": 224
   },
   {
     "name": "Anhui University of Science and Technology",
@@ -27793,7 +29422,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1630,
-    "countryRank": 211
+    "countryRank": 211,
+    "countryTotal": 224
   },
   {
     "name": "Henan Polytechnic University",
@@ -27806,7 +29436,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1631,
-    "countryRank": 212
+    "countryRank": 212,
+    "countryTotal": 224
   },
   {
     "name": "Shihezi University",
@@ -27819,7 +29450,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1632,
-    "countryRank": 213
+    "countryRank": 213,
+    "countryTotal": 224
   },
   {
     "name": "Xi'an University of Science & Technology",
@@ -27832,7 +29464,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1633,
-    "countryRank": 214
+    "countryRank": 214,
+    "countryTotal": 224
   },
   {
     "name": "Hangzhou Medical College",
@@ -27845,7 +29478,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1634,
-    "countryRank": 215
+    "countryRank": 215,
+    "countryTotal": 224
   },
   {
     "name": "University of Picardie Jules Verne",
@@ -27858,7 +29492,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1635,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 60
   },
   {
     "name": "Taiyuan University of Science and Technology",
@@ -27871,7 +29506,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1636,
-    "countryRank": 216
+    "countryRank": 216,
+    "countryTotal": 224
   },
   {
     "name": "Hainan Medical University",
@@ -27884,7 +29520,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1637,
-    "countryRank": 217
+    "countryRank": 217,
+    "countryTotal": 224
   },
   {
     "name": "Hangzhou City University",
@@ -27897,7 +29534,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1638,
-    "countryRank": 218
+    "countryRank": 218,
+    "countryTotal": 224
   },
   {
     "name": "Jilin Agricultural University",
@@ -27910,7 +29548,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1639,
-    "countryRank": 219
+    "countryRank": 219,
+    "countryTotal": 224
   },
   {
     "name": "Kunming Medical University",
@@ -27923,7 +29562,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1640,
-    "countryRank": 220
+    "countryRank": 220,
+    "countryTotal": 224
   },
   {
     "name": "Nanjing University of Finance and Economics",
@@ -27936,7 +29576,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1641,
-    "countryRank": 221
+    "countryRank": 221,
+    "countryTotal": 224
   },
   {
     "name": "Southwest Medical University",
@@ -27949,7 +29590,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1642,
-    "countryRank": 222
+    "countryRank": 222,
+    "countryTotal": 224
   },
   {
     "name": "Bayero University",
@@ -27962,7 +29604,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1643,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 61
   },
   {
     "name": "Birkbeck University London",
@@ -27975,7 +29618,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1644,
-    "countryRank": 102
+    "countryRank": 102,
+    "countryTotal": 102
   },
   {
     "name": "Jiangsu University of Science & Technology",
@@ -27988,7 +29632,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1645,
-    "countryRank": 223
+    "countryRank": 223,
+    "countryTotal": 224
   },
   {
     "name": "Port Said University",
@@ -28001,7 +29646,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1646,
-    "countryRank": 54
+    "countryRank": 54,
+    "countryTotal": 61
   },
   {
     "name": "Scuola Superiore Sant'Anna",
@@ -28014,7 +29660,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1647,
-    "countryRank": 61
+    "countryRank": 61,
+    "countryTotal": 61
   },
   {
     "name": "All India Institute of Medical Sciences (AIIMS) New Delhi",
@@ -28027,7 +29674,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1648,
-    "countryRank": 55
+    "countryRank": 55,
+    "countryTotal": 61
   },
   {
     "name": "Fayoum University",
@@ -28040,7 +29688,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1649,
-    "countryRank": 56
+    "countryRank": 56,
+    "countryTotal": 61
   },
   {
     "name": "Jeonbuk National University",
@@ -28053,7 +29702,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1650,
-    "countryRank": 37
+    "countryRank": 37,
+    "countryTotal": 37
   },
   {
     "name": "Shanghai Maritime University",
@@ -28066,7 +29716,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1651,
-    "countryRank": 224
+    "countryRank": 224,
+    "countryTotal": 224
   },
   {
     "name": "University of Montana",
@@ -28079,7 +29730,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1652,
-    "countryRank": 218
+    "countryRank": 218,
+    "countryTotal": 220
   },
   {
     "name": "State University of New York (SUNY) Upstate Medical Center",
@@ -28092,7 +29744,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1653,
-    "countryRank": 219
+    "countryRank": 219,
+    "countryTotal": 220
   },
   {
     "name": "University of New England",
@@ -28105,7 +29758,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1654,
-    "countryRank": 41
+    "countryRank": 41,
+    "countryTotal": 41
   },
   {
     "name": "Tribhuvan University",
@@ -28118,7 +29772,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1655,
-    "countryRank": 57
+    "countryRank": 57,
+    "countryTotal": 61
   },
   {
     "name": "Otto von Guericke University",
@@ -28131,7 +29786,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1656,
-    "countryRank": 84
+    "countryRank": 84,
+    "countryTotal": 84
   },
   {
     "name": "Royal College of Surgeons - Ireland",
@@ -28144,7 +29800,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1657,
-    "countryRank": 58
+    "countryRank": 58,
+    "countryTotal": 61
   },
   {
     "name": "Abylkas Saginov Karaganda Technical University",
@@ -28157,7 +29814,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1658,
-    "countryRank": 10
+    "countryRank": 10,
+    "countryTotal": 10
   },
   {
     "name": "Al-Nahrain University",
@@ -28170,7 +29828,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1659,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "Al-Quds University",
@@ -28183,7 +29842,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1660,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "Sohar University",
@@ -28196,7 +29856,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1661,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "University of Cyberjaya",
@@ -28209,7 +29870,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1662,
-    "countryRank": 26
+    "countryRank": 26,
+    "countryTotal": 26
   },
   {
     "name": "University Torcuato di Tella",
@@ -28222,7 +29884,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1663,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 8
   },
   {
     "name": "University of Belgrano",
@@ -28235,7 +29898,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1664,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 8
   },
   {
     "name": "Khazar University",
@@ -28248,7 +29912,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1665,
-    "countryRank": 6
+    "countryRank": 6,
+    "countryTotal": 6
   },
   {
     "name": "University of Bahrain",
@@ -28261,7 +29926,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1666,
-    "countryRank": 4
+    "countryRank": 4,
+    "countryTotal": 4
   },
   {
     "name": "EAFIT University",
@@ -28274,7 +29940,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1667,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 9
   },
   {
     "name": "University Externado de Colombia",
@@ -28287,7 +29954,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1668,
-    "countryRank": 8
+    "countryRank": 8,
+    "countryTotal": 9
   },
   {
     "name": "University of La Sabana",
@@ -28300,7 +29968,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1669,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 9
   },
   {
     "name": "Escuela Superior Polit�cnica del Litoral",
@@ -28313,7 +29982,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1670,
-    "countryRank": 3
+    "countryRank": 3,
+    "countryTotal": 3
   },
   {
     "name": "University of C�rdoba",
@@ -28326,7 +29996,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1671,
-    "countryRank": 52
+    "countryRank": 52,
+    "countryTotal": 53
   },
   {
     "name": "Tbilisi State University",
@@ -28339,7 +30010,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1672,
-    "countryRank": 1
+    "countryRank": 1,
+    "countryTotal": 1
   },
   {
     "name": "Athens University of Economics and Business",
@@ -28352,7 +30024,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1673,
-    "countryRank": 7
+    "countryRank": 7,
+    "countryTotal": 7
   },
   {
     "name": "Sophia University",
@@ -28365,7 +30038,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1674,
-    "countryRank": 36
+    "countryRank": 36,
+    "countryTotal": 36
   },
   {
     "name": "Kyrgyz Turkish Manas University",
@@ -28378,7 +30052,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1675,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "Metropolitan Autonomous University",
@@ -28391,7 +30066,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1676,
-    "countryRank": 9
+    "countryRank": 9,
+    "countryTotal": 9
   },
   {
     "name": "National University of San Marcos",
@@ -28404,7 +30080,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1677,
-    "countryRank": 2
+    "countryRank": 2,
+    "countryTotal": 2
   },
   {
     "name": "University of Lodz",
@@ -28417,7 +30094,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1678,
-    "countryRank": 13
+    "countryRank": 13,
+    "countryTotal": 13
   },
   {
     "name": "Clarkson University",
@@ -28430,7 +30108,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1679,
-    "countryRank": 220
+    "countryRank": 220,
+    "countryTotal": 220
   },
   {
     "name": "Indian Institute of Technology - Bhubaneswar",
@@ -28443,7 +30122,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1680,
-    "countryRank": 63
+    "countryRank": 63,
+    "countryTotal": 63
   },
   {
     "name": "Immanuel Kant Baltic Federal University",
@@ -28456,7 +30136,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1681,
-    "countryRank": 27
+    "countryRank": 27,
+    "countryTotal": 27
   },
   {
     "name": "CY Cergy Paris University",
@@ -28469,7 +30150,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1682,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 60
   },
   {
     "name": "Universitas Hasanuddin",
@@ -28482,7 +30164,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1683,
-    "countryRank": 11
+    "countryRank": 11,
+    "countryTotal": 11
   },
   {
     "name": "Oslo Metropolitan University (OsloMet)",
@@ -28495,7 +30178,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1684,
-    "countryRank": 59
+    "countryRank": 59,
+    "countryTotal": 61
   },
   {
     "name": "Universitat de Girona",
@@ -28508,7 +30192,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1685,
-    "countryRank": 53
+    "countryRank": 53,
+    "countryTotal": 53
   },
   {
     "name": "University of Nairobi",
@@ -28521,7 +30206,8 @@
     },
     "appearances": 1,
     "aggregatedRank": 1686,
-    "countryRank": 60
+    "countryRank": 60,
+    "countryTotal": 61
   },
   {
     "name": "Aswan University",
@@ -28534,6 +30220,7 @@
     },
     "appearances": 1,
     "aggregatedRank": 1687,
-    "countryRank": 61
+    "countryRank": 61,
+    "countryTotal": 61
   }
 ]

--- a/frontend/public/data/enhanced-aggregated-rankings.json
+++ b/frontend/public/data/enhanced-aggregated-rankings.json
@@ -20,6 +20,7 @@
     "appearances": 4,
     "aggregatedRank": 1,
     "countryRank": 1,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91,6 +92,7 @@
     "appearances": 4,
     "aggregatedRank": 2,
     "countryRank": 2,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -164,6 +166,7 @@
     "appearances": 4,
     "aggregatedRank": 3,
     "countryRank": 3,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -237,6 +240,7 @@
     "appearances": 4,
     "aggregatedRank": 4,
     "countryRank": 1,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -310,6 +314,7 @@
     "appearances": 4,
     "aggregatedRank": 5,
     "countryRank": 2,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -383,6 +388,7 @@
     "appearances": 4,
     "aggregatedRank": 6,
     "countryRank": 4,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -454,6 +460,7 @@
     "appearances": 4,
     "aggregatedRank": 7,
     "countryRank": 3,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -527,6 +534,7 @@
     "appearances": 4,
     "aggregatedRank": 8,
     "countryRank": 5,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -601,6 +609,7 @@
     "appearances": 4,
     "aggregatedRank": 9,
     "countryRank": 6,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -674,6 +683,7 @@
     "appearances": 4,
     "aggregatedRank": 10,
     "countryRank": 7,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -747,6 +757,7 @@
     "appearances": 4,
     "aggregatedRank": 11,
     "countryRank": 4,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -820,6 +831,7 @@
     "appearances": 4,
     "aggregatedRank": 12,
     "countryRank": 8,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -893,6 +905,7 @@
     "appearances": 4,
     "aggregatedRank": 13,
     "countryRank": 1,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -966,6 +979,7 @@
     "appearances": 4,
     "aggregatedRank": 14,
     "countryRank": 9,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1039,6 +1053,7 @@
     "appearances": 4,
     "aggregatedRank": 15,
     "countryRank": 10,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1112,6 +1127,7 @@
     "appearances": 4,
     "aggregatedRank": 16,
     "countryRank": 11,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1185,6 +1201,7 @@
     "appearances": 4,
     "aggregatedRank": 17,
     "countryRank": 1,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1259,6 +1276,7 @@
     "appearances": 4,
     "aggregatedRank": 18,
     "countryRank": 2,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1332,6 +1350,7 @@
     "appearances": 4,
     "aggregatedRank": 19,
     "countryRank": 12,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1405,6 +1424,7 @@
     "appearances": 4,
     "aggregatedRank": 20,
     "countryRank": 1,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1478,6 +1498,7 @@
     "appearances": 4,
     "aggregatedRank": 21,
     "countryRank": 13,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1549,6 +1570,7 @@
     "appearances": 4,
     "aggregatedRank": 22,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1622,6 +1644,7 @@
     "appearances": 4,
     "aggregatedRank": 23,
     "countryRank": 14,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1696,6 +1719,7 @@
     "appearances": 4,
     "aggregatedRank": 24,
     "countryRank": 1,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1769,6 +1793,7 @@
     "appearances": 4,
     "aggregatedRank": 25,
     "countryRank": 15,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1842,6 +1867,7 @@
     "appearances": 4,
     "aggregatedRank": 26,
     "countryRank": 16,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1916,6 +1942,7 @@
     "appearances": 4,
     "aggregatedRank": 27,
     "countryRank": 5,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -1989,6 +2016,7 @@
     "appearances": 4,
     "aggregatedRank": 28,
     "countryRank": 17,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2062,6 +2090,7 @@
     "appearances": 4,
     "aggregatedRank": 29,
     "countryRank": 18,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2133,6 +2162,7 @@
     "appearances": 4,
     "aggregatedRank": 30,
     "countryRank": 3,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2204,6 +2234,7 @@
     "appearances": 4,
     "aggregatedRank": 31,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2278,6 +2309,7 @@
     "appearances": 4,
     "aggregatedRank": 32,
     "countryRank": 4,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2351,6 +2383,7 @@
     "appearances": 4,
     "aggregatedRank": 33,
     "countryRank": 19,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2424,6 +2457,7 @@
     "appearances": 4,
     "aggregatedRank": 34,
     "countryRank": 6,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2497,6 +2531,7 @@
     "appearances": 4,
     "aggregatedRank": 35,
     "countryRank": 5,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2570,6 +2605,7 @@
     "appearances": 4,
     "aggregatedRank": 36,
     "countryRank": 1,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2641,6 +2677,7 @@
     "appearances": 4,
     "aggregatedRank": 37,
     "countryRank": 2,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2712,6 +2749,7 @@
     "appearances": 4,
     "aggregatedRank": 38,
     "countryRank": 2,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2785,6 +2823,7 @@
     "appearances": 4,
     "aggregatedRank": 39,
     "countryRank": 2,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2859,6 +2898,7 @@
     "appearances": 4,
     "aggregatedRank": 40,
     "countryRank": 7,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -2932,6 +2972,7 @@
     "appearances": 4,
     "aggregatedRank": 41,
     "countryRank": 3,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3005,6 +3046,7 @@
     "appearances": 4,
     "aggregatedRank": 42,
     "countryRank": 3,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3078,6 +3120,7 @@
     "appearances": 4,
     "aggregatedRank": 43,
     "countryRank": 1,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3151,6 +3194,7 @@
     "appearances": 4,
     "aggregatedRank": 44,
     "countryRank": 4,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3225,6 +3269,7 @@
     "appearances": 4,
     "aggregatedRank": 45,
     "countryRank": 1,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3299,6 +3344,7 @@
     "appearances": 4,
     "aggregatedRank": 46,
     "countryRank": 5,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3372,6 +3418,7 @@
     "appearances": 4,
     "aggregatedRank": 47,
     "countryRank": 1,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3446,6 +3493,7 @@
     "appearances": 4,
     "aggregatedRank": 48,
     "countryRank": 20,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3517,6 +3565,7 @@
     "appearances": 4,
     "aggregatedRank": 49,
     "countryRank": 1,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3591,6 +3640,7 @@
     "appearances": 4,
     "aggregatedRank": 50,
     "countryRank": 1,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3664,6 +3714,7 @@
     "appearances": 4,
     "aggregatedRank": 51,
     "countryRank": 2,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3738,6 +3789,7 @@
     "appearances": 4,
     "aggregatedRank": 52,
     "countryRank": 1,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3811,6 +3863,7 @@
     "appearances": 4,
     "aggregatedRank": 53,
     "countryRank": 21,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3882,6 +3935,7 @@
     "appearances": 4,
     "aggregatedRank": 54,
     "countryRank": 22,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -3953,6 +4007,7 @@
     "appearances": 4,
     "aggregatedRank": 55,
     "countryRank": 2,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4027,6 +4082,7 @@
     "appearances": 4,
     "aggregatedRank": 56,
     "countryRank": 23,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4101,6 +4157,7 @@
     "appearances": 4,
     "aggregatedRank": 57,
     "countryRank": 6,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4174,6 +4231,7 @@
     "appearances": 4,
     "aggregatedRank": 58,
     "countryRank": 6,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4245,6 +4303,7 @@
     "appearances": 4,
     "aggregatedRank": 59,
     "countryRank": 24,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4318,6 +4377,7 @@
     "appearances": 4,
     "aggregatedRank": 60,
     "countryRank": 25,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4389,6 +4449,7 @@
     "appearances": 4,
     "aggregatedRank": 61,
     "countryRank": 1,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4462,6 +4523,7 @@
     "appearances": 4,
     "aggregatedRank": 62,
     "countryRank": 8,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4535,6 +4597,7 @@
     "appearances": 4,
     "aggregatedRank": 63,
     "countryRank": 9,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4608,6 +4671,7 @@
     "appearances": 4,
     "aggregatedRank": 64,
     "countryRank": 3,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4681,6 +4745,7 @@
     "appearances": 4,
     "aggregatedRank": 65,
     "countryRank": 2,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4755,6 +4820,7 @@
     "appearances": 4,
     "aggregatedRank": 66,
     "countryRank": 2,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4828,6 +4894,7 @@
     "appearances": 4,
     "aggregatedRank": 67,
     "countryRank": 26,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4901,6 +4968,7 @@
     "appearances": 4,
     "aggregatedRank": 68,
     "countryRank": 27,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -4974,6 +5042,7 @@
     "appearances": 4,
     "aggregatedRank": 69,
     "countryRank": 28,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5045,6 +5114,7 @@
     "appearances": 4,
     "aggregatedRank": 70,
     "countryRank": 3,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5118,6 +5188,7 @@
     "appearances": 4,
     "aggregatedRank": 71,
     "countryRank": 29,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5191,6 +5262,7 @@
     "appearances": 4,
     "aggregatedRank": 72,
     "countryRank": 30,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5264,6 +5336,7 @@
     "appearances": 4,
     "aggregatedRank": 73,
     "countryRank": 1,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5337,6 +5410,7 @@
     "appearances": 4,
     "aggregatedRank": 74,
     "countryRank": 31,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5410,6 +5484,7 @@
     "appearances": 4,
     "aggregatedRank": 75,
     "countryRank": 4,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5481,6 +5556,7 @@
     "appearances": 4,
     "aggregatedRank": 76,
     "countryRank": 32,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5552,6 +5628,7 @@
     "appearances": 4,
     "aggregatedRank": 77,
     "countryRank": 1,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5625,6 +5702,7 @@
     "appearances": 4,
     "aggregatedRank": 78,
     "countryRank": 10,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5698,6 +5776,7 @@
     "appearances": 4,
     "aggregatedRank": 79,
     "countryRank": 33,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5769,6 +5848,7 @@
     "appearances": 4,
     "aggregatedRank": 80,
     "countryRank": 4,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5842,6 +5922,7 @@
     "appearances": 4,
     "aggregatedRank": 81,
     "countryRank": 1,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5915,6 +5996,7 @@
     "appearances": 4,
     "aggregatedRank": 82,
     "countryRank": 7,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -5988,6 +6070,7 @@
     "appearances": 4,
     "aggregatedRank": 83,
     "countryRank": 2,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6061,6 +6144,7 @@
     "appearances": 4,
     "aggregatedRank": 84,
     "countryRank": 5,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6134,6 +6218,7 @@
     "appearances": 4,
     "aggregatedRank": 85,
     "countryRank": 34,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6207,6 +6292,7 @@
     "appearances": 4,
     "aggregatedRank": 86,
     "countryRank": 35,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6280,6 +6366,7 @@
     "appearances": 4,
     "aggregatedRank": 87,
     "countryRank": 36,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6351,6 +6438,7 @@
     "appearances": 4,
     "aggregatedRank": 88,
     "countryRank": 37,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6424,6 +6512,7 @@
     "appearances": 4,
     "aggregatedRank": 89,
     "countryRank": 2,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6497,6 +6586,7 @@
     "appearances": 4,
     "aggregatedRank": 90,
     "countryRank": 2,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6570,6 +6660,7 @@
     "appearances": 4,
     "aggregatedRank": 91,
     "countryRank": 4,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6643,6 +6734,7 @@
     "appearances": 4,
     "aggregatedRank": 92,
     "countryRank": 38,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6716,6 +6808,7 @@
     "appearances": 4,
     "aggregatedRank": 93,
     "countryRank": 11,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6789,6 +6882,7 @@
     "appearances": 4,
     "aggregatedRank": 94,
     "countryRank": 7,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6860,6 +6954,7 @@
     "appearances": 4,
     "aggregatedRank": 95,
     "countryRank": 12,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -6933,6 +7028,7 @@
     "appearances": 4,
     "aggregatedRank": 96,
     "countryRank": 6,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7006,6 +7102,7 @@
     "appearances": 4,
     "aggregatedRank": 97,
     "countryRank": 13,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7079,6 +7176,7 @@
     "appearances": 4,
     "aggregatedRank": 98,
     "countryRank": 14,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7152,6 +7250,7 @@
     "appearances": 4,
     "aggregatedRank": 99,
     "countryRank": 15,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7225,6 +7324,7 @@
     "appearances": 4,
     "aggregatedRank": 100,
     "countryRank": 8,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7299,6 +7399,7 @@
     "appearances": 4,
     "aggregatedRank": 101,
     "countryRank": 16,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7372,6 +7473,7 @@
     "appearances": 4,
     "aggregatedRank": 102,
     "countryRank": 9,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7445,6 +7547,7 @@
     "appearances": 4,
     "aggregatedRank": 103,
     "countryRank": 17,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7518,6 +7621,7 @@
     "appearances": 4,
     "aggregatedRank": 104,
     "countryRank": 2,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7591,6 +7695,7 @@
     "appearances": 4,
     "aggregatedRank": 105,
     "countryRank": 3,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7664,6 +7769,7 @@
     "appearances": 4,
     "aggregatedRank": 106,
     "countryRank": 5,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7737,6 +7843,7 @@
     "appearances": 4,
     "aggregatedRank": 107,
     "countryRank": 1,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7810,6 +7917,7 @@
     "appearances": 4,
     "aggregatedRank": 108,
     "countryRank": 18,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7884,6 +7992,7 @@
     "appearances": 4,
     "aggregatedRank": 109,
     "countryRank": 39,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -7957,6 +8066,7 @@
     "appearances": 4,
     "aggregatedRank": 110,
     "countryRank": 8,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8030,6 +8140,7 @@
     "appearances": 4,
     "aggregatedRank": 111,
     "countryRank": 1,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8103,6 +8214,7 @@
     "appearances": 4,
     "aggregatedRank": 112,
     "countryRank": 40,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8176,6 +8288,7 @@
     "appearances": 4,
     "aggregatedRank": 113,
     "countryRank": 4,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8249,6 +8362,7 @@
     "appearances": 4,
     "aggregatedRank": 114,
     "countryRank": 1,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8322,6 +8436,7 @@
     "appearances": 4,
     "aggregatedRank": 115,
     "countryRank": 3,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8395,6 +8510,7 @@
     "appearances": 4,
     "aggregatedRank": 116,
     "countryRank": 5,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8466,6 +8582,7 @@
     "appearances": 4,
     "aggregatedRank": 117,
     "countryRank": 1,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8541,6 +8658,7 @@
     "appearances": 4,
     "aggregatedRank": 118,
     "countryRank": 1,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8614,6 +8732,7 @@
     "appearances": 4,
     "aggregatedRank": 119,
     "countryRank": 41,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8685,6 +8804,7 @@
     "appearances": 4,
     "aggregatedRank": 120,
     "countryRank": 42,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8758,6 +8878,7 @@
     "appearances": 4,
     "aggregatedRank": 121,
     "countryRank": 6,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8831,6 +8952,7 @@
     "appearances": 4,
     "aggregatedRank": 122,
     "countryRank": 19,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8904,6 +9026,7 @@
     "appearances": 4,
     "aggregatedRank": 123,
     "countryRank": 3,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -8977,6 +9100,7 @@
     "appearances": 4,
     "aggregatedRank": 124,
     "countryRank": 43,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9050,6 +9174,7 @@
     "appearances": 4,
     "aggregatedRank": 125,
     "countryRank": 2,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9123,6 +9248,7 @@
     "appearances": 4,
     "aggregatedRank": 126,
     "countryRank": 9,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9196,6 +9322,7 @@
     "appearances": 4,
     "aggregatedRank": 127,
     "countryRank": 3,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9269,6 +9396,7 @@
     "appearances": 4,
     "aggregatedRank": 128,
     "countryRank": 10,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9343,6 +9471,7 @@
     "appearances": 4,
     "aggregatedRank": 129,
     "countryRank": 44,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9414,6 +9543,7 @@
     "appearances": 4,
     "aggregatedRank": 130,
     "countryRank": 4,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9488,6 +9618,7 @@
     "appearances": 4,
     "aggregatedRank": 131,
     "countryRank": 6,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9561,6 +9692,7 @@
     "appearances": 4,
     "aggregatedRank": 132,
     "countryRank": 3,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9634,6 +9766,7 @@
     "appearances": 4,
     "aggregatedRank": 133,
     "countryRank": 3,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9707,6 +9840,7 @@
     "appearances": 4,
     "aggregatedRank": 134,
     "countryRank": 1,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9780,6 +9914,7 @@
     "appearances": 4,
     "aggregatedRank": 135,
     "countryRank": 1,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9853,6 +9988,7 @@
     "appearances": 4,
     "aggregatedRank": 136,
     "countryRank": 1,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -9926,6 +10062,7 @@
     "appearances": 4,
     "aggregatedRank": 137,
     "countryRank": 20,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10000,6 +10137,7 @@
     "appearances": 4,
     "aggregatedRank": 138,
     "countryRank": 4,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10073,6 +10211,7 @@
     "appearances": 4,
     "aggregatedRank": 139,
     "countryRank": 11,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10146,6 +10285,7 @@
     "appearances": 4,
     "aggregatedRank": 140,
     "countryRank": 1,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10219,6 +10359,7 @@
     "appearances": 4,
     "aggregatedRank": 141,
     "countryRank": 7,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10292,6 +10433,7 @@
     "appearances": 4,
     "aggregatedRank": 142,
     "countryRank": 12,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10363,6 +10505,7 @@
     "appearances": 4,
     "aggregatedRank": 143,
     "countryRank": 5,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10436,6 +10579,7 @@
     "appearances": 4,
     "aggregatedRank": 144,
     "countryRank": 10,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10509,6 +10653,7 @@
     "appearances": 4,
     "aggregatedRank": 145,
     "countryRank": 45,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10582,6 +10727,7 @@
     "appearances": 4,
     "aggregatedRank": 146,
     "countryRank": 4,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10655,6 +10801,7 @@
     "appearances": 4,
     "aggregatedRank": 147,
     "countryRank": 46,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10729,6 +10876,7 @@
     "appearances": 4,
     "aggregatedRank": 148,
     "countryRank": 13,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10800,6 +10948,7 @@
     "appearances": 4,
     "aggregatedRank": 149,
     "countryRank": 3,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10873,6 +11022,7 @@
     "appearances": 4,
     "aggregatedRank": 150,
     "countryRank": 3,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -10946,6 +11096,7 @@
     "appearances": 4,
     "aggregatedRank": 151,
     "countryRank": 47,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11020,6 +11171,7 @@
     "appearances": 4,
     "aggregatedRank": 152,
     "countryRank": 14,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11091,6 +11243,7 @@
     "appearances": 4,
     "aggregatedRank": 153,
     "countryRank": 15,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11164,6 +11317,7 @@
     "appearances": 4,
     "aggregatedRank": 154,
     "countryRank": 16,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11237,6 +11391,7 @@
     "appearances": 4,
     "aggregatedRank": 155,
     "countryRank": 4,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11311,6 +11466,7 @@
     "appearances": 4,
     "aggregatedRank": 156,
     "countryRank": 21,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11385,6 +11541,7 @@
     "appearances": 4,
     "aggregatedRank": 157,
     "countryRank": 48,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11458,6 +11615,7 @@
     "appearances": 4,
     "aggregatedRank": 158,
     "countryRank": 7,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11531,6 +11689,7 @@
     "appearances": 4,
     "aggregatedRank": 159,
     "countryRank": 49,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11604,6 +11763,7 @@
     "appearances": 4,
     "aggregatedRank": 160,
     "countryRank": 50,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11675,6 +11835,7 @@
     "appearances": 4,
     "aggregatedRank": 161,
     "countryRank": 22,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11748,6 +11909,7 @@
     "appearances": 4,
     "aggregatedRank": 162,
     "countryRank": 6,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11821,6 +11983,7 @@
     "appearances": 4,
     "aggregatedRank": 163,
     "countryRank": 51,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11894,6 +12057,7 @@
     "appearances": 4,
     "aggregatedRank": 164,
     "countryRank": 11,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -11967,6 +12131,7 @@
     "appearances": 4,
     "aggregatedRank": 165,
     "countryRank": 2,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12040,6 +12205,7 @@
     "appearances": 4,
     "aggregatedRank": 166,
     "countryRank": 12,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12113,6 +12279,7 @@
     "appearances": 4,
     "aggregatedRank": 167,
     "countryRank": 17,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12186,6 +12353,7 @@
     "appearances": 4,
     "aggregatedRank": 168,
     "countryRank": 7,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12259,6 +12427,7 @@
     "appearances": 4,
     "aggregatedRank": 169,
     "countryRank": 5,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12332,6 +12501,7 @@
     "appearances": 4,
     "aggregatedRank": 170,
     "countryRank": 1,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12405,6 +12575,7 @@
     "appearances": 4,
     "aggregatedRank": 171,
     "countryRank": 23,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12478,6 +12649,7 @@
     "appearances": 4,
     "aggregatedRank": 172,
     "countryRank": 8,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12551,6 +12723,7 @@
     "appearances": 4,
     "aggregatedRank": 173,
     "countryRank": 8,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12625,6 +12798,7 @@
     "appearances": 4,
     "aggregatedRank": 174,
     "countryRank": 2,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12698,6 +12872,7 @@
     "appearances": 4,
     "aggregatedRank": 175,
     "countryRank": 18,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12771,6 +12946,7 @@
     "appearances": 4,
     "aggregatedRank": 176,
     "countryRank": 1,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12845,6 +13021,7 @@
     "appearances": 4,
     "aggregatedRank": 177,
     "countryRank": 8,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12918,6 +13095,7 @@
     "appearances": 4,
     "aggregatedRank": 178,
     "countryRank": 2,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -12991,6 +13169,7 @@
     "appearances": 4,
     "aggregatedRank": 179,
     "countryRank": 4,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13064,6 +13243,7 @@
     "appearances": 4,
     "aggregatedRank": 180,
     "countryRank": 19,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13137,6 +13317,7 @@
     "appearances": 4,
     "aggregatedRank": 181,
     "countryRank": 13,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13210,6 +13391,7 @@
     "appearances": 4,
     "aggregatedRank": 182,
     "countryRank": 14,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13283,6 +13465,7 @@
     "appearances": 4,
     "aggregatedRank": 183,
     "countryRank": 20,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13357,6 +13540,7 @@
     "appearances": 4,
     "aggregatedRank": 184,
     "countryRank": 24,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13430,6 +13614,7 @@
     "appearances": 4,
     "aggregatedRank": 185,
     "countryRank": 15,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13503,6 +13688,7 @@
     "appearances": 4,
     "aggregatedRank": 186,
     "countryRank": 21,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13576,6 +13762,7 @@
     "appearances": 4,
     "aggregatedRank": 187,
     "countryRank": 52,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13647,6 +13834,7 @@
     "appearances": 4,
     "aggregatedRank": 188,
     "countryRank": 5,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13721,6 +13909,7 @@
     "appearances": 4,
     "aggregatedRank": 189,
     "countryRank": 25,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13796,6 +13985,7 @@
     "appearances": 4,
     "aggregatedRank": 190,
     "countryRank": 22,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13869,6 +14059,7 @@
     "appearances": 4,
     "aggregatedRank": 191,
     "countryRank": 5,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -13942,6 +14133,7 @@
     "appearances": 4,
     "aggregatedRank": 192,
     "countryRank": 26,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14015,6 +14207,7 @@
     "appearances": 4,
     "aggregatedRank": 193,
     "countryRank": 23,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14086,6 +14279,7 @@
     "appearances": 4,
     "aggregatedRank": 194,
     "countryRank": 2,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14159,6 +14353,7 @@
     "appearances": 4,
     "aggregatedRank": 195,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14232,6 +14427,7 @@
     "appearances": 4,
     "aggregatedRank": 196,
     "countryRank": 9,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14305,6 +14501,7 @@
     "appearances": 4,
     "aggregatedRank": 197,
     "countryRank": 27,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14379,6 +14576,7 @@
     "appearances": 4,
     "aggregatedRank": 198,
     "countryRank": 2,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14452,6 +14650,7 @@
     "appearances": 4,
     "aggregatedRank": 199,
     "countryRank": 24,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14525,6 +14724,7 @@
     "appearances": 4,
     "aggregatedRank": 200,
     "countryRank": 28,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14598,6 +14798,7 @@
     "appearances": 4,
     "aggregatedRank": 201,
     "countryRank": 2,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14671,6 +14872,7 @@
     "appearances": 4,
     "aggregatedRank": 202,
     "countryRank": 53,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14744,6 +14946,7 @@
     "appearances": 4,
     "aggregatedRank": 203,
     "countryRank": 25,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14817,6 +15020,7 @@
     "appearances": 4,
     "aggregatedRank": 204,
     "countryRank": 5,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14890,6 +15094,7 @@
     "appearances": 4,
     "aggregatedRank": 205,
     "countryRank": 54,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -14963,6 +15168,7 @@
     "appearances": 4,
     "aggregatedRank": 206,
     "countryRank": 6,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15036,6 +15242,7 @@
     "appearances": 4,
     "aggregatedRank": 207,
     "countryRank": 3,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15110,6 +15317,7 @@
     "appearances": 4,
     "aggregatedRank": 208,
     "countryRank": 55,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15183,6 +15391,7 @@
     "appearances": 4,
     "aggregatedRank": 209,
     "countryRank": 29,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15256,6 +15465,7 @@
     "appearances": 4,
     "aggregatedRank": 210,
     "countryRank": 9,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15329,6 +15539,7 @@
     "appearances": 4,
     "aggregatedRank": 211,
     "countryRank": 56,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15402,6 +15613,7 @@
     "appearances": 4,
     "aggregatedRank": 212,
     "countryRank": 6,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15475,6 +15687,7 @@
     "appearances": 4,
     "aggregatedRank": 213,
     "countryRank": 57,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15548,6 +15761,7 @@
     "appearances": 4,
     "aggregatedRank": 214,
     "countryRank": 58,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15621,6 +15835,7 @@
     "appearances": 4,
     "aggregatedRank": 215,
     "countryRank": 16,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15694,6 +15909,7 @@
     "appearances": 4,
     "aggregatedRank": 216,
     "countryRank": 2,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15767,6 +15983,7 @@
     "appearances": 4,
     "aggregatedRank": 217,
     "countryRank": 26,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15840,6 +16057,7 @@
     "appearances": 4,
     "aggregatedRank": 218,
     "countryRank": 17,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15913,6 +16131,7 @@
     "appearances": 4,
     "aggregatedRank": 219,
     "countryRank": 1,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -15986,6 +16205,7 @@
     "appearances": 4,
     "aggregatedRank": 220,
     "countryRank": 6,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16057,6 +16277,7 @@
     "appearances": 4,
     "aggregatedRank": 221,
     "countryRank": 4,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16131,6 +16352,7 @@
     "appearances": 4,
     "aggregatedRank": 222,
     "countryRank": 59,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16202,6 +16424,7 @@
     "appearances": 4,
     "aggregatedRank": 223,
     "countryRank": 60,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16275,6 +16498,7 @@
     "appearances": 4,
     "aggregatedRank": 224,
     "countryRank": 27,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16348,6 +16572,7 @@
     "appearances": 4,
     "aggregatedRank": 225,
     "countryRank": 10,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16421,6 +16646,7 @@
     "appearances": 4,
     "aggregatedRank": 226,
     "countryRank": 2,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16495,6 +16721,7 @@
     "appearances": 4,
     "aggregatedRank": 227,
     "countryRank": 4,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16568,6 +16795,7 @@
     "appearances": 4,
     "aggregatedRank": 228,
     "countryRank": 6,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16641,6 +16869,7 @@
     "appearances": 4,
     "aggregatedRank": 229,
     "countryRank": 28,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16714,6 +16943,7 @@
     "appearances": 4,
     "aggregatedRank": 230,
     "countryRank": 2,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16785,6 +17015,7 @@
     "appearances": 4,
     "aggregatedRank": 231,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16859,6 +17090,7 @@
     "appearances": 4,
     "aggregatedRank": 232,
     "countryRank": 3,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -16930,6 +17162,7 @@
     "appearances": 4,
     "aggregatedRank": 233,
     "countryRank": 5,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17003,6 +17236,7 @@
     "appearances": 4,
     "aggregatedRank": 234,
     "countryRank": 4,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17076,6 +17310,7 @@
     "appearances": 4,
     "aggregatedRank": 235,
     "countryRank": 3,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17149,6 +17384,7 @@
     "appearances": 4,
     "aggregatedRank": 236,
     "countryRank": 18,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17222,6 +17458,7 @@
     "appearances": 4,
     "aggregatedRank": 237,
     "countryRank": 7,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17295,6 +17532,7 @@
     "appearances": 4,
     "aggregatedRank": 238,
     "countryRank": 7,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17368,6 +17606,7 @@
     "appearances": 4,
     "aggregatedRank": 239,
     "countryRank": 29,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17441,6 +17680,7 @@
     "appearances": 4,
     "aggregatedRank": 240,
     "countryRank": 30,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17514,6 +17754,7 @@
     "appearances": 4,
     "aggregatedRank": 241,
     "countryRank": 61,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17585,6 +17826,7 @@
     "appearances": 4,
     "aggregatedRank": 242,
     "countryRank": 31,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17656,6 +17898,7 @@
     "appearances": 4,
     "aggregatedRank": 243,
     "countryRank": 62,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17729,6 +17972,7 @@
     "appearances": 4,
     "aggregatedRank": 244,
     "countryRank": 32,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17802,6 +18046,7 @@
     "appearances": 4,
     "aggregatedRank": 245,
     "countryRank": 1,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17876,6 +18121,7 @@
     "appearances": 4,
     "aggregatedRank": 246,
     "countryRank": 63,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -17949,6 +18195,7 @@
     "appearances": 4,
     "aggregatedRank": 247,
     "countryRank": 64,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18020,6 +18267,7 @@
     "appearances": 4,
     "aggregatedRank": 248,
     "countryRank": 1,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18093,6 +18341,7 @@
     "appearances": 4,
     "aggregatedRank": 249,
     "countryRank": 7,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18166,6 +18415,7 @@
     "appearances": 4,
     "aggregatedRank": 250,
     "countryRank": 30,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18239,6 +18489,7 @@
     "appearances": 4,
     "aggregatedRank": 251,
     "countryRank": 8,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18312,6 +18563,7 @@
     "appearances": 4,
     "aggregatedRank": 252,
     "countryRank": 2,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18385,6 +18637,7 @@
     "appearances": 4,
     "aggregatedRank": 253,
     "countryRank": 3,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18458,6 +18711,7 @@
     "appearances": 4,
     "aggregatedRank": 254,
     "countryRank": 19,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18532,6 +18786,7 @@
     "appearances": 4,
     "aggregatedRank": 255,
     "countryRank": 65,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18606,6 +18861,7 @@
     "appearances": 4,
     "aggregatedRank": 256,
     "countryRank": 8,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18679,6 +18935,7 @@
     "appearances": 4,
     "aggregatedRank": 257,
     "countryRank": 31,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18752,6 +19009,7 @@
     "appearances": 4,
     "aggregatedRank": 258,
     "countryRank": 3,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18825,6 +19083,7 @@
     "appearances": 4,
     "aggregatedRank": 259,
     "countryRank": 9,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18898,6 +19157,7 @@
     "appearances": 4,
     "aggregatedRank": 260,
     "countryRank": 9,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -18971,6 +19231,7 @@
     "appearances": 4,
     "aggregatedRank": 261,
     "countryRank": 5,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19045,6 +19306,7 @@
     "appearances": 4,
     "aggregatedRank": 262,
     "countryRank": 11,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19118,6 +19380,7 @@
     "appearances": 4,
     "aggregatedRank": 263,
     "countryRank": 10,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19191,6 +19454,7 @@
     "appearances": 4,
     "aggregatedRank": 264,
     "countryRank": 3,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19265,6 +19529,7 @@
     "appearances": 4,
     "aggregatedRank": 265,
     "countryRank": 10,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19338,6 +19603,7 @@
     "appearances": 4,
     "aggregatedRank": 266,
     "countryRank": 2,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19411,6 +19677,7 @@
     "appearances": 4,
     "aggregatedRank": 267,
     "countryRank": 33,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19484,6 +19751,7 @@
     "appearances": 4,
     "aggregatedRank": 268,
     "countryRank": 2,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19557,6 +19825,7 @@
     "appearances": 4,
     "aggregatedRank": 269,
     "countryRank": 9,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19630,6 +19899,7 @@
     "appearances": 4,
     "aggregatedRank": 270,
     "countryRank": 66,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19703,6 +19973,7 @@
     "appearances": 4,
     "aggregatedRank": 271,
     "countryRank": 67,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19776,6 +20047,7 @@
     "appearances": 4,
     "aggregatedRank": 272,
     "countryRank": 6,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19849,6 +20121,7 @@
     "appearances": 4,
     "aggregatedRank": 273,
     "countryRank": 3,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19922,6 +20195,7 @@
     "appearances": 4,
     "aggregatedRank": 274,
     "countryRank": 7,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -19995,6 +20269,7 @@
     "appearances": 4,
     "aggregatedRank": 275,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20068,6 +20343,7 @@
     "appearances": 4,
     "aggregatedRank": 276,
     "countryRank": 1,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20141,6 +20417,7 @@
     "appearances": 4,
     "aggregatedRank": 277,
     "countryRank": 1,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20215,6 +20492,7 @@
     "appearances": 4,
     "aggregatedRank": 278,
     "countryRank": 8,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20289,6 +20567,7 @@
     "appearances": 4,
     "aggregatedRank": 279,
     "countryRank": 4,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20360,6 +20639,7 @@
     "appearances": 4,
     "aggregatedRank": 280,
     "countryRank": 34,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20433,6 +20713,7 @@
     "appearances": 4,
     "aggregatedRank": 281,
     "countryRank": 12,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20506,6 +20787,7 @@
     "appearances": 4,
     "aggregatedRank": 282,
     "countryRank": 11,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20577,6 +20859,7 @@
     "appearances": 4,
     "aggregatedRank": 283,
     "countryRank": 68,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20648,6 +20931,7 @@
     "appearances": 4,
     "aggregatedRank": 284,
     "countryRank": 69,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20721,6 +21005,7 @@
     "appearances": 4,
     "aggregatedRank": 285,
     "countryRank": 32,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20794,6 +21079,7 @@
     "appearances": 4,
     "aggregatedRank": 286,
     "countryRank": 1,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20867,6 +21153,7 @@
     "appearances": 4,
     "aggregatedRank": 287,
     "countryRank": 12,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -20940,6 +21227,7 @@
     "appearances": 4,
     "aggregatedRank": 288,
     "countryRank": 4,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21013,6 +21301,7 @@
     "appearances": 4,
     "aggregatedRank": 289,
     "countryRank": 2,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21086,6 +21375,7 @@
     "appearances": 4,
     "aggregatedRank": 290,
     "countryRank": 5,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21159,6 +21449,7 @@
     "appearances": 4,
     "aggregatedRank": 291,
     "countryRank": 70,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21230,6 +21521,7 @@
     "appearances": 4,
     "aggregatedRank": 292,
     "countryRank": 13,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21303,6 +21595,7 @@
     "appearances": 4,
     "aggregatedRank": 293,
     "countryRank": 10,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21376,6 +21669,7 @@
     "appearances": 4,
     "aggregatedRank": 294,
     "countryRank": 14,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21449,6 +21743,7 @@
     "appearances": 4,
     "aggregatedRank": 295,
     "countryRank": 71,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21522,6 +21817,7 @@
     "appearances": 4,
     "aggregatedRank": 296,
     "countryRank": 20,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21595,6 +21891,7 @@
     "appearances": 4,
     "aggregatedRank": 297,
     "countryRank": 4,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21668,6 +21965,7 @@
     "appearances": 4,
     "aggregatedRank": 298,
     "countryRank": 3,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21742,6 +22040,7 @@
     "appearances": 4,
     "aggregatedRank": 299,
     "countryRank": 11,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21815,6 +22114,7 @@
     "appearances": 4,
     "aggregatedRank": 300,
     "countryRank": 1,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21889,6 +22189,7 @@
     "appearances": 4,
     "aggregatedRank": 301,
     "countryRank": 9,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -21962,6 +22263,7 @@
     "appearances": 4,
     "aggregatedRank": 302,
     "countryRank": 72,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22032,6 +22334,7 @@
     "appearances": 3,
     "aggregatedRank": 303,
     "countryRank": 12,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22105,6 +22408,7 @@
     "appearances": 4,
     "aggregatedRank": 304,
     "countryRank": 73,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22179,6 +22483,7 @@
     "appearances": 4,
     "aggregatedRank": 305,
     "countryRank": 15,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22252,6 +22557,7 @@
     "appearances": 4,
     "aggregatedRank": 306,
     "countryRank": 74,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22320,6 +22626,7 @@
     "appearances": 3,
     "aggregatedRank": 307,
     "countryRank": 13,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22394,6 +22701,7 @@
     "appearances": 4,
     "aggregatedRank": 308,
     "countryRank": 33,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22465,6 +22773,7 @@
     "appearances": 3,
     "aggregatedRank": 309,
     "countryRank": 7,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22539,6 +22848,7 @@
     "appearances": 4,
     "aggregatedRank": 310,
     "countryRank": 75,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22609,6 +22919,7 @@
     "appearances": 3,
     "aggregatedRank": 311,
     "countryRank": 5,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22682,6 +22993,7 @@
     "appearances": 4,
     "aggregatedRank": 312,
     "countryRank": 21,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22755,6 +23067,7 @@
     "appearances": 4,
     "aggregatedRank": 313,
     "countryRank": 76,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22828,6 +23141,7 @@
     "appearances": 4,
     "aggregatedRank": 314,
     "countryRank": 8,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22901,6 +23215,7 @@
     "appearances": 4,
     "aggregatedRank": 315,
     "countryRank": 34,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -22974,6 +23289,7 @@
     "appearances": 4,
     "aggregatedRank": 316,
     "countryRank": 13,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23047,6 +23363,7 @@
     "appearances": 4,
     "aggregatedRank": 317,
     "countryRank": 3,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23120,6 +23437,7 @@
     "appearances": 4,
     "aggregatedRank": 318,
     "countryRank": 77,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23193,6 +23511,7 @@
     "appearances": 4,
     "aggregatedRank": 319,
     "countryRank": 22,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23266,6 +23585,7 @@
     "appearances": 4,
     "aggregatedRank": 320,
     "countryRank": 78,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23336,6 +23656,7 @@
     "appearances": 3,
     "aggregatedRank": 321,
     "countryRank": 11,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23409,6 +23730,7 @@
     "appearances": 4,
     "aggregatedRank": 322,
     "countryRank": 14,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23479,6 +23801,7 @@
     "appearances": 3,
     "aggregatedRank": 323,
     "countryRank": 7,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23552,6 +23875,7 @@
     "appearances": 4,
     "aggregatedRank": 324,
     "countryRank": 15,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23625,6 +23949,7 @@
     "appearances": 4,
     "aggregatedRank": 325,
     "countryRank": 8,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23695,6 +24020,7 @@
     "appearances": 3,
     "aggregatedRank": 326,
     "countryRank": 16,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23768,6 +24094,7 @@
     "appearances": 4,
     "aggregatedRank": 327,
     "countryRank": 5,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23839,6 +24166,7 @@
     "appearances": 3,
     "aggregatedRank": 328,
     "countryRank": 17,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23912,6 +24240,7 @@
     "appearances": 4,
     "aggregatedRank": 329,
     "countryRank": 14,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -23985,6 +24314,7 @@
     "appearances": 4,
     "aggregatedRank": 330,
     "countryRank": 18,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24059,6 +24389,7 @@
     "appearances": 4,
     "aggregatedRank": 331,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24132,6 +24463,7 @@
     "appearances": 4,
     "aggregatedRank": 332,
     "countryRank": 35,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24202,6 +24534,7 @@
     "appearances": 3,
     "aggregatedRank": 333,
     "countryRank": 6,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24276,6 +24609,7 @@
     "appearances": 4,
     "aggregatedRank": 334,
     "countryRank": 36,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24349,6 +24683,7 @@
     "appearances": 4,
     "aggregatedRank": 335,
     "countryRank": 1,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24422,6 +24757,7 @@
     "appearances": 4,
     "aggregatedRank": 336,
     "countryRank": 2,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24495,6 +24831,7 @@
     "appearances": 4,
     "aggregatedRank": 337,
     "countryRank": 15,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24569,6 +24906,7 @@
     "appearances": 4,
     "aggregatedRank": 338,
     "countryRank": 79,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24642,6 +24980,7 @@
     "appearances": 4,
     "aggregatedRank": 339,
     "countryRank": 2,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24715,6 +25054,7 @@
     "appearances": 4,
     "aggregatedRank": 340,
     "countryRank": 37,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24788,6 +25128,7 @@
     "appearances": 4,
     "aggregatedRank": 341,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24859,6 +25200,7 @@
     "appearances": 4,
     "aggregatedRank": 342,
     "countryRank": 80,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -24930,6 +25272,7 @@
     "appearances": 4,
     "aggregatedRank": 343,
     "countryRank": 1,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25003,6 +25346,7 @@
     "appearances": 4,
     "aggregatedRank": 344,
     "countryRank": 4,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25076,6 +25420,7 @@
     "appearances": 4,
     "aggregatedRank": 345,
     "countryRank": 81,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25149,6 +25494,7 @@
     "appearances": 4,
     "aggregatedRank": 346,
     "countryRank": 1,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25222,6 +25568,7 @@
     "appearances": 4,
     "aggregatedRank": 347,
     "countryRank": 5,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25295,6 +25642,7 @@
     "appearances": 4,
     "aggregatedRank": 348,
     "countryRank": 23,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25368,6 +25716,7 @@
     "appearances": 4,
     "aggregatedRank": 349,
     "countryRank": 82,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25439,6 +25788,7 @@
     "appearances": 4,
     "aggregatedRank": 350,
     "countryRank": 38,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25509,6 +25859,7 @@
     "appearances": 3,
     "aggregatedRank": 351,
     "countryRank": 16,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25579,6 +25930,7 @@
     "appearances": 3,
     "aggregatedRank": 352,
     "countryRank": 19,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25650,6 +26002,7 @@
     "appearances": 4,
     "aggregatedRank": 353,
     "countryRank": 1,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25720,6 +26073,7 @@
     "appearances": 3,
     "aggregatedRank": 354,
     "countryRank": 10,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25790,6 +26144,7 @@
     "appearances": 3,
     "aggregatedRank": 355,
     "countryRank": 83,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25863,6 +26218,7 @@
     "appearances": 4,
     "aggregatedRank": 356,
     "countryRank": 84,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -25936,6 +26292,7 @@
     "appearances": 4,
     "aggregatedRank": 357,
     "countryRank": 17,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26009,6 +26366,7 @@
     "appearances": 4,
     "aggregatedRank": 358,
     "countryRank": 85,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26082,6 +26440,7 @@
     "appearances": 4,
     "aggregatedRank": 359,
     "countryRank": 86,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26152,6 +26511,7 @@
     "appearances": 3,
     "aggregatedRank": 360,
     "countryRank": 12,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26225,6 +26585,7 @@
     "appearances": 4,
     "aggregatedRank": 361,
     "countryRank": 4,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26298,6 +26659,7 @@
     "appearances": 4,
     "aggregatedRank": 362,
     "countryRank": 20,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26371,6 +26733,7 @@
     "appearances": 4,
     "aggregatedRank": 363,
     "countryRank": 87,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26444,6 +26807,7 @@
     "appearances": 4,
     "aggregatedRank": 364,
     "countryRank": 88,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26514,6 +26878,7 @@
     "appearances": 3,
     "aggregatedRank": 365,
     "countryRank": 10,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26584,6 +26949,7 @@
     "appearances": 3,
     "aggregatedRank": 366,
     "countryRank": 4,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26654,6 +27020,7 @@
     "appearances": 3,
     "aggregatedRank": 367,
     "countryRank": 5,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26725,6 +27092,7 @@
     "appearances": 4,
     "aggregatedRank": 368,
     "countryRank": 35,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26798,6 +27166,7 @@
     "appearances": 4,
     "aggregatedRank": 369,
     "countryRank": 5,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26868,6 +27237,7 @@
     "appearances": 3,
     "aggregatedRank": 370,
     "countryRank": 21,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -26938,6 +27308,7 @@
     "appearances": 3,
     "aggregatedRank": 371,
     "countryRank": 3,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27011,6 +27382,7 @@
     "appearances": 4,
     "aggregatedRank": 372,
     "countryRank": 18,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27081,6 +27453,7 @@
     "appearances": 3,
     "aggregatedRank": 373,
     "countryRank": 22,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27152,6 +27525,7 @@
     "appearances": 4,
     "aggregatedRank": 374,
     "countryRank": 23,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27222,6 +27596,7 @@
     "appearances": 3,
     "aggregatedRank": 375,
     "countryRank": 24,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27293,6 +27668,7 @@
     "appearances": 4,
     "aggregatedRank": 376,
     "countryRank": 36,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27364,6 +27740,7 @@
     "appearances": 4,
     "aggregatedRank": 377,
     "countryRank": 13,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27437,6 +27814,7 @@
     "appearances": 4,
     "aggregatedRank": 378,
     "countryRank": 89,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27508,6 +27886,7 @@
     "appearances": 4,
     "aggregatedRank": 379,
     "countryRank": 37,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27579,6 +27958,7 @@
     "appearances": 4,
     "aggregatedRank": 380,
     "countryRank": 9,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27653,6 +28033,7 @@
     "appearances": 4,
     "aggregatedRank": 381,
     "countryRank": 2,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27726,6 +28107,7 @@
     "appearances": 4,
     "aggregatedRank": 382,
     "countryRank": 90,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27799,6 +28181,7 @@
     "appearances": 4,
     "aggregatedRank": 383,
     "countryRank": 2,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27872,6 +28255,7 @@
     "appearances": 4,
     "aggregatedRank": 384,
     "countryRank": 3,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -27942,6 +28326,7 @@
     "appearances": 3,
     "aggregatedRank": 385,
     "countryRank": 25,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28012,6 +28397,7 @@
     "appearances": 3,
     "aggregatedRank": 386,
     "countryRank": 24,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28085,6 +28471,7 @@
     "appearances": 4,
     "aggregatedRank": 387,
     "countryRank": 2,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28153,6 +28540,7 @@
     "appearances": 3,
     "aggregatedRank": 388,
     "countryRank": 4,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28226,6 +28614,7 @@
     "appearances": 4,
     "aggregatedRank": 389,
     "countryRank": 16,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28300,6 +28689,7 @@
     "appearances": 4,
     "aggregatedRank": 390,
     "countryRank": 91,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28373,6 +28763,7 @@
     "appearances": 4,
     "aggregatedRank": 391,
     "countryRank": 92,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28443,6 +28834,7 @@
     "appearances": 3,
     "aggregatedRank": 392,
     "countryRank": 26,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28516,6 +28908,7 @@
     "appearances": 4,
     "aggregatedRank": 393,
     "countryRank": 3,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28587,6 +28980,7 @@
     "appearances": 3,
     "aggregatedRank": 394,
     "countryRank": 3,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28660,6 +29054,7 @@
     "appearances": 4,
     "aggregatedRank": 395,
     "countryRank": 17,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28733,6 +29128,7 @@
     "appearances": 4,
     "aggregatedRank": 396,
     "countryRank": 11,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28806,6 +29202,7 @@
     "appearances": 4,
     "aggregatedRank": 397,
     "countryRank": 6,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28879,6 +29276,7 @@
     "appearances": 4,
     "aggregatedRank": 398,
     "countryRank": 93,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -28952,6 +29350,7 @@
     "appearances": 4,
     "aggregatedRank": 399,
     "countryRank": 2,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29025,6 +29424,7 @@
     "appearances": 4,
     "aggregatedRank": 400,
     "countryRank": 4,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29099,6 +29499,7 @@
     "appearances": 4,
     "aggregatedRank": 401,
     "countryRank": 27,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29172,6 +29573,7 @@
     "appearances": 4,
     "aggregatedRank": 402,
     "countryRank": 25,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29245,6 +29647,7 @@
     "appearances": 4,
     "aggregatedRank": 403,
     "countryRank": 28,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29315,6 +29718,7 @@
     "appearances": 3,
     "aggregatedRank": 404,
     "countryRank": 1,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29388,6 +29792,7 @@
     "appearances": 4,
     "aggregatedRank": 405,
     "countryRank": 5,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29461,6 +29866,7 @@
     "appearances": 4,
     "aggregatedRank": 406,
     "countryRank": 94,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29534,6 +29940,7 @@
     "appearances": 4,
     "aggregatedRank": 407,
     "countryRank": 95,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29607,6 +30014,7 @@
     "appearances": 4,
     "aggregatedRank": 408,
     "countryRank": 11,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29677,6 +30085,7 @@
     "appearances": 3,
     "aggregatedRank": 409,
     "countryRank": 96,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29751,6 +30160,7 @@
     "appearances": 4,
     "aggregatedRank": 410,
     "countryRank": 97,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29824,6 +30234,7 @@
     "appearances": 4,
     "aggregatedRank": 411,
     "countryRank": 38,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29897,6 +30308,7 @@
     "appearances": 4,
     "aggregatedRank": 412,
     "countryRank": 6,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -29970,6 +30382,7 @@
     "appearances": 4,
     "aggregatedRank": 413,
     "countryRank": 2,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30043,6 +30456,7 @@
     "appearances": 4,
     "aggregatedRank": 414,
     "countryRank": 7,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30113,6 +30527,7 @@
     "appearances": 3,
     "aggregatedRank": 415,
     "countryRank": 7,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30187,6 +30602,7 @@
     "appearances": 4,
     "aggregatedRank": 416,
     "countryRank": 39,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30257,6 +30673,7 @@
     "appearances": 3,
     "aggregatedRank": 417,
     "countryRank": 29,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30330,6 +30747,7 @@
     "appearances": 4,
     "aggregatedRank": 418,
     "countryRank": 12,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30403,6 +30821,7 @@
     "appearances": 4,
     "aggregatedRank": 419,
     "countryRank": 10,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30477,6 +30896,7 @@
     "appearances": 4,
     "aggregatedRank": 420,
     "countryRank": 98,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30550,6 +30970,7 @@
     "appearances": 4,
     "aggregatedRank": 421,
     "countryRank": 6,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30623,6 +31044,7 @@
     "appearances": 4,
     "aggregatedRank": 422,
     "countryRank": 1,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30696,6 +31118,7 @@
     "appearances": 4,
     "aggregatedRank": 423,
     "countryRank": 26,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30769,6 +31192,7 @@
     "appearances": 4,
     "aggregatedRank": 424,
     "countryRank": 8,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30839,6 +31263,7 @@
     "appearances": 3,
     "aggregatedRank": 425,
     "countryRank": 27,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30912,6 +31337,7 @@
     "appearances": 4,
     "aggregatedRank": 426,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -30982,6 +31408,7 @@
     "appearances": 3,
     "aggregatedRank": 427,
     "countryRank": 40,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31052,6 +31479,7 @@
     "appearances": 3,
     "aggregatedRank": 428,
     "countryRank": 30,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31125,6 +31553,7 @@
     "appearances": 4,
     "aggregatedRank": 429,
     "countryRank": 99,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31198,6 +31627,7 @@
     "appearances": 4,
     "aggregatedRank": 430,
     "countryRank": 11,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31269,6 +31699,7 @@
     "appearances": 3,
     "aggregatedRank": 431,
     "countryRank": 1,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31343,6 +31774,7 @@
     "appearances": 4,
     "aggregatedRank": 432,
     "countryRank": 12,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31416,6 +31848,7 @@
     "appearances": 4,
     "aggregatedRank": 433,
     "countryRank": 2,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31489,6 +31922,7 @@
     "appearances": 4,
     "aggregatedRank": 434,
     "countryRank": 13,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31559,6 +31993,7 @@
     "appearances": 3,
     "aggregatedRank": 435,
     "countryRank": 3,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31632,6 +32067,7 @@
     "appearances": 4,
     "aggregatedRank": 436,
     "countryRank": 1,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31705,6 +32141,7 @@
     "appearances": 4,
     "aggregatedRank": 437,
     "countryRank": 2,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31775,6 +32212,7 @@
     "appearances": 3,
     "aggregatedRank": 438,
     "countryRank": 8,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31848,6 +32286,7 @@
     "appearances": 4,
     "aggregatedRank": 439,
     "countryRank": 18,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31921,6 +32360,7 @@
     "appearances": 4,
     "aggregatedRank": 440,
     "countryRank": 5,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -31994,6 +32434,7 @@
     "appearances": 4,
     "aggregatedRank": 441,
     "countryRank": 6,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32067,6 +32508,7 @@
     "appearances": 4,
     "aggregatedRank": 442,
     "countryRank": 19,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32137,6 +32579,7 @@
     "appearances": 3,
     "aggregatedRank": 443,
     "countryRank": 41,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32207,6 +32650,7 @@
     "appearances": 3,
     "aggregatedRank": 444,
     "countryRank": 5,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32280,6 +32724,7 @@
     "appearances": 4,
     "aggregatedRank": 445,
     "countryRank": 39,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32353,6 +32798,7 @@
     "appearances": 4,
     "aggregatedRank": 446,
     "countryRank": 100,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32426,6 +32872,7 @@
     "appearances": 4,
     "aggregatedRank": 447,
     "countryRank": 20,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32500,6 +32947,7 @@
     "appearances": 4,
     "aggregatedRank": 448,
     "countryRank": 4,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32573,6 +33021,7 @@
     "appearances": 4,
     "aggregatedRank": 449,
     "countryRank": 1,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32643,6 +33092,7 @@
     "appearances": 3,
     "aggregatedRank": 450,
     "countryRank": 42,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32717,6 +33167,7 @@
     "appearances": 4,
     "aggregatedRank": 451,
     "countryRank": 101,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32787,6 +33238,7 @@
     "appearances": 3,
     "aggregatedRank": 452,
     "countryRank": 5,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32861,6 +33313,7 @@
     "appearances": 4,
     "aggregatedRank": 453,
     "countryRank": 2,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -32931,6 +33384,7 @@
     "appearances": 3,
     "aggregatedRank": 454,
     "countryRank": 31,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33002,6 +33456,7 @@
     "appearances": 3,
     "aggregatedRank": 455,
     "countryRank": 43,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33070,6 +33525,7 @@
     "appearances": 3,
     "aggregatedRank": 456,
     "countryRank": 21,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33140,6 +33596,7 @@
     "appearances": 3,
     "aggregatedRank": 457,
     "countryRank": 6,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33210,6 +33667,7 @@
     "appearances": 3,
     "aggregatedRank": 458,
     "countryRank": 6,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33281,6 +33739,7 @@
     "appearances": 4,
     "aggregatedRank": 459,
     "countryRank": 1,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33354,6 +33813,7 @@
     "appearances": 4,
     "aggregatedRank": 460,
     "countryRank": 40,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33428,6 +33888,7 @@
     "appearances": 4,
     "aggregatedRank": 461,
     "countryRank": 19,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33498,6 +33959,7 @@
     "appearances": 3,
     "aggregatedRank": 462,
     "countryRank": 9,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33571,6 +34033,7 @@
     "appearances": 4,
     "aggregatedRank": 463,
     "countryRank": 102,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33641,6 +34104,7 @@
     "appearances": 3,
     "aggregatedRank": 464,
     "countryRank": 3,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33711,6 +34175,7 @@
     "appearances": 3,
     "aggregatedRank": 465,
     "countryRank": 4,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33784,6 +34249,7 @@
     "appearances": 4,
     "aggregatedRank": 466,
     "countryRank": 3,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33857,6 +34323,7 @@
     "appearances": 4,
     "aggregatedRank": 467,
     "countryRank": 7,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -33927,6 +34394,7 @@
     "appearances": 3,
     "aggregatedRank": 468,
     "countryRank": 44,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34000,6 +34468,7 @@
     "appearances": 4,
     "aggregatedRank": 469,
     "countryRank": 103,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34073,6 +34542,7 @@
     "appearances": 4,
     "aggregatedRank": 470,
     "countryRank": 6,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34144,6 +34614,7 @@
     "appearances": 3,
     "aggregatedRank": 471,
     "countryRank": 32,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34214,6 +34685,7 @@
     "appearances": 3,
     "aggregatedRank": 472,
     "countryRank": 2,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34287,6 +34759,7 @@
     "appearances": 4,
     "aggregatedRank": 473,
     "countryRank": 41,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34360,6 +34833,7 @@
     "appearances": 4,
     "aggregatedRank": 474,
     "countryRank": 13,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34433,6 +34907,7 @@
     "appearances": 4,
     "aggregatedRank": 475,
     "countryRank": 7,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34506,6 +34981,7 @@
     "appearances": 4,
     "aggregatedRank": 476,
     "countryRank": 42,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34576,6 +35052,7 @@
     "appearances": 3,
     "aggregatedRank": 477,
     "countryRank": 43,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34649,6 +35126,7 @@
     "appearances": 4,
     "aggregatedRank": 478,
     "countryRank": 44,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34722,6 +35200,7 @@
     "appearances": 4,
     "aggregatedRank": 479,
     "countryRank": 45,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34792,6 +35271,7 @@
     "appearances": 3,
     "aggregatedRank": 480,
     "countryRank": 10,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34865,6 +35345,7 @@
     "appearances": 4,
     "aggregatedRank": 481,
     "countryRank": 5,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -34938,6 +35419,7 @@
     "appearances": 4,
     "aggregatedRank": 482,
     "countryRank": 46,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35009,6 +35491,7 @@
     "appearances": 4,
     "aggregatedRank": 483,
     "countryRank": 22,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35079,6 +35562,7 @@
     "appearances": 3,
     "aggregatedRank": 484,
     "countryRank": 23,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35149,6 +35633,7 @@
     "appearances": 3,
     "aggregatedRank": 485,
     "countryRank": 4,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35219,6 +35704,7 @@
     "appearances": 3,
     "aggregatedRank": 486,
     "countryRank": 3,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35289,6 +35775,7 @@
     "appearances": 3,
     "aggregatedRank": 487,
     "countryRank": 24,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35359,6 +35846,7 @@
     "appearances": 3,
     "aggregatedRank": 488,
     "countryRank": 104,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35429,6 +35917,7 @@
     "appearances": 3,
     "aggregatedRank": 489,
     "countryRank": 9,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35499,6 +35988,7 @@
     "appearances": 3,
     "aggregatedRank": 490,
     "countryRank": 6,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35569,6 +36059,7 @@
     "appearances": 3,
     "aggregatedRank": 491,
     "countryRank": 105,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35642,6 +36133,7 @@
     "appearances": 4,
     "aggregatedRank": 492,
     "countryRank": 47,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35715,6 +36207,7 @@
     "appearances": 4,
     "aggregatedRank": 493,
     "countryRank": 8,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35788,6 +36281,7 @@
     "appearances": 4,
     "aggregatedRank": 494,
     "countryRank": 25,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35858,6 +36352,7 @@
     "appearances": 3,
     "aggregatedRank": 495,
     "countryRank": 11,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -35932,6 +36427,7 @@
     "appearances": 4,
     "aggregatedRank": 496,
     "countryRank": 48,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36002,6 +36498,7 @@
     "appearances": 3,
     "aggregatedRank": 497,
     "countryRank": 4,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36075,6 +36572,7 @@
     "appearances": 4,
     "aggregatedRank": 498,
     "countryRank": 20,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36143,6 +36641,7 @@
     "appearances": 3,
     "aggregatedRank": 499,
     "countryRank": 45,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36216,6 +36715,7 @@
     "appearances": 4,
     "aggregatedRank": 500,
     "countryRank": 6,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36286,6 +36786,7 @@
     "appearances": 3,
     "aggregatedRank": 501,
     "countryRank": 46,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36359,6 +36860,7 @@
     "appearances": 4,
     "aggregatedRank": 502,
     "countryRank": 14,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36430,6 +36932,7 @@
     "appearances": 3,
     "aggregatedRank": 503,
     "countryRank": 2,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36500,6 +37003,7 @@
     "appearances": 3,
     "aggregatedRank": 504,
     "countryRank": 47,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36570,6 +37074,7 @@
     "appearances": 3,
     "aggregatedRank": 505,
     "countryRank": 48,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36643,6 +37148,7 @@
     "appearances": 4,
     "aggregatedRank": 506,
     "countryRank": 49,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36714,6 +37220,7 @@
     "appearances": 4,
     "aggregatedRank": 507,
     "countryRank": 106,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36784,6 +37291,7 @@
     "appearances": 3,
     "aggregatedRank": 508,
     "countryRank": 5,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36854,6 +37362,7 @@
     "appearances": 3,
     "aggregatedRank": 509,
     "countryRank": 9,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36924,6 +37433,7 @@
     "appearances": 3,
     "aggregatedRank": 510,
     "countryRank": 21,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -36997,6 +37507,7 @@
     "appearances": 4,
     "aggregatedRank": 511,
     "countryRank": 26,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37070,6 +37581,7 @@
     "appearances": 4,
     "aggregatedRank": 512,
     "countryRank": 27,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37140,6 +37652,7 @@
     "appearances": 3,
     "aggregatedRank": 513,
     "countryRank": 49,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37210,6 +37723,7 @@
     "appearances": 3,
     "aggregatedRank": 514,
     "countryRank": 50,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37280,6 +37794,7 @@
     "appearances": 3,
     "aggregatedRank": 515,
     "countryRank": 33,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37353,6 +37868,7 @@
     "appearances": 4,
     "aggregatedRank": 516,
     "countryRank": 12,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37423,6 +37939,7 @@
     "appearances": 3,
     "aggregatedRank": 517,
     "countryRank": 9,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37496,6 +38013,7 @@
     "appearances": 4,
     "aggregatedRank": 518,
     "countryRank": 10,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37566,6 +38084,7 @@
     "appearances": 3,
     "aggregatedRank": 519,
     "countryRank": 28,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37636,6 +38155,7 @@
     "appearances": 3,
     "aggregatedRank": 520,
     "countryRank": 51,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37706,6 +38226,7 @@
     "appearances": 3,
     "aggregatedRank": 521,
     "countryRank": 52,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37779,6 +38300,7 @@
     "appearances": 4,
     "aggregatedRank": 522,
     "countryRank": 53,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37852,6 +38374,7 @@
     "appearances": 4,
     "aggregatedRank": 523,
     "countryRank": 29,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37922,6 +38445,7 @@
     "appearances": 3,
     "aggregatedRank": 524,
     "countryRank": 50,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -37992,6 +38516,7 @@
     "appearances": 3,
     "aggregatedRank": 525,
     "countryRank": 1,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38062,6 +38587,7 @@
     "appearances": 3,
     "aggregatedRank": 526,
     "countryRank": 12,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38132,6 +38658,7 @@
     "appearances": 3,
     "aggregatedRank": 527,
     "countryRank": 8,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38203,6 +38730,7 @@
     "appearances": 3,
     "aggregatedRank": 528,
     "countryRank": 1,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38273,6 +38801,7 @@
     "appearances": 3,
     "aggregatedRank": 529,
     "countryRank": 54,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38343,6 +38872,7 @@
     "appearances": 3,
     "aggregatedRank": 530,
     "countryRank": 107,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38413,6 +38943,7 @@
     "appearances": 3,
     "aggregatedRank": 531,
     "countryRank": 55,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38480,6 +39011,7 @@
     "appearances": 2,
     "aggregatedRank": 532,
     "countryRank": 108,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38548,6 +39080,7 @@
     "appearances": 3,
     "aggregatedRank": 533,
     "countryRank": 51,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38618,6 +39151,7 @@
     "appearances": 3,
     "aggregatedRank": 534,
     "countryRank": 4,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38688,6 +39222,7 @@
     "appearances": 3,
     "aggregatedRank": 535,
     "countryRank": 13,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38758,6 +39293,7 @@
     "appearances": 3,
     "aggregatedRank": 536,
     "countryRank": 56,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38831,6 +39367,7 @@
     "appearances": 4,
     "aggregatedRank": 537,
     "countryRank": 3,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38901,6 +39438,7 @@
     "appearances": 3,
     "aggregatedRank": 538,
     "countryRank": 1,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -38971,6 +39509,7 @@
     "appearances": 3,
     "aggregatedRank": 539,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39041,6 +39580,7 @@
     "appearances": 3,
     "aggregatedRank": 540,
     "countryRank": 3,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39111,6 +39651,7 @@
     "appearances": 3,
     "aggregatedRank": 541,
     "countryRank": 57,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39181,6 +39722,7 @@
     "appearances": 3,
     "aggregatedRank": 542,
     "countryRank": 58,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39249,6 +39791,7 @@
     "appearances": 3,
     "aggregatedRank": 543,
     "countryRank": 34,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39319,6 +39862,7 @@
     "appearances": 3,
     "aggregatedRank": 544,
     "countryRank": 59,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39392,6 +39936,7 @@
     "appearances": 4,
     "aggregatedRank": 545,
     "countryRank": 5,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39459,6 +40004,7 @@
     "appearances": 2,
     "aggregatedRank": 546,
     "countryRank": 109,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39529,6 +40075,7 @@
     "appearances": 3,
     "aggregatedRank": 547,
     "countryRank": 6,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39596,6 +40143,7 @@
     "appearances": 2,
     "aggregatedRank": 548,
     "countryRank": 110,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39666,6 +40214,7 @@
     "appearances": 3,
     "aggregatedRank": 549,
     "countryRank": 60,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39739,6 +40288,7 @@
     "appearances": 4,
     "aggregatedRank": 550,
     "countryRank": 15,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39806,6 +40356,7 @@
     "appearances": 2,
     "aggregatedRank": 551,
     "countryRank": 111,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39877,6 +40428,7 @@
     "appearances": 4,
     "aggregatedRank": 552,
     "countryRank": 35,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -39947,6 +40499,7 @@
     "appearances": 3,
     "aggregatedRank": 553,
     "countryRank": 112,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40017,6 +40570,7 @@
     "appearances": 3,
     "aggregatedRank": 554,
     "countryRank": 61,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40085,6 +40639,7 @@
     "appearances": 3,
     "aggregatedRank": 555,
     "countryRank": 36,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40155,6 +40710,7 @@
     "appearances": 3,
     "aggregatedRank": 556,
     "countryRank": 62,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40225,6 +40781,7 @@
     "appearances": 3,
     "aggregatedRank": 557,
     "countryRank": 7,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40295,6 +40852,7 @@
     "appearances": 3,
     "aggregatedRank": 558,
     "countryRank": 3,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40365,6 +40923,7 @@
     "appearances": 3,
     "aggregatedRank": 559,
     "countryRank": 4,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40432,6 +40991,7 @@
     "appearances": 2,
     "aggregatedRank": 560,
     "countryRank": 7,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40505,6 +41065,7 @@
     "appearances": 4,
     "aggregatedRank": 561,
     "countryRank": 113,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40578,6 +41139,7 @@
     "appearances": 4,
     "aggregatedRank": 562,
     "countryRank": 3,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40651,6 +41213,7 @@
     "appearances": 4,
     "aggregatedRank": 563,
     "countryRank": 3,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40721,6 +41284,7 @@
     "appearances": 3,
     "aggregatedRank": 564,
     "countryRank": 52,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40791,6 +41355,7 @@
     "appearances": 3,
     "aggregatedRank": 565,
     "countryRank": 11,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40858,6 +41423,7 @@
     "appearances": 2,
     "aggregatedRank": 566,
     "countryRank": 37,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40928,6 +41494,7 @@
     "appearances": 3,
     "aggregatedRank": 567,
     "countryRank": 12,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -40996,6 +41563,7 @@
     "appearances": 3,
     "aggregatedRank": 568,
     "countryRank": 16,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41066,6 +41634,7 @@
     "appearances": 3,
     "aggregatedRank": 569,
     "countryRank": 63,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41136,6 +41705,7 @@
     "appearances": 3,
     "aggregatedRank": 570,
     "countryRank": 5,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41206,6 +41776,7 @@
     "appearances": 3,
     "aggregatedRank": 571,
     "countryRank": 4,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41277,6 +41848,7 @@
     "appearances": 3,
     "aggregatedRank": 572,
     "countryRank": 6,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41347,6 +41919,7 @@
     "appearances": 3,
     "aggregatedRank": 573,
     "countryRank": 64,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41420,6 +41993,7 @@
     "appearances": 4,
     "aggregatedRank": 574,
     "countryRank": 30,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41490,6 +42064,7 @@
     "appearances": 3,
     "aggregatedRank": 575,
     "countryRank": 114,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41560,6 +42135,7 @@
     "appearances": 3,
     "aggregatedRank": 576,
     "countryRank": 65,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41630,6 +42206,7 @@
     "appearances": 3,
     "aggregatedRank": 577,
     "countryRank": 8,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41700,6 +42277,7 @@
     "appearances": 3,
     "aggregatedRank": 578,
     "countryRank": 66,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41770,6 +42348,7 @@
     "appearances": 3,
     "aggregatedRank": 579,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41837,6 +42416,7 @@
     "appearances": 2,
     "aggregatedRank": 580,
     "countryRank": 13,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41902,6 +42482,7 @@
     "appearances": 2,
     "aggregatedRank": 581,
     "countryRank": 53,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -41972,6 +42553,7 @@
     "appearances": 3,
     "aggregatedRank": 582,
     "countryRank": 13,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42039,6 +42621,7 @@
     "appearances": 2,
     "aggregatedRank": 583,
     "countryRank": 10,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42106,6 +42689,7 @@
     "appearances": 2,
     "aggregatedRank": 584,
     "countryRank": 115,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42176,6 +42760,7 @@
     "appearances": 3,
     "aggregatedRank": 585,
     "countryRank": 22,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42249,6 +42834,7 @@
     "appearances": 4,
     "aggregatedRank": 586,
     "countryRank": 54,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42320,6 +42906,7 @@
     "appearances": 3,
     "aggregatedRank": 587,
     "countryRank": 67,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42390,6 +42977,7 @@
     "appearances": 3,
     "aggregatedRank": 588,
     "countryRank": 9,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42463,6 +43051,7 @@
     "appearances": 4,
     "aggregatedRank": 589,
     "countryRank": 3,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42531,6 +43120,7 @@
     "appearances": 3,
     "aggregatedRank": 590,
     "countryRank": 1,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42602,6 +43192,7 @@
     "appearances": 3,
     "aggregatedRank": 591,
     "countryRank": 7,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42672,6 +43263,7 @@
     "appearances": 3,
     "aggregatedRank": 592,
     "countryRank": 116,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42740,6 +43332,7 @@
     "appearances": 3,
     "aggregatedRank": 593,
     "countryRank": 68,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42810,6 +43403,7 @@
     "appearances": 3,
     "aggregatedRank": 594,
     "countryRank": 2,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42880,6 +43474,7 @@
     "appearances": 3,
     "aggregatedRank": 595,
     "countryRank": 5,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -42950,6 +43545,7 @@
     "appearances": 3,
     "aggregatedRank": 596,
     "countryRank": 14,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43020,6 +43616,7 @@
     "appearances": 3,
     "aggregatedRank": 597,
     "countryRank": 117,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43093,6 +43690,7 @@
     "appearances": 4,
     "aggregatedRank": 598,
     "countryRank": 118,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43163,6 +43761,7 @@
     "appearances": 3,
     "aggregatedRank": 599,
     "countryRank": 14,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43233,6 +43832,7 @@
     "appearances": 3,
     "aggregatedRank": 600,
     "countryRank": 119,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43306,6 +43906,7 @@
     "appearances": 4,
     "aggregatedRank": 601,
     "countryRank": 120,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43376,6 +43977,7 @@
     "appearances": 3,
     "aggregatedRank": 602,
     "countryRank": 4,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43443,6 +44045,7 @@
     "appearances": 2,
     "aggregatedRank": 603,
     "countryRank": 69,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43513,6 +44116,7 @@
     "appearances": 3,
     "aggregatedRank": 604,
     "countryRank": 5,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43583,6 +44187,7 @@
     "appearances": 3,
     "aggregatedRank": 605,
     "countryRank": 31,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43650,6 +44255,7 @@
     "appearances": 2,
     "aggregatedRank": 606,
     "countryRank": 6,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43717,6 +44323,7 @@
     "appearances": 2,
     "aggregatedRank": 607,
     "countryRank": 38,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43787,6 +44394,7 @@
     "appearances": 3,
     "aggregatedRank": 608,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43857,6 +44465,7 @@
     "appearances": 3,
     "aggregatedRank": 609,
     "countryRank": 28,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43927,6 +44536,7 @@
     "appearances": 3,
     "aggregatedRank": 610,
     "countryRank": 29,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -43997,6 +44607,7 @@
     "appearances": 3,
     "aggregatedRank": 611,
     "countryRank": 70,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44068,6 +44679,7 @@
     "appearances": 3,
     "aggregatedRank": 612,
     "countryRank": 39,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44135,6 +44747,7 @@
     "appearances": 2,
     "aggregatedRank": 613,
     "countryRank": 121,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44203,6 +44816,7 @@
     "appearances": 3,
     "aggregatedRank": 614,
     "countryRank": 4,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44273,6 +44887,7 @@
     "appearances": 3,
     "aggregatedRank": 615,
     "countryRank": 4,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44343,6 +44958,7 @@
     "appearances": 3,
     "aggregatedRank": 616,
     "countryRank": 122,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44413,6 +45029,7 @@
     "appearances": 3,
     "aggregatedRank": 617,
     "countryRank": 8,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44483,6 +45100,7 @@
     "appearances": 3,
     "aggregatedRank": 618,
     "countryRank": 6,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44553,6 +45171,7 @@
     "appearances": 3,
     "aggregatedRank": 619,
     "countryRank": 32,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44623,6 +45242,7 @@
     "appearances": 3,
     "aggregatedRank": 620,
     "countryRank": 30,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44690,6 +45310,7 @@
     "appearances": 2,
     "aggregatedRank": 621,
     "countryRank": 15,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44760,6 +45381,7 @@
     "appearances": 3,
     "aggregatedRank": 622,
     "countryRank": 5,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44830,6 +45452,7 @@
     "appearances": 3,
     "aggregatedRank": 623,
     "countryRank": 2,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44898,6 +45521,7 @@
     "appearances": 3,
     "aggregatedRank": 624,
     "countryRank": 71,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -44968,6 +45592,7 @@
     "appearances": 3,
     "aggregatedRank": 625,
     "countryRank": 7,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45035,6 +45660,7 @@
     "appearances": 2,
     "aggregatedRank": 626,
     "countryRank": 123,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45106,6 +45732,7 @@
     "appearances": 4,
     "aggregatedRank": 627,
     "countryRank": 4,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45179,6 +45806,7 @@
     "appearances": 4,
     "aggregatedRank": 628,
     "countryRank": 23,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45246,6 +45874,7 @@
     "appearances": 2,
     "aggregatedRank": 629,
     "countryRank": 40,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45316,6 +45945,7 @@
     "appearances": 3,
     "aggregatedRank": 630,
     "countryRank": 124,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45383,6 +46013,7 @@
     "appearances": 2,
     "aggregatedRank": 631,
     "countryRank": 7,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45453,6 +46084,7 @@
     "appearances": 3,
     "aggregatedRank": 632,
     "countryRank": 3,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45523,6 +46155,7 @@
     "appearances": 3,
     "aggregatedRank": 633,
     "countryRank": 9,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45596,6 +46229,7 @@
     "appearances": 4,
     "aggregatedRank": 634,
     "countryRank": 125,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45666,6 +46300,7 @@
     "appearances": 3,
     "aggregatedRank": 635,
     "countryRank": 8,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45736,6 +46371,7 @@
     "appearances": 3,
     "aggregatedRank": 636,
     "countryRank": 126,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45806,6 +46442,7 @@
     "appearances": 3,
     "aggregatedRank": 637,
     "countryRank": 72,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45876,6 +46513,7 @@
     "appearances": 3,
     "aggregatedRank": 638,
     "countryRank": 127,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -45946,6 +46584,7 @@
     "appearances": 3,
     "aggregatedRank": 639,
     "countryRank": 33,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46017,6 +46656,7 @@
     "appearances": 3,
     "aggregatedRank": 640,
     "countryRank": 17,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46087,6 +46727,7 @@
     "appearances": 3,
     "aggregatedRank": 641,
     "countryRank": 5,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46155,6 +46796,7 @@
     "appearances": 2,
     "aggregatedRank": 642,
     "countryRank": 4,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46225,6 +46867,7 @@
     "appearances": 3,
     "aggregatedRank": 643,
     "countryRank": 10,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46295,6 +46938,7 @@
     "appearances": 3,
     "aggregatedRank": 644,
     "countryRank": 128,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46363,6 +47007,7 @@
     "appearances": 3,
     "aggregatedRank": 645,
     "countryRank": 7,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46433,6 +47078,7 @@
     "appearances": 3,
     "aggregatedRank": 646,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46503,6 +47149,7 @@
     "appearances": 3,
     "aggregatedRank": 647,
     "countryRank": 11,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46573,6 +47220,7 @@
     "appearances": 3,
     "aggregatedRank": 648,
     "countryRank": 1,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46640,6 +47288,7 @@
     "appearances": 2,
     "aggregatedRank": 649,
     "countryRank": 6,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46710,6 +47359,7 @@
     "appearances": 3,
     "aggregatedRank": 650,
     "countryRank": 5,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46780,6 +47430,7 @@
     "appearances": 3,
     "aggregatedRank": 651,
     "countryRank": 6,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46847,6 +47498,7 @@
     "appearances": 2,
     "aggregatedRank": 652,
     "countryRank": 73,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46917,6 +47569,7 @@
     "appearances": 3,
     "aggregatedRank": 653,
     "countryRank": 6,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -46985,6 +47638,7 @@
     "appearances": 3,
     "aggregatedRank": 654,
     "countryRank": 7,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47052,6 +47706,7 @@
     "appearances": 2,
     "aggregatedRank": 655,
     "countryRank": 74,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47122,6 +47777,7 @@
     "appearances": 3,
     "aggregatedRank": 656,
     "countryRank": 41,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47195,6 +47851,7 @@
     "appearances": 4,
     "aggregatedRank": 657,
     "countryRank": 14,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47268,6 +47925,7 @@
     "appearances": 4,
     "aggregatedRank": 658,
     "countryRank": 34,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47336,6 +47994,7 @@
     "appearances": 3,
     "aggregatedRank": 659,
     "countryRank": 75,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47406,6 +48065,7 @@
     "appearances": 3,
     "aggregatedRank": 660,
     "countryRank": 6,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47473,6 +48133,7 @@
     "appearances": 2,
     "aggregatedRank": 661,
     "countryRank": 76,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47543,6 +48204,7 @@
     "appearances": 3,
     "aggregatedRank": 662,
     "countryRank": 77,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47610,6 +48272,7 @@
     "appearances": 2,
     "aggregatedRank": 663,
     "countryRank": 2,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47680,6 +48343,7 @@
     "appearances": 3,
     "aggregatedRank": 664,
     "countryRank": 24,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47750,6 +48414,7 @@
     "appearances": 3,
     "aggregatedRank": 665,
     "countryRank": 129,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47820,6 +48485,7 @@
     "appearances": 3,
     "aggregatedRank": 666,
     "countryRank": 15,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47890,6 +48556,7 @@
     "appearances": 3,
     "aggregatedRank": 667,
     "countryRank": 16,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -47960,6 +48627,7 @@
     "appearances": 3,
     "aggregatedRank": 668,
     "countryRank": 18,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48030,6 +48698,7 @@
     "appearances": 3,
     "aggregatedRank": 669,
     "countryRank": 130,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48100,6 +48769,7 @@
     "appearances": 3,
     "aggregatedRank": 670,
     "countryRank": 7,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48170,6 +48840,7 @@
     "appearances": 3,
     "aggregatedRank": 671,
     "countryRank": 8,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48240,6 +48911,7 @@
     "appearances": 3,
     "aggregatedRank": 672,
     "countryRank": 16,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48308,6 +48980,7 @@
     "appearances": 2,
     "aggregatedRank": 673,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48375,6 +49048,7 @@
     "appearances": 2,
     "aggregatedRank": 674,
     "countryRank": 19,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48445,6 +49119,7 @@
     "appearances": 3,
     "aggregatedRank": 675,
     "countryRank": 7,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48515,6 +49190,7 @@
     "appearances": 3,
     "aggregatedRank": 676,
     "countryRank": 131,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48585,6 +49261,7 @@
     "appearances": 3,
     "aggregatedRank": 677,
     "countryRank": 8,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48652,6 +49329,7 @@
     "appearances": 2,
     "aggregatedRank": 678,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48723,6 +49401,7 @@
     "appearances": 3,
     "aggregatedRank": 679,
     "countryRank": 132,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48794,6 +49473,7 @@
     "appearances": 4,
     "aggregatedRank": 680,
     "countryRank": 55,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48864,6 +49544,7 @@
     "appearances": 3,
     "aggregatedRank": 681,
     "countryRank": 1,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -48934,6 +49615,7 @@
     "appearances": 3,
     "aggregatedRank": 682,
     "countryRank": 78,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49005,6 +49687,7 @@
     "appearances": 3,
     "aggregatedRank": 683,
     "countryRank": 56,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49075,6 +49758,7 @@
     "appearances": 3,
     "aggregatedRank": 684,
     "countryRank": 79,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49142,6 +49826,7 @@
     "appearances": 2,
     "aggregatedRank": 685,
     "countryRank": 20,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49209,6 +49894,7 @@
     "appearances": 2,
     "aggregatedRank": 686,
     "countryRank": 2,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49279,6 +49965,7 @@
     "appearances": 3,
     "aggregatedRank": 687,
     "countryRank": 133,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49349,6 +50036,7 @@
     "appearances": 3,
     "aggregatedRank": 688,
     "countryRank": 9,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49419,6 +50107,7 @@
     "appearances": 3,
     "aggregatedRank": 689,
     "countryRank": 3,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49489,6 +50178,7 @@
     "appearances": 3,
     "aggregatedRank": 690,
     "countryRank": 21,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49559,6 +50249,7 @@
     "appearances": 3,
     "aggregatedRank": 691,
     "countryRank": 10,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49626,6 +50317,7 @@
     "appearances": 2,
     "aggregatedRank": 692,
     "countryRank": 80,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49699,6 +50391,7 @@
     "appearances": 4,
     "aggregatedRank": 693,
     "countryRank": 17,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49772,6 +50465,7 @@
     "appearances": 4,
     "aggregatedRank": 694,
     "countryRank": 35,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49842,6 +50536,7 @@
     "appearances": 3,
     "aggregatedRank": 695,
     "countryRank": 2,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49913,6 +50608,7 @@
     "appearances": 3,
     "aggregatedRank": 696,
     "countryRank": 6,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -49980,6 +50676,7 @@
     "appearances": 2,
     "aggregatedRank": 697,
     "countryRank": 81,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50050,6 +50747,7 @@
     "appearances": 3,
     "aggregatedRank": 698,
     "countryRank": 36,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50123,6 +50821,7 @@
     "appearances": 4,
     "aggregatedRank": 699,
     "countryRank": 15,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50191,6 +50890,7 @@
     "appearances": 2,
     "aggregatedRank": 700,
     "countryRank": 2,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50258,6 +50958,7 @@
     "appearances": 2,
     "aggregatedRank": 701,
     "countryRank": 11,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50325,6 +51026,7 @@
     "appearances": 2,
     "aggregatedRank": 702,
     "countryRank": 42,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50396,6 +51098,7 @@
     "appearances": 3,
     "aggregatedRank": 703,
     "countryRank": 7,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50463,6 +51166,7 @@
     "appearances": 2,
     "aggregatedRank": 704,
     "countryRank": 5,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50530,6 +51234,7 @@
     "appearances": 2,
     "aggregatedRank": 705,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50595,6 +51300,7 @@
     "appearances": 2,
     "aggregatedRank": 706,
     "countryRank": 31,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50662,6 +51368,7 @@
     "appearances": 2,
     "aggregatedRank": 707,
     "countryRank": 82,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50732,6 +51439,7 @@
     "appearances": 3,
     "aggregatedRank": 708,
     "countryRank": 7,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50799,6 +51507,7 @@
     "appearances": 2,
     "aggregatedRank": 709,
     "countryRank": 8,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50867,6 +51576,7 @@
     "appearances": 3,
     "aggregatedRank": 710,
     "countryRank": 37,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -50937,6 +51647,7 @@
     "appearances": 3,
     "aggregatedRank": 711,
     "countryRank": 38,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51007,6 +51718,7 @@
     "appearances": 3,
     "aggregatedRank": 712,
     "countryRank": 57,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51074,6 +51786,7 @@
     "appearances": 2,
     "aggregatedRank": 713,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51144,6 +51857,7 @@
     "appearances": 3,
     "aggregatedRank": 714,
     "countryRank": 83,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51212,6 +51926,7 @@
     "appearances": 3,
     "aggregatedRank": 715,
     "countryRank": 134,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51280,6 +51995,7 @@
     "appearances": 3,
     "aggregatedRank": 716,
     "countryRank": 84,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51348,6 +52064,7 @@
     "appearances": 2,
     "aggregatedRank": 717,
     "countryRank": 135,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51421,6 +52138,7 @@
     "appearances": 4,
     "aggregatedRank": 718,
     "countryRank": 5,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51488,6 +52206,7 @@
     "appearances": 2,
     "aggregatedRank": 719,
     "countryRank": 85,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51556,6 +52275,7 @@
     "appearances": 2,
     "aggregatedRank": 720,
     "countryRank": 8,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51623,6 +52343,7 @@
     "appearances": 2,
     "aggregatedRank": 721,
     "countryRank": 86,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51690,6 +52411,7 @@
     "appearances": 2,
     "aggregatedRank": 722,
     "countryRank": 12,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51757,6 +52479,7 @@
     "appearances": 2,
     "aggregatedRank": 723,
     "countryRank": 8,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51827,6 +52550,7 @@
     "appearances": 3,
     "aggregatedRank": 724,
     "countryRank": 16,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51895,6 +52619,7 @@
     "appearances": 2,
     "aggregatedRank": 725,
     "countryRank": 58,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -51965,6 +52690,7 @@
     "appearances": 3,
     "aggregatedRank": 726,
     "countryRank": 22,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52035,6 +52761,7 @@
     "appearances": 3,
     "aggregatedRank": 727,
     "countryRank": 59,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52105,6 +52832,7 @@
     "appearances": 3,
     "aggregatedRank": 728,
     "countryRank": 87,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52173,6 +52901,7 @@
     "appearances": 3,
     "aggregatedRank": 729,
     "countryRank": 136,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52240,6 +52969,7 @@
     "appearances": 2,
     "aggregatedRank": 730,
     "countryRank": 18,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52310,6 +53040,7 @@
     "appearances": 3,
     "aggregatedRank": 731,
     "countryRank": 137,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52380,6 +53111,7 @@
     "appearances": 3,
     "aggregatedRank": 732,
     "countryRank": 4,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52445,6 +53177,7 @@
     "appearances": 2,
     "aggregatedRank": 733,
     "countryRank": 17,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52512,6 +53245,7 @@
     "appearances": 2,
     "aggregatedRank": 734,
     "countryRank": 43,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52582,6 +53316,7 @@
     "appearances": 3,
     "aggregatedRank": 735,
     "countryRank": 44,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52649,6 +53384,7 @@
     "appearances": 2,
     "aggregatedRank": 736,
     "countryRank": 6,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52719,6 +53455,7 @@
     "appearances": 3,
     "aggregatedRank": 737,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52786,6 +53523,7 @@
     "appearances": 2,
     "aggregatedRank": 738,
     "countryRank": 138,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52853,6 +53591,7 @@
     "appearances": 2,
     "aggregatedRank": 739,
     "countryRank": 18,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52923,6 +53662,7 @@
     "appearances": 3,
     "aggregatedRank": 740,
     "countryRank": 139,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -52993,6 +53733,7 @@
     "appearances": 3,
     "aggregatedRank": 741,
     "countryRank": 45,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53060,6 +53801,7 @@
     "appearances": 2,
     "aggregatedRank": 742,
     "countryRank": 32,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53127,6 +53869,7 @@
     "appearances": 2,
     "aggregatedRank": 743,
     "countryRank": 140,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53194,6 +53937,7 @@
     "appearances": 2,
     "aggregatedRank": 744,
     "countryRank": 141,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53264,6 +54008,7 @@
     "appearances": 3,
     "aggregatedRank": 745,
     "countryRank": 88,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53331,6 +54076,7 @@
     "appearances": 2,
     "aggregatedRank": 746,
     "countryRank": 89,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53398,6 +54144,7 @@
     "appearances": 2,
     "aggregatedRank": 747,
     "countryRank": 19,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53468,6 +54215,7 @@
     "appearances": 3,
     "aggregatedRank": 748,
     "countryRank": 142,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53538,6 +54286,7 @@
     "appearances": 3,
     "aggregatedRank": 749,
     "countryRank": 9,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53605,6 +54354,7 @@
     "appearances": 2,
     "aggregatedRank": 750,
     "countryRank": 60,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53675,6 +54425,7 @@
     "appearances": 3,
     "aggregatedRank": 751,
     "countryRank": 17,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53742,6 +54493,7 @@
     "appearances": 2,
     "aggregatedRank": 752,
     "countryRank": 90,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53810,6 +54562,7 @@
     "appearances": 3,
     "aggregatedRank": 753,
     "countryRank": 143,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53880,6 +54633,7 @@
     "appearances": 3,
     "aggregatedRank": 754,
     "countryRank": 144,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -53947,6 +54701,7 @@
     "appearances": 2,
     "aggregatedRank": 755,
     "countryRank": 91,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54014,6 +54769,7 @@
     "appearances": 2,
     "aggregatedRank": 756,
     "countryRank": 61,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54084,6 +54840,7 @@
     "appearances": 3,
     "aggregatedRank": 757,
     "countryRank": 145,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54151,6 +54908,7 @@
     "appearances": 2,
     "aggregatedRank": 758,
     "countryRank": 33,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54221,6 +54979,7 @@
     "appearances": 3,
     "aggregatedRank": 759,
     "countryRank": 9,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54291,6 +55050,7 @@
     "appearances": 3,
     "aggregatedRank": 760,
     "countryRank": 13,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54358,6 +55118,7 @@
     "appearances": 2,
     "aggregatedRank": 761,
     "countryRank": 20,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54423,6 +55184,7 @@
     "appearances": 2,
     "aggregatedRank": 762,
     "countryRank": 62,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54490,6 +55252,7 @@
     "appearances": 2,
     "aggregatedRank": 763,
     "countryRank": 14,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54557,6 +55320,7 @@
     "appearances": 2,
     "aggregatedRank": 764,
     "countryRank": 1,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54627,6 +55391,7 @@
     "appearances": 3,
     "aggregatedRank": 765,
     "countryRank": 14,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54694,6 +55459,7 @@
     "appearances": 2,
     "aggregatedRank": 766,
     "countryRank": 146,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54764,6 +55530,7 @@
     "appearances": 3,
     "aggregatedRank": 767,
     "countryRank": 9,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54832,6 +55599,7 @@
     "appearances": 3,
     "aggregatedRank": 768,
     "countryRank": 7,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54899,6 +55667,7 @@
     "appearances": 2,
     "aggregatedRank": 769,
     "countryRank": 92,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -54966,6 +55735,7 @@
     "appearances": 2,
     "aggregatedRank": 770,
     "countryRank": 93,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55033,6 +55803,7 @@
     "appearances": 2,
     "aggregatedRank": 771,
     "countryRank": 94,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55098,6 +55869,7 @@
     "appearances": 2,
     "aggregatedRank": 772,
     "countryRank": 10,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55168,6 +55940,7 @@
     "appearances": 3,
     "aggregatedRank": 773,
     "countryRank": 4,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55238,6 +56011,7 @@
     "appearances": 3,
     "aggregatedRank": 774,
     "countryRank": 147,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55308,6 +56082,7 @@
     "appearances": 3,
     "aggregatedRank": 775,
     "countryRank": 15,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55375,6 +56150,7 @@
     "appearances": 2,
     "aggregatedRank": 776,
     "countryRank": 148,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55445,6 +56221,7 @@
     "appearances": 3,
     "aggregatedRank": 777,
     "countryRank": 7,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55515,6 +56292,7 @@
     "appearances": 3,
     "aggregatedRank": 778,
     "countryRank": 23,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55582,6 +56360,7 @@
     "appearances": 2,
     "aggregatedRank": 779,
     "countryRank": 63,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55649,6 +56428,7 @@
     "appearances": 2,
     "aggregatedRank": 780,
     "countryRank": 149,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55716,6 +56496,7 @@
     "appearances": 2,
     "aggregatedRank": 781,
     "countryRank": 5,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55783,6 +56564,7 @@
     "appearances": 2,
     "aggregatedRank": 782,
     "countryRank": 150,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55853,6 +56635,7 @@
     "appearances": 3,
     "aggregatedRank": 783,
     "countryRank": 46,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55923,6 +56706,7 @@
     "appearances": 3,
     "aggregatedRank": 784,
     "countryRank": 64,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -55990,6 +56774,7 @@
     "appearances": 2,
     "aggregatedRank": 785,
     "countryRank": 151,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56058,6 +56843,7 @@
     "appearances": 2,
     "aggregatedRank": 786,
     "countryRank": 15,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56123,6 +56909,7 @@
     "appearances": 2,
     "aggregatedRank": 787,
     "countryRank": 7,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56190,6 +56977,7 @@
     "appearances": 2,
     "aggregatedRank": 788,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56260,6 +57048,7 @@
     "appearances": 3,
     "aggregatedRank": 789,
     "countryRank": 16,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56327,6 +57116,7 @@
     "appearances": 2,
     "aggregatedRank": 790,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56394,6 +57184,7 @@
     "appearances": 2,
     "aggregatedRank": 791,
     "countryRank": 9,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56461,6 +57252,7 @@
     "appearances": 2,
     "aggregatedRank": 792,
     "countryRank": 8,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56528,6 +57320,7 @@
     "appearances": 2,
     "aggregatedRank": 793,
     "countryRank": 95,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56598,6 +57391,7 @@
     "appearances": 3,
     "aggregatedRank": 794,
     "countryRank": 10,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56665,6 +57459,7 @@
     "appearances": 2,
     "aggregatedRank": 795,
     "countryRank": 65,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56732,6 +57527,7 @@
     "appearances": 2,
     "aggregatedRank": 796,
     "countryRank": 39,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56799,6 +57595,7 @@
     "appearances": 2,
     "aggregatedRank": 797,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56866,6 +57663,7 @@
     "appearances": 2,
     "aggregatedRank": 798,
     "countryRank": 17,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -56933,6 +57731,7 @@
     "appearances": 2,
     "aggregatedRank": 799,
     "countryRank": 3,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57000,6 +57799,7 @@
     "appearances": 2,
     "aggregatedRank": 800,
     "countryRank": 1,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57070,6 +57870,7 @@
     "appearances": 3,
     "aggregatedRank": 801,
     "countryRank": 11,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57140,6 +57941,7 @@
     "appearances": 3,
     "aggregatedRank": 802,
     "countryRank": 5,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57207,6 +58009,7 @@
     "appearances": 2,
     "aggregatedRank": 803,
     "countryRank": 10,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57274,6 +58077,7 @@
     "appearances": 2,
     "aggregatedRank": 804,
     "countryRank": 152,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57341,6 +58145,7 @@
     "appearances": 2,
     "aggregatedRank": 805,
     "countryRank": 47,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57408,6 +58213,7 @@
     "appearances": 2,
     "aggregatedRank": 806,
     "countryRank": 66,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57475,6 +58281,7 @@
     "appearances": 2,
     "aggregatedRank": 807,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57542,6 +58349,7 @@
     "appearances": 2,
     "aggregatedRank": 808,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57609,6 +58417,7 @@
     "appearances": 2,
     "aggregatedRank": 809,
     "countryRank": 2,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57676,6 +58485,7 @@
     "appearances": 2,
     "aggregatedRank": 810,
     "countryRank": 153,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57743,6 +58553,7 @@
     "appearances": 2,
     "aggregatedRank": 811,
     "countryRank": 96,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57810,6 +58621,7 @@
     "appearances": 2,
     "aggregatedRank": 812,
     "countryRank": 97,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57877,6 +58689,7 @@
     "appearances": 2,
     "aggregatedRank": 813,
     "countryRank": 4,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -57947,6 +58760,7 @@
     "appearances": 3,
     "aggregatedRank": 814,
     "countryRank": 10,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58015,6 +58829,7 @@
     "appearances": 2,
     "aggregatedRank": 815,
     "countryRank": 154,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58082,6 +58897,7 @@
     "appearances": 2,
     "aggregatedRank": 816,
     "countryRank": 11,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58149,6 +58965,7 @@
     "appearances": 2,
     "aggregatedRank": 817,
     "countryRank": 98,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58216,6 +59033,7 @@
     "appearances": 2,
     "aggregatedRank": 818,
     "countryRank": 24,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58283,6 +59101,7 @@
     "appearances": 2,
     "aggregatedRank": 819,
     "countryRank": 155,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58350,6 +59169,7 @@
     "appearances": 2,
     "aggregatedRank": 820,
     "countryRank": 156,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58417,6 +59237,7 @@
     "appearances": 2,
     "aggregatedRank": 821,
     "countryRank": 12,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58487,6 +59308,7 @@
     "appearances": 3,
     "aggregatedRank": 822,
     "countryRank": 157,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58554,6 +59376,7 @@
     "appearances": 2,
     "aggregatedRank": 823,
     "countryRank": 67,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58624,6 +59447,7 @@
     "appearances": 3,
     "aggregatedRank": 824,
     "countryRank": 158,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58691,6 +59515,7 @@
     "appearances": 2,
     "aggregatedRank": 825,
     "countryRank": 99,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58761,6 +59586,7 @@
     "appearances": 3,
     "aggregatedRank": 826,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58825,6 +59651,7 @@
     "appearances": 1,
     "aggregatedRank": 827,
     "countryRank": 48,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58887,6 +59714,7 @@
     "appearances": 2,
     "aggregatedRank": 828,
     "countryRank": 8,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -58954,6 +59782,7 @@
     "appearances": 2,
     "aggregatedRank": 829,
     "countryRank": 19,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59022,6 +59851,7 @@
     "appearances": 2,
     "aggregatedRank": 830,
     "countryRank": 34,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59089,6 +59919,7 @@
     "appearances": 2,
     "aggregatedRank": 831,
     "countryRank": 49,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59156,6 +59987,7 @@
     "appearances": 2,
     "aggregatedRank": 832,
     "countryRank": 11,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59223,6 +60055,7 @@
     "appearances": 2,
     "aggregatedRank": 833,
     "countryRank": 10,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59293,6 +60126,7 @@
     "appearances": 3,
     "aggregatedRank": 834,
     "countryRank": 35,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59360,6 +60194,7 @@
     "appearances": 2,
     "aggregatedRank": 835,
     "countryRank": 100,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59425,6 +60260,7 @@
     "appearances": 1,
     "aggregatedRank": 836,
     "countryRank": 50,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59487,6 +60323,7 @@
     "appearances": 2,
     "aggregatedRank": 837,
     "countryRank": 18,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59554,6 +60391,7 @@
     "appearances": 2,
     "aggregatedRank": 838,
     "countryRank": 6,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59616,6 +60454,7 @@
     "appearances": 1,
     "aggregatedRank": 839,
     "countryRank": 21,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59681,6 +60520,7 @@
     "appearances": 3,
     "aggregatedRank": 840,
     "countryRank": 8,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59748,6 +60588,7 @@
     "appearances": 2,
     "aggregatedRank": 841,
     "countryRank": 3,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59812,6 +60653,7 @@
     "appearances": 1,
     "aggregatedRank": 842,
     "countryRank": 159,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59876,6 +60718,7 @@
     "appearances": 2,
     "aggregatedRank": 843,
     "countryRank": 160,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -59943,6 +60786,7 @@
     "appearances": 2,
     "aggregatedRank": 844,
     "countryRank": 22,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60010,6 +60854,7 @@
     "appearances": 2,
     "aggregatedRank": 845,
     "countryRank": 12,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60074,6 +60919,7 @@
     "appearances": 1,
     "aggregatedRank": 846,
     "countryRank": 51,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60138,6 +60984,7 @@
     "appearances": 2,
     "aggregatedRank": 847,
     "countryRank": 101,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60205,6 +61052,7 @@
     "appearances": 2,
     "aggregatedRank": 848,
     "countryRank": 11,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60272,6 +61120,7 @@
     "appearances": 2,
     "aggregatedRank": 849,
     "countryRank": 19,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60339,6 +61188,7 @@
     "appearances": 2,
     "aggregatedRank": 850,
     "countryRank": 16,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60403,6 +61253,7 @@
     "appearances": 1,
     "aggregatedRank": 851,
     "countryRank": 161,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60464,6 +61315,7 @@
     "appearances": 1,
     "aggregatedRank": 852,
     "countryRank": 14,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60528,6 +61380,7 @@
     "appearances": 2,
     "aggregatedRank": 853,
     "countryRank": 68,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60595,6 +61448,7 @@
     "appearances": 2,
     "aggregatedRank": 854,
     "countryRank": 36,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60662,6 +61516,7 @@
     "appearances": 2,
     "aggregatedRank": 855,
     "countryRank": 162,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60729,6 +61584,7 @@
     "appearances": 2,
     "aggregatedRank": 856,
     "countryRank": 69,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60796,6 +61652,7 @@
     "appearances": 2,
     "aggregatedRank": 857,
     "countryRank": 7,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60863,6 +61720,7 @@
     "appearances": 2,
     "aggregatedRank": 858,
     "countryRank": 3,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -60933,6 +61791,7 @@
     "appearances": 3,
     "aggregatedRank": 859,
     "countryRank": 25,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61003,6 +61862,7 @@
     "appearances": 3,
     "aggregatedRank": 860,
     "countryRank": 9,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61073,6 +61933,7 @@
     "appearances": 3,
     "aggregatedRank": 861,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61140,6 +62001,7 @@
     "appearances": 2,
     "aggregatedRank": 862,
     "countryRank": 102,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61207,6 +62069,7 @@
     "appearances": 2,
     "aggregatedRank": 863,
     "countryRank": 18,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61274,6 +62137,7 @@
     "appearances": 2,
     "aggregatedRank": 864,
     "countryRank": 13,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61341,6 +62205,7 @@
     "appearances": 2,
     "aggregatedRank": 865,
     "countryRank": 70,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61409,6 +62274,7 @@
     "appearances": 2,
     "aggregatedRank": 866,
     "countryRank": 6,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61476,6 +62342,7 @@
     "appearances": 2,
     "aggregatedRank": 867,
     "countryRank": 103,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61540,6 +62407,7 @@
     "appearances": 1,
     "aggregatedRank": 868,
     "countryRank": 8,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61604,6 +62472,7 @@
     "appearances": 2,
     "aggregatedRank": 869,
     "countryRank": 163,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61671,6 +62540,7 @@
     "appearances": 2,
     "aggregatedRank": 870,
     "countryRank": 11,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61738,6 +62608,7 @@
     "appearances": 2,
     "aggregatedRank": 871,
     "countryRank": 104,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61805,6 +62676,7 @@
     "appearances": 2,
     "aggregatedRank": 872,
     "countryRank": 105,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61870,6 +62742,7 @@
     "appearances": 2,
     "aggregatedRank": 873,
     "countryRank": 164,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -61935,6 +62808,7 @@
     "appearances": 2,
     "aggregatedRank": 874,
     "countryRank": 71,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62002,6 +62876,7 @@
     "appearances": 2,
     "aggregatedRank": 875,
     "countryRank": 20,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62066,6 +62941,7 @@
     "appearances": 1,
     "aggregatedRank": 876,
     "countryRank": 165,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62130,6 +63006,7 @@
     "appearances": 2,
     "aggregatedRank": 877,
     "countryRank": 166,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62197,6 +63074,7 @@
     "appearances": 2,
     "aggregatedRank": 878,
     "countryRank": 167,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62264,6 +63142,7 @@
     "appearances": 2,
     "aggregatedRank": 879,
     "countryRank": 3,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62331,6 +63210,7 @@
     "appearances": 2,
     "aggregatedRank": 880,
     "countryRank": 25,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62395,6 +63275,7 @@
     "appearances": 1,
     "aggregatedRank": 881,
     "countryRank": 9,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62457,6 +63338,7 @@
     "appearances": 2,
     "aggregatedRank": 882,
     "countryRank": 106,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62521,6 +63403,7 @@
     "appearances": 1,
     "aggregatedRank": 883,
     "countryRank": 1,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62585,6 +63468,7 @@
     "appearances": 2,
     "aggregatedRank": 884,
     "countryRank": 7,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62652,6 +63536,7 @@
     "appearances": 2,
     "aggregatedRank": 885,
     "countryRank": 107,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62717,6 +63602,7 @@
     "appearances": 2,
     "aggregatedRank": 886,
     "countryRank": 21,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62784,6 +63670,7 @@
     "appearances": 2,
     "aggregatedRank": 887,
     "countryRank": 26,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62851,6 +63738,7 @@
     "appearances": 2,
     "aggregatedRank": 888,
     "countryRank": 4,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62918,6 +63806,7 @@
     "appearances": 2,
     "aggregatedRank": 889,
     "countryRank": 19,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -62985,6 +63874,7 @@
     "appearances": 2,
     "aggregatedRank": 890,
     "countryRank": 14,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63052,6 +63942,7 @@
     "appearances": 2,
     "aggregatedRank": 891,
     "countryRank": 22,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63119,6 +64010,7 @@
     "appearances": 2,
     "aggregatedRank": 892,
     "countryRank": 5,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63186,6 +64078,7 @@
     "appearances": 2,
     "aggregatedRank": 893,
     "countryRank": 8,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63253,6 +64146,7 @@
     "appearances": 2,
     "aggregatedRank": 894,
     "countryRank": 23,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63317,6 +64211,7 @@
     "appearances": 1,
     "aggregatedRank": 895,
     "countryRank": 12,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63378,6 +64273,7 @@
     "appearances": 1,
     "aggregatedRank": 896,
     "countryRank": 168,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63439,6 +64335,7 @@
     "appearances": 1,
     "aggregatedRank": 897,
     "countryRank": 8,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63501,6 +64398,7 @@
     "appearances": 2,
     "aggregatedRank": 898,
     "countryRank": 20,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63568,6 +64466,7 @@
     "appearances": 2,
     "aggregatedRank": 899,
     "countryRank": 10,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63632,6 +64531,7 @@
     "appearances": 1,
     "aggregatedRank": 900,
     "countryRank": 13,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63691,6 +64591,7 @@
     "appearances": 1,
     "aggregatedRank": 901,
     "countryRank": 40,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63755,6 +64656,7 @@
     "appearances": 2,
     "aggregatedRank": 902,
     "countryRank": 41,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63822,6 +64724,7 @@
     "appearances": 2,
     "aggregatedRank": 903,
     "countryRank": 3,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63889,6 +64792,7 @@
     "appearances": 2,
     "aggregatedRank": 904,
     "countryRank": 12,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -63953,6 +64857,7 @@
     "appearances": 1,
     "aggregatedRank": 905,
     "countryRank": 23,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64015,6 +64920,7 @@
     "appearances": 2,
     "aggregatedRank": 906,
     "countryRank": 108,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64079,6 +64985,7 @@
     "appearances": 1,
     "aggregatedRank": 907,
     "countryRank": 169,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64140,6 +65047,7 @@
     "appearances": 1,
     "aggregatedRank": 908,
     "countryRank": 2,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64202,6 +65110,7 @@
     "appearances": 2,
     "aggregatedRank": 909,
     "countryRank": 72,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64266,6 +65175,7 @@
     "appearances": 1,
     "aggregatedRank": 910,
     "countryRank": 26,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64327,6 +65237,7 @@
     "appearances": 1,
     "aggregatedRank": 911,
     "countryRank": 52,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64389,6 +65300,7 @@
     "appearances": 2,
     "aggregatedRank": 912,
     "countryRank": 170,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64456,6 +65368,7 @@
     "appearances": 2,
     "aggregatedRank": 913,
     "countryRank": 4,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64520,6 +65433,7 @@
     "appearances": 1,
     "aggregatedRank": 914,
     "countryRank": 37,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64584,6 +65498,7 @@
     "appearances": 2,
     "aggregatedRank": 915,
     "countryRank": 9,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64651,6 +65566,7 @@
     "appearances": 2,
     "aggregatedRank": 916,
     "countryRank": 73,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64718,6 +65634,7 @@
     "appearances": 2,
     "aggregatedRank": 917,
     "countryRank": 74,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64785,6 +65702,7 @@
     "appearances": 2,
     "aggregatedRank": 918,
     "countryRank": 75,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64852,6 +65770,7 @@
     "appearances": 2,
     "aggregatedRank": 919,
     "countryRank": 24,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64919,6 +65838,7 @@
     "appearances": 2,
     "aggregatedRank": 920,
     "countryRank": 17,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -64986,6 +65906,7 @@
     "appearances": 2,
     "aggregatedRank": 921,
     "countryRank": 53,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65053,6 +65974,7 @@
     "appearances": 2,
     "aggregatedRank": 922,
     "countryRank": 54,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65117,6 +66039,7 @@
     "appearances": 1,
     "aggregatedRank": 923,
     "countryRank": 55,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65181,6 +66104,7 @@
     "appearances": 2,
     "aggregatedRank": 924,
     "countryRank": 24,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65245,6 +66169,7 @@
     "appearances": 1,
     "aggregatedRank": 925,
     "countryRank": 2,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65307,6 +66232,7 @@
     "appearances": 2,
     "aggregatedRank": 926,
     "countryRank": 11,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65369,6 +66295,7 @@
     "appearances": 1,
     "aggregatedRank": 927,
     "countryRank": 11,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65428,6 +66355,7 @@
     "appearances": 1,
     "aggregatedRank": 928,
     "countryRank": 12,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65490,6 +66418,7 @@
     "appearances": 2,
     "aggregatedRank": 929,
     "countryRank": 56,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65554,6 +66483,7 @@
     "appearances": 1,
     "aggregatedRank": 930,
     "countryRank": 57,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65613,6 +66543,7 @@
     "appearances": 1,
     "aggregatedRank": 931,
     "countryRank": 1,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65672,6 +66603,7 @@
     "appearances": 1,
     "aggregatedRank": 932,
     "countryRank": 58,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65733,6 +66665,7 @@
     "appearances": 1,
     "aggregatedRank": 933,
     "countryRank": 59,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65792,6 +66725,7 @@
     "appearances": 1,
     "aggregatedRank": 934,
     "countryRank": 60,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65853,6 +66787,7 @@
     "appearances": 1,
     "aggregatedRank": 935,
     "countryRank": 61,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65915,6 +66850,7 @@
     "appearances": 1,
     "aggregatedRank": 936,
     "countryRank": 5,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -65977,6 +66913,7 @@
     "appearances": 2,
     "aggregatedRank": 937,
     "countryRank": 13,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66047,6 +66984,7 @@
     "appearances": 3,
     "aggregatedRank": 938,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66111,6 +67049,7 @@
     "appearances": 1,
     "aggregatedRank": 939,
     "countryRank": 3,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66170,6 +67109,7 @@
     "appearances": 1,
     "aggregatedRank": 940,
     "countryRank": 25,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66231,6 +67171,7 @@
     "appearances": 1,
     "aggregatedRank": 941,
     "countryRank": 26,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66296,6 +67237,7 @@
     "appearances": 3,
     "aggregatedRank": 942,
     "countryRank": 4,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66364,6 +67306,7 @@
     "appearances": 2,
     "aggregatedRank": 943,
     "countryRank": 109,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66428,6 +67371,7 @@
     "appearances": 1,
     "aggregatedRank": 944,
     "countryRank": 38,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66493,6 +67437,7 @@
     "appearances": 3,
     "aggregatedRank": 945,
     "countryRank": 9,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66560,6 +67505,7 @@
     "appearances": 2,
     "aggregatedRank": 946,
     "countryRank": 21,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66624,6 +67570,7 @@
     "appearances": 1,
     "aggregatedRank": 947,
     "countryRank": 6,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66683,6 +67630,7 @@
     "appearances": 1,
     "aggregatedRank": 948,
     "countryRank": 8,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66747,6 +67695,7 @@
     "appearances": 2,
     "aggregatedRank": 949,
     "countryRank": 110,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66814,6 +67763,7 @@
     "appearances": 2,
     "aggregatedRank": 950,
     "countryRank": 18,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66881,6 +67831,7 @@
     "appearances": 2,
     "aggregatedRank": 951,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -66948,6 +67899,7 @@
     "appearances": 2,
     "aggregatedRank": 952,
     "countryRank": 5,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67015,6 +67967,7 @@
     "appearances": 2,
     "aggregatedRank": 953,
     "countryRank": 171,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67082,6 +68035,7 @@
     "appearances": 2,
     "aggregatedRank": 954,
     "countryRank": 42,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67149,6 +68103,7 @@
     "appearances": 2,
     "aggregatedRank": 955,
     "countryRank": 13,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67216,6 +68171,7 @@
     "appearances": 2,
     "aggregatedRank": 956,
     "countryRank": 8,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67283,6 +68239,7 @@
     "appearances": 2,
     "aggregatedRank": 957,
     "countryRank": 111,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67345,6 +68302,7 @@
     "appearances": 1,
     "aggregatedRank": 958,
     "countryRank": 4,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67410,6 +68368,7 @@
     "appearances": 2,
     "aggregatedRank": 959,
     "countryRank": 76,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67477,6 +68436,7 @@
     "appearances": 2,
     "aggregatedRank": 960,
     "countryRank": 14,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67547,6 +68507,7 @@
     "appearances": 3,
     "aggregatedRank": 961,
     "countryRank": 77,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67611,6 +68572,7 @@
     "appearances": 1,
     "aggregatedRank": 962,
     "countryRank": 27,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67670,6 +68632,7 @@
     "appearances": 1,
     "aggregatedRank": 963,
     "countryRank": 22,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67729,6 +68692,7 @@
     "appearances": 1,
     "aggregatedRank": 964,
     "countryRank": 112,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67790,6 +68754,7 @@
     "appearances": 1,
     "aggregatedRank": 965,
     "countryRank": 172,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67851,6 +68816,7 @@
     "appearances": 1,
     "aggregatedRank": 966,
     "countryRank": 113,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67915,6 +68881,7 @@
     "appearances": 2,
     "aggregatedRank": 967,
     "countryRank": 25,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -67979,6 +68946,7 @@
     "appearances": 1,
     "aggregatedRank": 968,
     "countryRank": 78,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68038,6 +69006,7 @@
     "appearances": 1,
     "aggregatedRank": 969,
     "countryRank": 114,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68102,6 +69071,7 @@
     "appearances": 2,
     "aggregatedRank": 970,
     "countryRank": 9,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68167,6 +69137,7 @@
     "appearances": 1,
     "aggregatedRank": 971,
     "countryRank": 28,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68228,6 +69199,7 @@
     "appearances": 1,
     "aggregatedRank": 972,
     "countryRank": 115,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68289,6 +69261,7 @@
     "appearances": 1,
     "aggregatedRank": 973,
     "countryRank": 2,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68353,6 +69326,7 @@
     "appearances": 2,
     "aggregatedRank": 974,
     "countryRank": 15,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68417,6 +69391,7 @@
     "appearances": 1,
     "aggregatedRank": 975,
     "countryRank": 3,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68479,6 +69454,7 @@
     "appearances": 2,
     "aggregatedRank": 976,
     "countryRank": 173,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68543,6 +69519,7 @@
     "appearances": 1,
     "aggregatedRank": 977,
     "countryRank": 26,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68607,6 +69584,7 @@
     "appearances": 2,
     "aggregatedRank": 978,
     "countryRank": 23,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68675,6 +69653,7 @@
     "appearances": 2,
     "aggregatedRank": 979,
     "countryRank": 24,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68739,6 +69718,7 @@
     "appearances": 1,
     "aggregatedRank": 980,
     "countryRank": 79,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68801,6 +69781,7 @@
     "appearances": 2,
     "aggregatedRank": 981,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68868,6 +69849,7 @@
     "appearances": 2,
     "aggregatedRank": 982,
     "countryRank": 12,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -68935,6 +69917,7 @@
     "appearances": 2,
     "aggregatedRank": 983,
     "countryRank": 80,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69002,6 +69985,7 @@
     "appearances": 2,
     "aggregatedRank": 984,
     "countryRank": 7,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69069,6 +70053,7 @@
     "appearances": 2,
     "aggregatedRank": 985,
     "countryRank": 43,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69136,6 +70121,7 @@
     "appearances": 2,
     "aggregatedRank": 986,
     "countryRank": 25,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69203,6 +70189,7 @@
     "appearances": 2,
     "aggregatedRank": 987,
     "countryRank": 26,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69270,6 +70257,7 @@
     "appearances": 2,
     "aggregatedRank": 988,
     "countryRank": 27,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69337,6 +70325,7 @@
     "appearances": 2,
     "aggregatedRank": 989,
     "countryRank": 116,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69399,6 +70388,7 @@
     "appearances": 1,
     "aggregatedRank": 990,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69458,6 +70448,7 @@
     "appearances": 1,
     "aggregatedRank": 991,
     "countryRank": 62,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69517,6 +70508,7 @@
     "appearances": 1,
     "aggregatedRank": 992,
     "countryRank": 10,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69578,6 +70570,7 @@
     "appearances": 1,
     "aggregatedRank": 993,
     "countryRank": 1,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69642,6 +70635,7 @@
     "appearances": 2,
     "aggregatedRank": 994,
     "countryRank": 6,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69706,6 +70700,7 @@
     "appearances": 1,
     "aggregatedRank": 995,
     "countryRank": 44,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69765,6 +70760,7 @@
     "appearances": 1,
     "aggregatedRank": 996,
     "countryRank": 29,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69826,6 +70822,7 @@
     "appearances": 1,
     "aggregatedRank": 997,
     "countryRank": 30,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69888,6 +70885,7 @@
     "appearances": 2,
     "aggregatedRank": 998,
     "countryRank": 174,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -69955,6 +70953,7 @@
     "appearances": 2,
     "aggregatedRank": 999,
     "countryRank": 16,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70019,6 +71018,7 @@
     "appearances": 1,
     "aggregatedRank": 1000,
     "countryRank": 117,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70078,6 +71078,7 @@
     "appearances": 1,
     "aggregatedRank": 1001,
     "countryRank": 3,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70139,6 +71140,7 @@
     "appearances": 1,
     "aggregatedRank": 1002,
     "countryRank": 10,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70198,6 +71200,7 @@
     "appearances": 1,
     "aggregatedRank": 1003,
     "countryRank": 31,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70262,6 +71265,7 @@
     "appearances": 2,
     "aggregatedRank": 1004,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70329,6 +71333,7 @@
     "appearances": 2,
     "aggregatedRank": 1005,
     "countryRank": 27,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70393,6 +71398,7 @@
     "appearances": 1,
     "aggregatedRank": 1006,
     "countryRank": 13,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70452,6 +71458,7 @@
     "appearances": 1,
     "aggregatedRank": 1007,
     "countryRank": 32,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70514,6 +71521,7 @@
     "appearances": 2,
     "aggregatedRank": 1008,
     "countryRank": 175,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70578,6 +71586,7 @@
     "appearances": 1,
     "aggregatedRank": 1009,
     "countryRank": 81,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70640,6 +71649,7 @@
     "appearances": 2,
     "aggregatedRank": 1010,
     "countryRank": 13,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70704,6 +71714,7 @@
     "appearances": 1,
     "aggregatedRank": 1011,
     "countryRank": 63,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70768,6 +71779,7 @@
     "appearances": 2,
     "aggregatedRank": 1012,
     "countryRank": 176,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70830,6 +71842,7 @@
     "appearances": 1,
     "aggregatedRank": 1013,
     "countryRank": 19,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70891,6 +71904,7 @@
     "appearances": 1,
     "aggregatedRank": 1014,
     "countryRank": 2,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -70955,6 +71969,7 @@
     "appearances": 2,
     "aggregatedRank": 1015,
     "countryRank": 11,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71019,6 +72034,7 @@
     "appearances": 1,
     "aggregatedRank": 1016,
     "countryRank": 5,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71081,6 +72097,7 @@
     "appearances": 2,
     "aggregatedRank": 1017,
     "countryRank": 28,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71145,6 +72162,7 @@
     "appearances": 1,
     "aggregatedRank": 1018,
     "countryRank": 118,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71206,6 +72224,7 @@
     "appearances": 1,
     "aggregatedRank": 1019,
     "countryRank": 119,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71267,6 +72286,7 @@
     "appearances": 1,
     "aggregatedRank": 1020,
     "countryRank": 120,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71328,6 +72348,7 @@
     "appearances": 1,
     "aggregatedRank": 1021,
     "countryRank": 121,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71389,6 +72410,7 @@
     "appearances": 1,
     "aggregatedRank": 1022,
     "countryRank": 33,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71450,6 +72472,7 @@
     "appearances": 1,
     "aggregatedRank": 1023,
     "countryRank": 177,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71511,6 +72534,7 @@
     "appearances": 1,
     "aggregatedRank": 1024,
     "countryRank": 178,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71572,6 +72596,7 @@
     "appearances": 1,
     "aggregatedRank": 1025,
     "countryRank": 122,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71633,6 +72658,7 @@
     "appearances": 1,
     "aggregatedRank": 1026,
     "countryRank": 123,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71694,6 +72720,7 @@
     "appearances": 1,
     "aggregatedRank": 1027,
     "countryRank": 124,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71758,6 +72785,7 @@
     "appearances": 2,
     "aggregatedRank": 1028,
     "countryRank": 1,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71825,6 +72853,7 @@
     "appearances": 2,
     "aggregatedRank": 1029,
     "countryRank": 28,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71889,6 +72918,7 @@
     "appearances": 1,
     "aggregatedRank": 1030,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -71950,6 +72980,7 @@
     "appearances": 1,
     "aggregatedRank": 1031,
     "countryRank": 64,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72011,6 +73042,7 @@
     "appearances": 1,
     "aggregatedRank": 1032,
     "countryRank": 7,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72072,6 +73104,7 @@
     "appearances": 1,
     "aggregatedRank": 1033,
     "countryRank": 9,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72133,6 +73166,7 @@
     "appearances": 1,
     "aggregatedRank": 1034,
     "countryRank": 14,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72194,6 +73228,7 @@
     "appearances": 1,
     "aggregatedRank": 1035,
     "countryRank": 34,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72255,6 +73290,7 @@
     "appearances": 1,
     "aggregatedRank": 1036,
     "countryRank": 65,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72316,6 +73352,7 @@
     "appearances": 1,
     "aggregatedRank": 1037,
     "countryRank": 4,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72380,6 +73417,7 @@
     "appearances": 2,
     "aggregatedRank": 1038,
     "countryRank": 20,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72444,6 +73482,7 @@
     "appearances": 1,
     "aggregatedRank": 1039,
     "countryRank": 35,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72506,6 +73545,7 @@
     "appearances": 2,
     "aggregatedRank": 1040,
     "countryRank": 12,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72570,6 +73610,7 @@
     "appearances": 1,
     "aggregatedRank": 1041,
     "countryRank": 66,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72629,6 +73670,7 @@
     "appearances": 1,
     "aggregatedRank": 1042,
     "countryRank": 125,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72688,6 +73730,7 @@
     "appearances": 1,
     "aggregatedRank": 1043,
     "countryRank": 67,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72752,6 +73795,7 @@
     "appearances": 2,
     "aggregatedRank": 1044,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72816,6 +73860,7 @@
     "appearances": 1,
     "aggregatedRank": 1045,
     "countryRank": 14,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72877,6 +73922,7 @@
     "appearances": 1,
     "aggregatedRank": 1046,
     "countryRank": 3,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -72939,6 +73985,7 @@
     "appearances": 2,
     "aggregatedRank": 1047,
     "countryRank": 27,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73004,6 +74051,7 @@
     "appearances": 2,
     "aggregatedRank": 1048,
     "countryRank": 126,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73071,6 +74119,7 @@
     "appearances": 2,
     "aggregatedRank": 1049,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73135,6 +74184,7 @@
     "appearances": 1,
     "aggregatedRank": 1050,
     "countryRank": 4,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73199,6 +74249,7 @@
     "appearances": 2,
     "aggregatedRank": 1051,
     "countryRank": 127,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73266,6 +74317,7 @@
     "appearances": 2,
     "aggregatedRank": 1052,
     "countryRank": 128,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73334,6 +74386,7 @@
     "appearances": 2,
     "aggregatedRank": 1053,
     "countryRank": 20,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73401,6 +74454,7 @@
     "appearances": 2,
     "aggregatedRank": 1054,
     "countryRank": 8,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73465,6 +74519,7 @@
     "appearances": 1,
     "aggregatedRank": 1055,
     "countryRank": 27,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73526,6 +74581,7 @@
     "appearances": 1,
     "aggregatedRank": 1056,
     "countryRank": 5,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73587,6 +74643,7 @@
     "appearances": 1,
     "aggregatedRank": 1057,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73651,6 +74708,7 @@
     "appearances": 2,
     "aggregatedRank": 1058,
     "countryRank": 129,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73715,6 +74773,7 @@
     "appearances": 1,
     "aggregatedRank": 1059,
     "countryRank": 6,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73782,6 +74841,7 @@
     "appearances": 3,
     "aggregatedRank": 1060,
     "countryRank": 179,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73846,6 +74906,7 @@
     "appearances": 1,
     "aggregatedRank": 1061,
     "countryRank": 68,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73907,6 +74968,7 @@
     "appearances": 1,
     "aggregatedRank": 1062,
     "countryRank": 180,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -73968,6 +75030,7 @@
     "appearances": 1,
     "aggregatedRank": 1063,
     "countryRank": 45,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74029,6 +75092,7 @@
     "appearances": 1,
     "aggregatedRank": 1064,
     "countryRank": 2,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74091,6 +75155,7 @@
     "appearances": 2,
     "aggregatedRank": 1065,
     "countryRank": 181,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74158,6 +75223,7 @@
     "appearances": 2,
     "aggregatedRank": 1066,
     "countryRank": 21,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74225,6 +75291,7 @@
     "appearances": 2,
     "aggregatedRank": 1067,
     "countryRank": 28,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74292,6 +75359,7 @@
     "appearances": 2,
     "aggregatedRank": 1068,
     "countryRank": 1,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74357,6 +75425,7 @@
     "appearances": 2,
     "aggregatedRank": 1069,
     "countryRank": 6,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74424,6 +75493,7 @@
     "appearances": 2,
     "aggregatedRank": 1070,
     "countryRank": 82,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74491,6 +75561,7 @@
     "appearances": 2,
     "aggregatedRank": 1071,
     "countryRank": 14,
+    "countryTotal": 14,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74558,6 +75629,7 @@
     "appearances": 2,
     "aggregatedRank": 1072,
     "countryRank": 130,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74625,6 +75697,7 @@
     "appearances": 2,
     "aggregatedRank": 1073,
     "countryRank": 28,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74692,6 +75765,7 @@
     "appearances": 2,
     "aggregatedRank": 1074,
     "countryRank": 36,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74759,6 +75833,7 @@
     "appearances": 2,
     "aggregatedRank": 1075,
     "countryRank": 182,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74826,6 +75901,7 @@
     "appearances": 2,
     "aggregatedRank": 1076,
     "countryRank": 1,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74894,6 +75970,7 @@
     "appearances": 2,
     "aggregatedRank": 1077,
     "countryRank": 131,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -74956,6 +76033,7 @@
     "appearances": 1,
     "aggregatedRank": 1078,
     "countryRank": 37,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75017,6 +76095,7 @@
     "appearances": 1,
     "aggregatedRank": 1079,
     "countryRank": 183,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75078,6 +76157,7 @@
     "appearances": 1,
     "aggregatedRank": 1080,
     "countryRank": 1,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75137,6 +76217,7 @@
     "appearances": 1,
     "aggregatedRank": 1081,
     "countryRank": 38,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75198,6 +76279,7 @@
     "appearances": 1,
     "aggregatedRank": 1082,
     "countryRank": 29,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75259,6 +76341,7 @@
     "appearances": 1,
     "aggregatedRank": 1083,
     "countryRank": 132,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75320,6 +76403,7 @@
     "appearances": 1,
     "aggregatedRank": 1084,
     "countryRank": 10,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75381,6 +76465,7 @@
     "appearances": 1,
     "aggregatedRank": 1085,
     "countryRank": 69,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75440,6 +76525,7 @@
     "appearances": 1,
     "aggregatedRank": 1086,
     "countryRank": 3,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75499,6 +76585,7 @@
     "appearances": 1,
     "aggregatedRank": 1087,
     "countryRank": 184,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75560,6 +76647,7 @@
     "appearances": 1,
     "aggregatedRank": 1088,
     "countryRank": 15,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75622,6 +76710,7 @@
     "appearances": 2,
     "aggregatedRank": 1089,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75684,6 +76773,7 @@
     "appearances": 1,
     "aggregatedRank": 1090,
     "countryRank": 7,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75745,6 +76835,7 @@
     "appearances": 1,
     "aggregatedRank": 1091,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75807,6 +76898,7 @@
     "appearances": 2,
     "aggregatedRank": 1092,
     "countryRank": 14,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75871,6 +76963,7 @@
     "appearances": 1,
     "aggregatedRank": 1093,
     "countryRank": 133,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75932,6 +77025,7 @@
     "appearances": 1,
     "aggregatedRank": 1094,
     "countryRank": 134,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -75993,6 +77087,7 @@
     "appearances": 1,
     "aggregatedRank": 1095,
     "countryRank": 135,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76054,6 +77149,7 @@
     "appearances": 1,
     "aggregatedRank": 1096,
     "countryRank": 136,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76115,6 +77211,7 @@
     "appearances": 1,
     "aggregatedRank": 1097,
     "countryRank": 137,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76176,6 +77273,7 @@
     "appearances": 1,
     "aggregatedRank": 1098,
     "countryRank": 138,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76237,6 +77335,7 @@
     "appearances": 1,
     "aggregatedRank": 1099,
     "countryRank": 46,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76298,6 +77397,7 @@
     "appearances": 1,
     "aggregatedRank": 1100,
     "countryRank": 185,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76359,6 +77459,7 @@
     "appearances": 1,
     "aggregatedRank": 1101,
     "countryRank": 139,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76420,6 +77521,7 @@
     "appearances": 1,
     "aggregatedRank": 1102,
     "countryRank": 140,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76481,6 +77583,7 @@
     "appearances": 1,
     "aggregatedRank": 1103,
     "countryRank": 141,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76542,6 +77645,7 @@
     "appearances": 1,
     "aggregatedRank": 1104,
     "countryRank": 70,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76603,6 +77707,7 @@
     "appearances": 1,
     "aggregatedRank": 1105,
     "countryRank": 29,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76664,6 +77769,7 @@
     "appearances": 1,
     "aggregatedRank": 1106,
     "countryRank": 47,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76725,6 +77831,7 @@
     "appearances": 1,
     "aggregatedRank": 1107,
     "countryRank": 15,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76786,6 +77893,7 @@
     "appearances": 1,
     "aggregatedRank": 1108,
     "countryRank": 186,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76847,6 +77955,7 @@
     "appearances": 1,
     "aggregatedRank": 1109,
     "countryRank": 187,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76908,6 +78017,7 @@
     "appearances": 1,
     "aggregatedRank": 1110,
     "countryRank": 39,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -76969,6 +78079,7 @@
     "appearances": 1,
     "aggregatedRank": 1111,
     "countryRank": 5,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77030,6 +78141,7 @@
     "appearances": 1,
     "aggregatedRank": 1112,
     "countryRank": 39,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77091,6 +78203,7 @@
     "appearances": 1,
     "aggregatedRank": 1113,
     "countryRank": 5,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77152,6 +78265,7 @@
     "appearances": 1,
     "aggregatedRank": 1114,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77213,6 +78327,7 @@
     "appearances": 1,
     "aggregatedRank": 1115,
     "countryRank": 3,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77274,6 +78389,7 @@
     "appearances": 1,
     "aggregatedRank": 1116,
     "countryRank": 71,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77335,6 +78451,7 @@
     "appearances": 1,
     "aggregatedRank": 1117,
     "countryRank": 30,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77396,6 +78513,7 @@
     "appearances": 1,
     "aggregatedRank": 1118,
     "countryRank": 142,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77461,6 +78579,7 @@
     "appearances": 2,
     "aggregatedRank": 1119,
     "countryRank": 83,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77528,6 +78647,7 @@
     "appearances": 2,
     "aggregatedRank": 1120,
     "countryRank": 17,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77592,6 +78712,7 @@
     "appearances": 1,
     "aggregatedRank": 1121,
     "countryRank": 6,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77651,6 +78772,7 @@
     "appearances": 1,
     "aggregatedRank": 1122,
     "countryRank": 16,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77712,6 +78834,7 @@
     "appearances": 1,
     "aggregatedRank": 1123,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77773,6 +78896,7 @@
     "appearances": 1,
     "aggregatedRank": 1124,
     "countryRank": 8,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77834,6 +78958,7 @@
     "appearances": 1,
     "aggregatedRank": 1125,
     "countryRank": 7,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77893,6 +79018,7 @@
     "appearances": 1,
     "aggregatedRank": 1126,
     "countryRank": 4,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -77952,6 +79078,7 @@
     "appearances": 1,
     "aggregatedRank": 1127,
     "countryRank": 9,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78013,6 +79140,7 @@
     "appearances": 1,
     "aggregatedRank": 1128,
     "countryRank": 3,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78072,6 +79200,7 @@
     "appearances": 1,
     "aggregatedRank": 1129,
     "countryRank": 4,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78131,6 +79260,7 @@
     "appearances": 1,
     "aggregatedRank": 1130,
     "countryRank": 143,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78192,6 +79322,7 @@
     "appearances": 1,
     "aggregatedRank": 1131,
     "countryRank": 40,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78251,6 +79382,7 @@
     "appearances": 1,
     "aggregatedRank": 1132,
     "countryRank": 48,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78315,6 +79447,7 @@
     "appearances": 2,
     "aggregatedRank": 1133,
     "countryRank": 144,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78379,6 +79512,7 @@
     "appearances": 1,
     "aggregatedRank": 1134,
     "countryRank": 29,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78440,6 +79574,7 @@
     "appearances": 1,
     "aggregatedRank": 1135,
     "countryRank": 17,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78502,6 +79637,7 @@
     "appearances": 2,
     "aggregatedRank": 1136,
     "countryRank": 18,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78569,6 +79705,7 @@
     "appearances": 2,
     "aggregatedRank": 1137,
     "countryRank": 31,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78633,6 +79770,7 @@
     "appearances": 1,
     "aggregatedRank": 1138,
     "countryRank": 84,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78695,6 +79833,7 @@
     "appearances": 1,
     "aggregatedRank": 1139,
     "countryRank": 49,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78756,6 +79895,7 @@
     "appearances": 1,
     "aggregatedRank": 1140,
     "countryRank": 10,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78815,6 +79955,7 @@
     "appearances": 1,
     "aggregatedRank": 1141,
     "countryRank": 4,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78876,6 +80017,7 @@
     "appearances": 1,
     "aggregatedRank": 1142,
     "countryRank": 22,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78937,6 +80079,7 @@
     "appearances": 1,
     "aggregatedRank": 1143,
     "countryRank": 11,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -78998,6 +80141,7 @@
     "appearances": 1,
     "aggregatedRank": 1144,
     "countryRank": 50,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79059,6 +80203,7 @@
     "appearances": 1,
     "aggregatedRank": 1145,
     "countryRank": 32,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79118,6 +80263,7 @@
     "appearances": 1,
     "aggregatedRank": 1146,
     "countryRank": 72,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79179,6 +80325,7 @@
     "appearances": 1,
     "aggregatedRank": 1147,
     "countryRank": 11,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79240,6 +80387,7 @@
     "appearances": 1,
     "aggregatedRank": 1148,
     "countryRank": 51,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79301,6 +80449,7 @@
     "appearances": 1,
     "aggregatedRank": 1149,
     "countryRank": 12,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79362,6 +80511,7 @@
     "appearances": 1,
     "aggregatedRank": 1150,
     "countryRank": 11,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79426,6 +80576,7 @@
     "appearances": 2,
     "aggregatedRank": 1151,
     "countryRank": 145,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79488,6 +80639,7 @@
     "appearances": 1,
     "aggregatedRank": 1152,
     "countryRank": 6,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79552,6 +80704,7 @@
     "appearances": 2,
     "aggregatedRank": 1153,
     "countryRank": 33,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79616,6 +80769,7 @@
     "appearances": 1,
     "aggregatedRank": 1154,
     "countryRank": 4,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79675,6 +80829,7 @@
     "appearances": 1,
     "aggregatedRank": 1155,
     "countryRank": 146,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79736,6 +80891,7 @@
     "appearances": 1,
     "aggregatedRank": 1156,
     "countryRank": 73,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79801,6 +80957,7 @@
     "appearances": 2,
     "aggregatedRank": 1157,
     "countryRank": 23,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79868,6 +81025,7 @@
     "appearances": 2,
     "aggregatedRank": 1158,
     "countryRank": 24,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79932,6 +81090,7 @@
     "appearances": 1,
     "aggregatedRank": 1159,
     "countryRank": 30,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -79994,6 +81153,7 @@
     "appearances": 2,
     "aggregatedRank": 1160,
     "countryRank": 5,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80061,6 +81221,7 @@
     "appearances": 2,
     "aggregatedRank": 1161,
     "countryRank": 85,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80128,6 +81289,7 @@
     "appearances": 2,
     "aggregatedRank": 1162,
     "countryRank": 30,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80195,6 +81357,7 @@
     "appearances": 2,
     "aggregatedRank": 1163,
     "countryRank": 31,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80262,6 +81425,7 @@
     "appearances": 2,
     "aggregatedRank": 1164,
     "countryRank": 32,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80329,6 +81493,7 @@
     "appearances": 2,
     "aggregatedRank": 1165,
     "countryRank": 12,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80396,6 +81561,7 @@
     "appearances": 2,
     "aggregatedRank": 1166,
     "countryRank": 16,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80463,6 +81629,7 @@
     "appearances": 2,
     "aggregatedRank": 1167,
     "countryRank": 52,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80527,6 +81694,7 @@
     "appearances": 1,
     "aggregatedRank": 1168,
     "countryRank": 7,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80586,6 +81754,7 @@
     "appearances": 1,
     "aggregatedRank": 1169,
     "countryRank": 74,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80647,6 +81816,7 @@
     "appearances": 1,
     "aggregatedRank": 1170,
     "countryRank": 188,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80708,6 +81878,7 @@
     "appearances": 1,
     "aggregatedRank": 1171,
     "countryRank": 18,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80767,6 +81938,7 @@
     "appearances": 1,
     "aggregatedRank": 1172,
     "countryRank": 9,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80829,6 +82001,7 @@
     "appearances": 2,
     "aggregatedRank": 1173,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80893,6 +82066,7 @@
     "appearances": 1,
     "aggregatedRank": 1174,
     "countryRank": 12,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -80957,6 +82131,7 @@
     "appearances": 2,
     "aggregatedRank": 1175,
     "countryRank": 15,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81019,6 +82194,7 @@
     "appearances": 1,
     "aggregatedRank": 1176,
     "countryRank": 19,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81078,6 +82254,7 @@
     "appearances": 1,
     "aggregatedRank": 1177,
     "countryRank": 13,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81139,6 +82316,7 @@
     "appearances": 1,
     "aggregatedRank": 1178,
     "countryRank": 147,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81200,6 +82378,7 @@
     "appearances": 1,
     "aggregatedRank": 1179,
     "countryRank": 148,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81261,6 +82440,7 @@
     "appearances": 1,
     "aggregatedRank": 1180,
     "countryRank": 149,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81322,6 +82502,7 @@
     "appearances": 1,
     "aggregatedRank": 1181,
     "countryRank": 150,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81383,6 +82564,7 @@
     "appearances": 1,
     "aggregatedRank": 1182,
     "countryRank": 151,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81444,6 +82626,7 @@
     "appearances": 1,
     "aggregatedRank": 1183,
     "countryRank": 152,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81505,6 +82688,7 @@
     "appearances": 1,
     "aggregatedRank": 1184,
     "countryRank": 75,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81566,6 +82750,7 @@
     "appearances": 1,
     "aggregatedRank": 1185,
     "countryRank": 76,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81627,6 +82812,7 @@
     "appearances": 1,
     "aggregatedRank": 1186,
     "countryRank": 41,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81688,6 +82874,7 @@
     "appearances": 1,
     "aggregatedRank": 1187,
     "countryRank": 12,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81749,6 +82936,7 @@
     "appearances": 1,
     "aggregatedRank": 1188,
     "countryRank": 153,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81810,6 +82998,7 @@
     "appearances": 1,
     "aggregatedRank": 1189,
     "countryRank": 154,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81871,6 +83060,7 @@
     "appearances": 1,
     "aggregatedRank": 1190,
     "countryRank": 155,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81932,6 +83122,7 @@
     "appearances": 1,
     "aggregatedRank": 1191,
     "countryRank": 156,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -81993,6 +83184,7 @@
     "appearances": 1,
     "aggregatedRank": 1192,
     "countryRank": 157,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82054,6 +83246,7 @@
     "appearances": 1,
     "aggregatedRank": 1193,
     "countryRank": 158,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82115,6 +83308,7 @@
     "appearances": 1,
     "aggregatedRank": 1194,
     "countryRank": 159,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82176,6 +83370,7 @@
     "appearances": 1,
     "aggregatedRank": 1195,
     "countryRank": 160,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82237,6 +83432,7 @@
     "appearances": 1,
     "aggregatedRank": 1196,
     "countryRank": 161,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82298,6 +83494,7 @@
     "appearances": 1,
     "aggregatedRank": 1197,
     "countryRank": 13,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82359,6 +83556,7 @@
     "appearances": 1,
     "aggregatedRank": 1198,
     "countryRank": 34,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82420,6 +83618,7 @@
     "appearances": 1,
     "aggregatedRank": 1199,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82479,6 +83678,7 @@
     "appearances": 1,
     "aggregatedRank": 1200,
     "countryRank": 35,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82538,6 +83738,7 @@
     "appearances": 1,
     "aggregatedRank": 1201,
     "countryRank": 36,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82597,6 +83798,7 @@
     "appearances": 1,
     "aggregatedRank": 1202,
     "countryRank": 31,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82658,6 +83860,7 @@
     "appearances": 1,
     "aggregatedRank": 1203,
     "countryRank": 12,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82719,6 +83922,7 @@
     "appearances": 1,
     "aggregatedRank": 1204,
     "countryRank": 77,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82780,6 +83984,7 @@
     "appearances": 1,
     "aggregatedRank": 1205,
     "countryRank": 78,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82841,6 +84046,7 @@
     "appearances": 1,
     "aggregatedRank": 1206,
     "countryRank": 42,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82902,6 +84108,7 @@
     "appearances": 1,
     "aggregatedRank": 1207,
     "countryRank": 43,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -82963,6 +84170,7 @@
     "appearances": 1,
     "aggregatedRank": 1208,
     "countryRank": 6,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83024,6 +84232,7 @@
     "appearances": 1,
     "aggregatedRank": 1209,
     "countryRank": 37,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83085,6 +84294,7 @@
     "appearances": 1,
     "aggregatedRank": 1210,
     "countryRank": 16,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83146,6 +84356,7 @@
     "appearances": 1,
     "aggregatedRank": 1211,
     "countryRank": 17,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83207,6 +84418,7 @@
     "appearances": 1,
     "aggregatedRank": 1212,
     "countryRank": 18,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83268,6 +84480,7 @@
     "appearances": 1,
     "aggregatedRank": 1213,
     "countryRank": 53,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83329,6 +84542,7 @@
     "appearances": 1,
     "aggregatedRank": 1214,
     "countryRank": 25,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83390,6 +84604,7 @@
     "appearances": 1,
     "aggregatedRank": 1215,
     "countryRank": 13,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83451,6 +84666,7 @@
     "appearances": 1,
     "aggregatedRank": 1216,
     "countryRank": 14,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83512,6 +84728,7 @@
     "appearances": 1,
     "aggregatedRank": 1217,
     "countryRank": 15,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83573,6 +84790,7 @@
     "appearances": 1,
     "aggregatedRank": 1218,
     "countryRank": 14,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83634,6 +84852,7 @@
     "appearances": 1,
     "aggregatedRank": 1219,
     "countryRank": 17,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83695,6 +84914,7 @@
     "appearances": 1,
     "aggregatedRank": 1220,
     "countryRank": 86,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83756,6 +84976,7 @@
     "appearances": 1,
     "aggregatedRank": 1221,
     "countryRank": 87,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83817,6 +85038,7 @@
     "appearances": 1,
     "aggregatedRank": 1222,
     "countryRank": 88,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83878,6 +85100,7 @@
     "appearances": 1,
     "aggregatedRank": 1223,
     "countryRank": 189,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -83939,6 +85162,7 @@
     "appearances": 1,
     "aggregatedRank": 1224,
     "countryRank": 38,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84000,6 +85224,7 @@
     "appearances": 1,
     "aggregatedRank": 1225,
     "countryRank": 89,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84061,6 +85286,7 @@
     "appearances": 1,
     "aggregatedRank": 1226,
     "countryRank": 19,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84122,6 +85348,7 @@
     "appearances": 1,
     "aggregatedRank": 1227,
     "countryRank": 44,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84183,6 +85410,7 @@
     "appearances": 1,
     "aggregatedRank": 1228,
     "countryRank": 54,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84244,6 +85472,7 @@
     "appearances": 1,
     "aggregatedRank": 1229,
     "countryRank": 39,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84305,6 +85534,7 @@
     "appearances": 1,
     "aggregatedRank": 1230,
     "countryRank": 55,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84366,6 +85596,7 @@
     "appearances": 1,
     "aggregatedRank": 1231,
     "countryRank": 90,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84427,6 +85658,7 @@
     "appearances": 1,
     "aggregatedRank": 1232,
     "countryRank": 8,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84488,6 +85720,7 @@
     "appearances": 1,
     "aggregatedRank": 1233,
     "countryRank": 20,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84549,6 +85782,7 @@
     "appearances": 1,
     "aggregatedRank": 1234,
     "countryRank": 21,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84610,6 +85844,7 @@
     "appearances": 1,
     "aggregatedRank": 1235,
     "countryRank": 22,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84671,6 +85906,7 @@
     "appearances": 1,
     "aggregatedRank": 1236,
     "countryRank": 16,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84732,6 +85968,7 @@
     "appearances": 1,
     "aggregatedRank": 1237,
     "countryRank": 40,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84793,6 +86030,7 @@
     "appearances": 1,
     "aggregatedRank": 1238,
     "countryRank": 10,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84854,6 +86092,7 @@
     "appearances": 1,
     "aggregatedRank": 1239,
     "countryRank": 21,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84915,6 +86154,7 @@
     "appearances": 1,
     "aggregatedRank": 1240,
     "countryRank": 41,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -84976,6 +86216,7 @@
     "appearances": 1,
     "aggregatedRank": 1241,
     "countryRank": 42,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85040,6 +86281,7 @@
     "appearances": 2,
     "aggregatedRank": 1242,
     "countryRank": 56,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85104,6 +86346,7 @@
     "appearances": 1,
     "aggregatedRank": 1243,
     "countryRank": 18,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85165,6 +86408,7 @@
     "appearances": 1,
     "aggregatedRank": 1244,
     "countryRank": 10,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85224,6 +86468,7 @@
     "appearances": 1,
     "aggregatedRank": 1245,
     "countryRank": 14,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85288,6 +86533,7 @@
     "appearances": 2,
     "aggregatedRank": 1246,
     "countryRank": 19,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85350,6 +86596,7 @@
     "appearances": 1,
     "aggregatedRank": 1247,
     "countryRank": 15,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85411,6 +86658,7 @@
     "appearances": 1,
     "aggregatedRank": 1248,
     "countryRank": 45,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85472,6 +86720,7 @@
     "appearances": 1,
     "aggregatedRank": 1249,
     "countryRank": 16,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85533,6 +86782,7 @@
     "appearances": 1,
     "aggregatedRank": 1250,
     "countryRank": 5,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85592,6 +86842,7 @@
     "appearances": 1,
     "aggregatedRank": 1251,
     "countryRank": 20,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85653,6 +86904,7 @@
     "appearances": 1,
     "aggregatedRank": 1252,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85712,6 +86964,7 @@
     "appearances": 1,
     "aggregatedRank": 1253,
     "countryRank": 17,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85771,6 +87024,7 @@
     "appearances": 1,
     "aggregatedRank": 1254,
     "countryRank": 5,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85835,6 +87089,7 @@
     "appearances": 2,
     "aggregatedRank": 1255,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85899,6 +87154,7 @@
     "appearances": 1,
     "aggregatedRank": 1256,
     "countryRank": 8,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -85960,6 +87216,7 @@
     "appearances": 1,
     "aggregatedRank": 1257,
     "countryRank": 5,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86019,6 +87276,7 @@
     "appearances": 1,
     "aggregatedRank": 1258,
     "countryRank": 18,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86080,6 +87338,7 @@
     "appearances": 1,
     "aggregatedRank": 1259,
     "countryRank": 91,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86141,6 +87400,7 @@
     "appearances": 1,
     "aggregatedRank": 1260,
     "countryRank": 162,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86202,6 +87462,7 @@
     "appearances": 1,
     "aggregatedRank": 1261,
     "countryRank": 21,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86261,6 +87522,7 @@
     "appearances": 1,
     "aggregatedRank": 1262,
     "countryRank": 7,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86325,6 +87587,7 @@
     "appearances": 2,
     "aggregatedRank": 1263,
     "countryRank": 2,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86389,6 +87652,7 @@
     "appearances": 1,
     "aggregatedRank": 1264,
     "countryRank": 92,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86448,6 +87712,7 @@
     "appearances": 1,
     "aggregatedRank": 1265,
     "countryRank": 79,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86512,6 +87777,7 @@
     "appearances": 2,
     "aggregatedRank": 1266,
     "countryRank": 26,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86579,6 +87845,7 @@
     "appearances": 2,
     "aggregatedRank": 1267,
     "countryRank": 6,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86646,6 +87913,7 @@
     "appearances": 2,
     "aggregatedRank": 1268,
     "countryRank": 2,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86713,6 +87981,7 @@
     "appearances": 2,
     "aggregatedRank": 1269,
     "countryRank": 43,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86780,6 +88049,7 @@
     "appearances": 2,
     "aggregatedRank": 1270,
     "countryRank": 23,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86847,6 +88117,7 @@
     "appearances": 2,
     "aggregatedRank": 1271,
     "countryRank": 93,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86911,6 +88182,7 @@
     "appearances": 1,
     "aggregatedRank": 1272,
     "countryRank": 10,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -86972,6 +88244,7 @@
     "appearances": 1,
     "aggregatedRank": 1273,
     "countryRank": 190,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87033,6 +88306,7 @@
     "appearances": 1,
     "aggregatedRank": 1274,
     "countryRank": 7,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87094,6 +88368,7 @@
     "appearances": 1,
     "aggregatedRank": 1275,
     "countryRank": 20,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87153,6 +88428,7 @@
     "appearances": 1,
     "aggregatedRank": 1276,
     "countryRank": 19,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87214,6 +88490,7 @@
     "appearances": 1,
     "aggregatedRank": 1277,
     "countryRank": 57,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87275,6 +88552,7 @@
     "appearances": 1,
     "aggregatedRank": 1278,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87336,6 +88614,7 @@
     "appearances": 1,
     "aggregatedRank": 1279,
     "countryRank": 13,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87397,6 +88676,7 @@
     "appearances": 1,
     "aggregatedRank": 1280,
     "countryRank": 20,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87458,6 +88738,7 @@
     "appearances": 1,
     "aggregatedRank": 1281,
     "countryRank": 191,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87519,6 +88800,7 @@
     "appearances": 1,
     "aggregatedRank": 1282,
     "countryRank": 21,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87583,6 +88865,7 @@
     "appearances": 2,
     "aggregatedRank": 1283,
     "countryRank": 163,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87647,6 +88930,7 @@
     "appearances": 1,
     "aggregatedRank": 1284,
     "countryRank": 22,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87708,6 +88992,7 @@
     "appearances": 1,
     "aggregatedRank": 1285,
     "countryRank": 23,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87769,6 +89054,7 @@
     "appearances": 1,
     "aggregatedRank": 1286,
     "countryRank": 44,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87830,6 +89116,7 @@
     "appearances": 1,
     "aggregatedRank": 1287,
     "countryRank": 45,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87889,6 +89176,7 @@
     "appearances": 1,
     "aggregatedRank": 1288,
     "countryRank": 192,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -87948,6 +89236,7 @@
     "appearances": 1,
     "aggregatedRank": 1289,
     "countryRank": 24,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88009,6 +89298,7 @@
     "appearances": 1,
     "aggregatedRank": 1290,
     "countryRank": 164,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88068,6 +89358,7 @@
     "appearances": 1,
     "aggregatedRank": 1291,
     "countryRank": 25,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88129,6 +89420,7 @@
     "appearances": 1,
     "aggregatedRank": 1292,
     "countryRank": 46,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88190,6 +89482,7 @@
     "appearances": 1,
     "aggregatedRank": 1293,
     "countryRank": 26,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88251,6 +89544,7 @@
     "appearances": 1,
     "aggregatedRank": 1294,
     "countryRank": 27,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88312,6 +89606,7 @@
     "appearances": 1,
     "aggregatedRank": 1295,
     "countryRank": 46,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88373,6 +89668,7 @@
     "appearances": 1,
     "aggregatedRank": 1296,
     "countryRank": 11,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88434,6 +89730,7 @@
     "appearances": 1,
     "aggregatedRank": 1297,
     "countryRank": 27,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88495,6 +89792,7 @@
     "appearances": 1,
     "aggregatedRank": 1298,
     "countryRank": 29,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88554,6 +89852,7 @@
     "appearances": 1,
     "aggregatedRank": 1299,
     "countryRank": 9,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88615,6 +89914,7 @@
     "appearances": 1,
     "aggregatedRank": 1300,
     "countryRank": 28,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88676,6 +89976,7 @@
     "appearances": 1,
     "aggregatedRank": 1301,
     "countryRank": 2,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88737,6 +90038,7 @@
     "appearances": 1,
     "aggregatedRank": 1302,
     "countryRank": 47,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88796,6 +90098,7 @@
     "appearances": 1,
     "aggregatedRank": 1303,
     "countryRank": 29,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88857,6 +90160,7 @@
     "appearances": 1,
     "aggregatedRank": 1304,
     "countryRank": 33,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88918,6 +90222,7 @@
     "appearances": 1,
     "aggregatedRank": 1305,
     "countryRank": 47,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -88977,6 +90282,7 @@
     "appearances": 1,
     "aggregatedRank": 1306,
     "countryRank": 34,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89036,6 +90342,7 @@
     "appearances": 1,
     "aggregatedRank": 1307,
     "countryRank": 28,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89097,6 +90404,7 @@
     "appearances": 1,
     "aggregatedRank": 1308,
     "countryRank": 6,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89158,6 +90466,7 @@
     "appearances": 1,
     "aggregatedRank": 1309,
     "countryRank": 30,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89222,6 +90531,7 @@
     "appearances": 2,
     "aggregatedRank": 1310,
     "countryRank": 193,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89287,6 +90597,7 @@
     "appearances": 2,
     "aggregatedRank": 1311,
     "countryRank": 15,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89349,6 +90660,7 @@
     "appearances": 1,
     "aggregatedRank": 1312,
     "countryRank": 30,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89408,6 +90720,7 @@
     "appearances": 1,
     "aggregatedRank": 1313,
     "countryRank": 4,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89467,6 +90780,7 @@
     "appearances": 1,
     "aggregatedRank": 1314,
     "countryRank": 6,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89528,6 +90842,7 @@
     "appearances": 1,
     "aggregatedRank": 1315,
     "countryRank": 165,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89590,6 +90905,7 @@
     "appearances": 1,
     "aggregatedRank": 1316,
     "countryRank": 14,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89651,6 +90967,7 @@
     "appearances": 1,
     "aggregatedRank": 1317,
     "countryRank": 15,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89712,6 +91029,7 @@
     "appearances": 1,
     "aggregatedRank": 1318,
     "countryRank": 16,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89773,6 +91091,7 @@
     "appearances": 1,
     "aggregatedRank": 1319,
     "countryRank": 166,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89834,6 +91153,7 @@
     "appearances": 1,
     "aggregatedRank": 1320,
     "countryRank": 167,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89893,6 +91213,7 @@
     "appearances": 1,
     "aggregatedRank": 1321,
     "countryRank": 168,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -89954,6 +91275,7 @@
     "appearances": 1,
     "aggregatedRank": 1322,
     "countryRank": 169,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90015,6 +91337,7 @@
     "appearances": 1,
     "aggregatedRank": 1323,
     "countryRank": 170,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90076,6 +91399,7 @@
     "appearances": 1,
     "aggregatedRank": 1324,
     "countryRank": 171,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90137,6 +91461,7 @@
     "appearances": 1,
     "aggregatedRank": 1325,
     "countryRank": 172,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90198,6 +91523,7 @@
     "appearances": 1,
     "aggregatedRank": 1326,
     "countryRank": 173,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90257,6 +91583,7 @@
     "appearances": 1,
     "aggregatedRank": 1327,
     "countryRank": 174,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90318,6 +91645,7 @@
     "appearances": 1,
     "aggregatedRank": 1328,
     "countryRank": 35,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90379,6 +91707,7 @@
     "appearances": 1,
     "aggregatedRank": 1329,
     "countryRank": 36,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90440,6 +91769,7 @@
     "appearances": 1,
     "aggregatedRank": 1330,
     "countryRank": 29,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90501,6 +91831,7 @@
     "appearances": 1,
     "aggregatedRank": 1331,
     "countryRank": 30,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90562,6 +91893,7 @@
     "appearances": 1,
     "aggregatedRank": 1332,
     "countryRank": 31,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90623,6 +91955,7 @@
     "appearances": 1,
     "aggregatedRank": 1333,
     "countryRank": 31,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90684,6 +92017,7 @@
     "appearances": 1,
     "aggregatedRank": 1334,
     "countryRank": 32,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90745,6 +92079,7 @@
     "appearances": 1,
     "aggregatedRank": 1335,
     "countryRank": 33,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90806,6 +92141,7 @@
     "appearances": 1,
     "aggregatedRank": 1336,
     "countryRank": 15,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90867,6 +92203,7 @@
     "appearances": 1,
     "aggregatedRank": 1337,
     "countryRank": 194,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90928,6 +92265,7 @@
     "appearances": 1,
     "aggregatedRank": 1338,
     "countryRank": 175,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -90987,6 +92325,7 @@
     "appearances": 1,
     "aggregatedRank": 1339,
     "countryRank": 176,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91046,6 +92385,7 @@
     "appearances": 1,
     "aggregatedRank": 1340,
     "countryRank": 177,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91107,6 +92447,7 @@
     "appearances": 1,
     "aggregatedRank": 1341,
     "countryRank": 178,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91168,6 +92509,7 @@
     "appearances": 1,
     "aggregatedRank": 1342,
     "countryRank": 179,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91229,6 +92571,7 @@
     "appearances": 1,
     "aggregatedRank": 1343,
     "countryRank": 180,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91290,6 +92633,7 @@
     "appearances": 1,
     "aggregatedRank": 1344,
     "countryRank": 16,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91351,6 +92695,7 @@
     "appearances": 1,
     "aggregatedRank": 1345,
     "countryRank": 195,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91412,6 +92757,7 @@
     "appearances": 1,
     "aggregatedRank": 1346,
     "countryRank": 181,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91473,6 +92819,7 @@
     "appearances": 1,
     "aggregatedRank": 1347,
     "countryRank": 37,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91534,6 +92881,7 @@
     "appearances": 1,
     "aggregatedRank": 1348,
     "countryRank": 38,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91595,6 +92943,7 @@
     "appearances": 1,
     "aggregatedRank": 1349,
     "countryRank": 32,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91654,6 +93003,7 @@
     "appearances": 1,
     "aggregatedRank": 1350,
     "countryRank": 9,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91715,6 +93065,7 @@
     "appearances": 1,
     "aggregatedRank": 1351,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91776,6 +93127,7 @@
     "appearances": 1,
     "aggregatedRank": 1352,
     "countryRank": 1,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91837,6 +93189,7 @@
     "appearances": 1,
     "aggregatedRank": 1353,
     "countryRank": 17,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91898,6 +93251,7 @@
     "appearances": 1,
     "aggregatedRank": 1354,
     "countryRank": 31,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -91960,6 +93314,7 @@
     "appearances": 2,
     "aggregatedRank": 1355,
     "countryRank": 18,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92024,6 +93379,7 @@
     "appearances": 1,
     "aggregatedRank": 1356,
     "countryRank": 22,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92083,6 +93439,7 @@
     "appearances": 1,
     "aggregatedRank": 1357,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92144,6 +93501,7 @@
     "appearances": 1,
     "aggregatedRank": 1358,
     "countryRank": 21,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92205,6 +93563,7 @@
     "appearances": 1,
     "aggregatedRank": 1359,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92264,6 +93623,7 @@
     "appearances": 1,
     "aggregatedRank": 1360,
     "countryRank": 7,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92325,6 +93685,7 @@
     "appearances": 1,
     "aggregatedRank": 1361,
     "countryRank": 32,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92389,6 +93750,7 @@
     "appearances": 2,
     "aggregatedRank": 1362,
     "countryRank": 196,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92454,6 +93816,7 @@
     "appearances": 1,
     "aggregatedRank": 1363,
     "countryRank": 33,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92515,6 +93878,7 @@
     "appearances": 1,
     "aggregatedRank": 1364,
     "countryRank": 9,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92576,6 +93940,7 @@
     "appearances": 1,
     "aggregatedRank": 1365,
     "countryRank": 2,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92637,6 +94002,7 @@
     "appearances": 1,
     "aggregatedRank": 1366,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92698,6 +94064,7 @@
     "appearances": 1,
     "aggregatedRank": 1367,
     "countryRank": 22,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92759,6 +94126,7 @@
     "appearances": 1,
     "aggregatedRank": 1368,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92820,6 +94188,7 @@
     "appearances": 1,
     "aggregatedRank": 1369,
     "countryRank": 34,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92881,6 +94250,7 @@
     "appearances": 1,
     "aggregatedRank": 1370,
     "countryRank": 35,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -92942,6 +94312,7 @@
     "appearances": 1,
     "aggregatedRank": 1371,
     "countryRank": 36,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93003,6 +94374,7 @@
     "appearances": 1,
     "aggregatedRank": 1372,
     "countryRank": 58,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93064,6 +94436,7 @@
     "appearances": 1,
     "aggregatedRank": 1373,
     "countryRank": 182,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93125,6 +94498,7 @@
     "appearances": 1,
     "aggregatedRank": 1374,
     "countryRank": 37,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93187,6 +94561,7 @@
     "appearances": 2,
     "aggregatedRank": 1375,
     "countryRank": 32,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93251,6 +94626,7 @@
     "appearances": 1,
     "aggregatedRank": 1376,
     "countryRank": 3,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93310,6 +94686,7 @@
     "appearances": 1,
     "aggregatedRank": 1377,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93371,6 +94748,7 @@
     "appearances": 1,
     "aggregatedRank": 1378,
     "countryRank": 4,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93432,6 +94810,7 @@
     "appearances": 1,
     "aggregatedRank": 1379,
     "countryRank": 8,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93493,6 +94872,7 @@
     "appearances": 1,
     "aggregatedRank": 1380,
     "countryRank": 59,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93554,6 +94934,7 @@
     "appearances": 1,
     "aggregatedRank": 1381,
     "countryRank": 197,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93615,6 +94996,7 @@
     "appearances": 1,
     "aggregatedRank": 1382,
     "countryRank": 38,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93676,6 +95058,7 @@
     "appearances": 1,
     "aggregatedRank": 1383,
     "countryRank": 5,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93737,6 +95120,7 @@
     "appearances": 1,
     "aggregatedRank": 1384,
     "countryRank": 6,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93798,6 +95182,7 @@
     "appearances": 1,
     "aggregatedRank": 1385,
     "countryRank": 33,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93859,6 +95244,7 @@
     "appearances": 1,
     "aggregatedRank": 1386,
     "countryRank": 80,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93920,6 +95306,7 @@
     "appearances": 1,
     "aggregatedRank": 1387,
     "countryRank": 9,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -93981,6 +95368,7 @@
     "appearances": 1,
     "aggregatedRank": 1388,
     "countryRank": 4,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94040,6 +95428,7 @@
     "appearances": 1,
     "aggregatedRank": 1389,
     "countryRank": 5,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94099,6 +95488,7 @@
     "appearances": 1,
     "aggregatedRank": 1390,
     "countryRank": 2,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94160,6 +95550,7 @@
     "appearances": 1,
     "aggregatedRank": 1391,
     "countryRank": 2,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94221,6 +95612,7 @@
     "appearances": 1,
     "aggregatedRank": 1392,
     "countryRank": 9,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94280,6 +95672,7 @@
     "appearances": 1,
     "aggregatedRank": 1393,
     "countryRank": 39,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94341,6 +95734,7 @@
     "appearances": 1,
     "aggregatedRank": 1394,
     "countryRank": 6,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94400,6 +95794,7 @@
     "appearances": 1,
     "aggregatedRank": 1395,
     "countryRank": 23,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94459,6 +95854,7 @@
     "appearances": 1,
     "aggregatedRank": 1396,
     "countryRank": 3,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94518,6 +95914,7 @@
     "appearances": 1,
     "aggregatedRank": 1397,
     "countryRank": 17,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94577,6 +95974,7 @@
     "appearances": 1,
     "aggregatedRank": 1398,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94636,6 +96034,7 @@
     "appearances": 1,
     "aggregatedRank": 1399,
     "countryRank": 2,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94695,6 +96094,7 @@
     "appearances": 1,
     "aggregatedRank": 1400,
     "countryRank": 48,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94756,6 +96156,7 @@
     "appearances": 1,
     "aggregatedRank": 1401,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94817,6 +96218,7 @@
     "appearances": 1,
     "aggregatedRank": 1402,
     "countryRank": 5,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94876,6 +96278,7 @@
     "appearances": 1,
     "aggregatedRank": 1403,
     "countryRank": 19,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94935,6 +96338,7 @@
     "appearances": 1,
     "aggregatedRank": 1404,
     "countryRank": 7,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -94994,6 +96398,7 @@
     "appearances": 1,
     "aggregatedRank": 1405,
     "countryRank": 8,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95055,6 +96460,7 @@
     "appearances": 1,
     "aggregatedRank": 1406,
     "countryRank": 3,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95116,6 +96522,7 @@
     "appearances": 1,
     "aggregatedRank": 1407,
     "countryRank": 2,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95175,6 +96582,7 @@
     "appearances": 1,
     "aggregatedRank": 1408,
     "countryRank": 198,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95234,6 +96642,7 @@
     "appearances": 1,
     "aggregatedRank": 1409,
     "countryRank": 9,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95293,6 +96702,7 @@
     "appearances": 1,
     "aggregatedRank": 1410,
     "countryRank": 5,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95354,6 +96764,7 @@
     "appearances": 1,
     "aggregatedRank": 1411,
     "countryRank": 49,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95415,6 +96826,7 @@
     "appearances": 1,
     "aggregatedRank": 1412,
     "countryRank": 13,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95476,6 +96888,7 @@
     "appearances": 1,
     "aggregatedRank": 1413,
     "countryRank": 50,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95537,6 +96950,7 @@
     "appearances": 1,
     "aggregatedRank": 1414,
     "countryRank": 18,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95598,6 +97012,7 @@
     "appearances": 1,
     "aggregatedRank": 1415,
     "countryRank": 19,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95659,6 +97074,7 @@
     "appearances": 1,
     "aggregatedRank": 1416,
     "countryRank": 34,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95718,6 +97134,7 @@
     "appearances": 1,
     "aggregatedRank": 1417,
     "countryRank": 183,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95777,6 +97194,7 @@
     "appearances": 1,
     "aggregatedRank": 1418,
     "countryRank": 184,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95838,6 +97256,7 @@
     "appearances": 1,
     "aggregatedRank": 1419,
     "countryRank": 185,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95897,6 +97316,7 @@
     "appearances": 1,
     "aggregatedRank": 1420,
     "countryRank": 186,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -95958,6 +97378,7 @@
     "appearances": 1,
     "aggregatedRank": 1421,
     "countryRank": 187,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96019,6 +97440,7 @@
     "appearances": 1,
     "aggregatedRank": 1422,
     "countryRank": 188,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96080,6 +97502,7 @@
     "appearances": 1,
     "aggregatedRank": 1423,
     "countryRank": 189,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96141,6 +97564,7 @@
     "appearances": 1,
     "aggregatedRank": 1424,
     "countryRank": 190,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96200,6 +97624,7 @@
     "appearances": 1,
     "aggregatedRank": 1425,
     "countryRank": 191,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96261,6 +97686,7 @@
     "appearances": 1,
     "aggregatedRank": 1426,
     "countryRank": 192,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96322,6 +97748,7 @@
     "appearances": 1,
     "aggregatedRank": 1427,
     "countryRank": 6,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96381,6 +97808,7 @@
     "appearances": 1,
     "aggregatedRank": 1428,
     "countryRank": 81,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96442,6 +97870,7 @@
     "appearances": 1,
     "aggregatedRank": 1429,
     "countryRank": 39,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96503,6 +97932,7 @@
     "appearances": 1,
     "aggregatedRank": 1430,
     "countryRank": 48,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96564,6 +97994,7 @@
     "appearances": 1,
     "aggregatedRank": 1431,
     "countryRank": 49,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96625,6 +98056,7 @@
     "appearances": 1,
     "aggregatedRank": 1432,
     "countryRank": 50,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96684,6 +98116,7 @@
     "appearances": 1,
     "aggregatedRank": 1433,
     "countryRank": 51,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96743,6 +98176,7 @@
     "appearances": 1,
     "aggregatedRank": 1434,
     "countryRank": 199,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96804,6 +98238,7 @@
     "appearances": 1,
     "aggregatedRank": 1435,
     "countryRank": 200,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96863,6 +98298,7 @@
     "appearances": 1,
     "aggregatedRank": 1436,
     "countryRank": 201,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96924,6 +98360,7 @@
     "appearances": 1,
     "aggregatedRank": 1437,
     "countryRank": 193,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -96985,6 +98422,7 @@
     "appearances": 1,
     "aggregatedRank": 1438,
     "countryRank": 194,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97046,6 +98484,7 @@
     "appearances": 1,
     "aggregatedRank": 1439,
     "countryRank": 195,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97107,6 +98546,7 @@
     "appearances": 1,
     "aggregatedRank": 1440,
     "countryRank": 196,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97168,6 +98608,7 @@
     "appearances": 1,
     "aggregatedRank": 1441,
     "countryRank": 197,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97227,6 +98668,7 @@
     "appearances": 1,
     "aggregatedRank": 1442,
     "countryRank": 12,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97286,6 +98728,7 @@
     "appearances": 1,
     "aggregatedRank": 1443,
     "countryRank": 198,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97345,6 +98788,7 @@
     "appearances": 1,
     "aggregatedRank": 1444,
     "countryRank": 24,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97406,6 +98850,7 @@
     "appearances": 1,
     "aggregatedRank": 1445,
     "countryRank": 17,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97465,6 +98910,7 @@
     "appearances": 1,
     "aggregatedRank": 1446,
     "countryRank": 25,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97524,6 +98970,7 @@
     "appearances": 1,
     "aggregatedRank": 1447,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97583,6 +99030,7 @@
     "appearances": 1,
     "aggregatedRank": 1448,
     "countryRank": 4,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97642,6 +99090,7 @@
     "appearances": 1,
     "aggregatedRank": 1449,
     "countryRank": 51,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97701,6 +99150,7 @@
     "appearances": 1,
     "aggregatedRank": 1450,
     "countryRank": 3,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97760,6 +99210,7 @@
     "appearances": 1,
     "aggregatedRank": 1451,
     "countryRank": 20,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97819,6 +99270,7 @@
     "appearances": 1,
     "aggregatedRank": 1452,
     "countryRank": 18,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97878,6 +99330,7 @@
     "appearances": 1,
     "aggregatedRank": 1453,
     "countryRank": 24,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97937,6 +99390,7 @@
     "appearances": 1,
     "aggregatedRank": 1454,
     "countryRank": 52,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -97996,6 +99450,7 @@
     "appearances": 1,
     "aggregatedRank": 1455,
     "countryRank": 26,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98055,6 +99510,7 @@
     "appearances": 1,
     "aggregatedRank": 1456,
     "countryRank": 52,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98114,6 +99570,7 @@
     "appearances": 1,
     "aggregatedRank": 1457,
     "countryRank": 13,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98175,6 +99632,7 @@
     "appearances": 1,
     "aggregatedRank": 1458,
     "countryRank": 40,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98234,6 +99692,7 @@
     "appearances": 1,
     "aggregatedRank": 1459,
     "countryRank": 5,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98295,6 +99754,7 @@
     "appearances": 1,
     "aggregatedRank": 1460,
     "countryRank": 6,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98356,6 +99816,7 @@
     "appearances": 1,
     "aggregatedRank": 1461,
     "countryRank": 35,
+    "countryTotal": 35,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98417,6 +99878,7 @@
     "appearances": 1,
     "aggregatedRank": 1462,
     "countryRank": 82,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98476,6 +99938,7 @@
     "appearances": 1,
     "aggregatedRank": 1463,
     "countryRank": 40,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98537,6 +100000,7 @@
     "appearances": 1,
     "aggregatedRank": 1464,
     "countryRank": 53,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98598,6 +100062,7 @@
     "appearances": 1,
     "aggregatedRank": 1465,
     "countryRank": 54,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98659,6 +100124,7 @@
     "appearances": 1,
     "aggregatedRank": 1466,
     "countryRank": 55,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98720,6 +100186,7 @@
     "appearances": 1,
     "aggregatedRank": 1467,
     "countryRank": 56,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98781,6 +100248,7 @@
     "appearances": 1,
     "aggregatedRank": 1468,
     "countryRank": 57,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98842,6 +100310,7 @@
     "appearances": 1,
     "aggregatedRank": 1469,
     "countryRank": 53,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98903,6 +100372,7 @@
     "appearances": 1,
     "aggregatedRank": 1470,
     "countryRank": 54,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -98964,6 +100434,7 @@
     "appearances": 1,
     "aggregatedRank": 1471,
     "countryRank": 27,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99025,6 +100496,7 @@
     "appearances": 1,
     "aggregatedRank": 1472,
     "countryRank": 28,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99086,6 +100558,7 @@
     "appearances": 1,
     "aggregatedRank": 1473,
     "countryRank": 29,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99147,6 +100620,7 @@
     "appearances": 1,
     "aggregatedRank": 1474,
     "countryRank": 30,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99208,6 +100682,7 @@
     "appearances": 1,
     "aggregatedRank": 1475,
     "countryRank": 31,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99269,6 +100744,7 @@
     "appearances": 1,
     "aggregatedRank": 1476,
     "countryRank": 32,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99328,6 +100804,7 @@
     "appearances": 1,
     "aggregatedRank": 1477,
     "countryRank": 33,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99389,6 +100866,7 @@
     "appearances": 1,
     "aggregatedRank": 1478,
     "countryRank": 34,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99450,6 +100928,7 @@
     "appearances": 1,
     "aggregatedRank": 1479,
     "countryRank": 35,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99509,6 +100988,7 @@
     "appearances": 1,
     "aggregatedRank": 1480,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99570,6 +101050,7 @@
     "appearances": 1,
     "aggregatedRank": 1481,
     "countryRank": 60,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99631,6 +101112,7 @@
     "appearances": 1,
     "aggregatedRank": 1482,
     "countryRank": 7,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99692,6 +101174,7 @@
     "appearances": 1,
     "aggregatedRank": 1483,
     "countryRank": 8,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99751,6 +101234,7 @@
     "appearances": 1,
     "aggregatedRank": 1484,
     "countryRank": 9,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99810,6 +101294,7 @@
     "appearances": 1,
     "aggregatedRank": 1485,
     "countryRank": 10,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99869,6 +101354,7 @@
     "appearances": 1,
     "aggregatedRank": 1486,
     "countryRank": 33,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99930,6 +101416,7 @@
     "appearances": 1,
     "aggregatedRank": 1487,
     "countryRank": 21,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -99989,6 +101476,7 @@
     "appearances": 1,
     "aggregatedRank": 1488,
     "countryRank": 22,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100050,6 +101538,7 @@
     "appearances": 1,
     "aggregatedRank": 1489,
     "countryRank": 23,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100111,6 +101600,7 @@
     "appearances": 1,
     "aggregatedRank": 1490,
     "countryRank": 24,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100172,6 +101662,7 @@
     "appearances": 1,
     "aggregatedRank": 1491,
     "countryRank": 10,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100233,6 +101724,7 @@
     "appearances": 1,
     "aggregatedRank": 1492,
     "countryRank": 23,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100294,6 +101786,7 @@
     "appearances": 1,
     "aggregatedRank": 1493,
     "countryRank": 22,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100355,6 +101848,7 @@
     "appearances": 1,
     "aggregatedRank": 1494,
     "countryRank": 16,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100414,6 +101908,7 @@
     "appearances": 1,
     "aggregatedRank": 1495,
     "countryRank": 17,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100475,6 +101970,7 @@
     "appearances": 1,
     "aggregatedRank": 1496,
     "countryRank": 19,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100536,6 +102032,7 @@
     "appearances": 1,
     "aggregatedRank": 1497,
     "countryRank": 94,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100597,6 +102094,7 @@
     "appearances": 1,
     "aggregatedRank": 1498,
     "countryRank": 95,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100658,6 +102156,7 @@
     "appearances": 1,
     "aggregatedRank": 1499,
     "countryRank": 96,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100719,6 +102218,7 @@
     "appearances": 1,
     "aggregatedRank": 1500,
     "countryRank": 97,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100780,6 +102280,7 @@
     "appearances": 1,
     "aggregatedRank": 1501,
     "countryRank": 6,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100841,6 +102342,7 @@
     "appearances": 1,
     "aggregatedRank": 1502,
     "countryRank": 202,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100902,6 +102404,7 @@
     "appearances": 1,
     "aggregatedRank": 1503,
     "countryRank": 203,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -100963,6 +102466,7 @@
     "appearances": 1,
     "aggregatedRank": 1504,
     "countryRank": 204,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101024,6 +102528,7 @@
     "appearances": 1,
     "aggregatedRank": 1505,
     "countryRank": 205,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101085,6 +102590,7 @@
     "appearances": 1,
     "aggregatedRank": 1506,
     "countryRank": 206,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101146,6 +102652,7 @@
     "appearances": 1,
     "aggregatedRank": 1507,
     "countryRank": 207,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101207,6 +102714,7 @@
     "appearances": 1,
     "aggregatedRank": 1508,
     "countryRank": 208,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101268,6 +102776,7 @@
     "appearances": 1,
     "aggregatedRank": 1509,
     "countryRank": 98,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101329,6 +102838,7 @@
     "appearances": 1,
     "aggregatedRank": 1510,
     "countryRank": 24,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101388,6 +102898,7 @@
     "appearances": 1,
     "aggregatedRank": 1511,
     "countryRank": 41,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101449,6 +102960,7 @@
     "appearances": 1,
     "aggregatedRank": 1512,
     "countryRank": 99,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101510,6 +103022,7 @@
     "appearances": 1,
     "aggregatedRank": 1513,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101571,6 +103084,7 @@
     "appearances": 1,
     "aggregatedRank": 1514,
     "countryRank": 25,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101632,6 +103146,7 @@
     "appearances": 1,
     "aggregatedRank": 1515,
     "countryRank": 55,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101693,6 +103208,7 @@
     "appearances": 1,
     "aggregatedRank": 1516,
     "countryRank": 56,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101754,6 +103270,7 @@
     "appearances": 1,
     "aggregatedRank": 1517,
     "countryRank": 57,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101815,6 +103332,7 @@
     "appearances": 1,
     "aggregatedRank": 1518,
     "countryRank": 20,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101876,6 +103394,7 @@
     "appearances": 1,
     "aggregatedRank": 1519,
     "countryRank": 23,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101935,6 +103454,7 @@
     "appearances": 1,
     "aggregatedRank": 1520,
     "countryRank": 36,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -101996,6 +103516,7 @@
     "appearances": 1,
     "aggregatedRank": 1521,
     "countryRank": 25,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102057,6 +103578,7 @@
     "appearances": 1,
     "aggregatedRank": 1522,
     "countryRank": 6,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102118,6 +103640,7 @@
     "appearances": 1,
     "aggregatedRank": 1523,
     "countryRank": 26,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102179,6 +103702,7 @@
     "appearances": 1,
     "aggregatedRank": 1524,
     "countryRank": 2,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102240,6 +103764,7 @@
     "appearances": 1,
     "aggregatedRank": 1525,
     "countryRank": 27,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102301,6 +103826,7 @@
     "appearances": 1,
     "aggregatedRank": 1526,
     "countryRank": 58,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102362,6 +103888,7 @@
     "appearances": 1,
     "aggregatedRank": 1527,
     "countryRank": 28,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102423,6 +103950,7 @@
     "appearances": 1,
     "aggregatedRank": 1528,
     "countryRank": 24,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102484,6 +104012,7 @@
     "appearances": 1,
     "aggregatedRank": 1529,
     "countryRank": 8,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102545,6 +104074,7 @@
     "appearances": 1,
     "aggregatedRank": 1530,
     "countryRank": 37,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102606,6 +104136,7 @@
     "appearances": 1,
     "aggregatedRank": 1531,
     "countryRank": 59,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102667,6 +104198,7 @@
     "appearances": 1,
     "aggregatedRank": 1532,
     "countryRank": 60,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102728,6 +104260,7 @@
     "appearances": 1,
     "aggregatedRank": 1533,
     "countryRank": 61,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102787,6 +104320,7 @@
     "appearances": 1,
     "aggregatedRank": 1534,
     "countryRank": 40,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102848,6 +104382,7 @@
     "appearances": 1,
     "aggregatedRank": 1535,
     "countryRank": 41,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102909,6 +104444,7 @@
     "appearances": 1,
     "aggregatedRank": 1536,
     "countryRank": 100,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -102970,6 +104506,7 @@
     "appearances": 1,
     "aggregatedRank": 1537,
     "countryRank": 20,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103031,6 +104568,7 @@
     "appearances": 1,
     "aggregatedRank": 1538,
     "countryRank": 42,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103090,6 +104628,7 @@
     "appearances": 1,
     "aggregatedRank": 1539,
     "countryRank": 42,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103149,6 +104688,7 @@
     "appearances": 1,
     "aggregatedRank": 1540,
     "countryRank": 209,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103210,6 +104750,7 @@
     "appearances": 1,
     "aggregatedRank": 1541,
     "countryRank": 43,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103271,6 +104812,7 @@
     "appearances": 1,
     "aggregatedRank": 1542,
     "countryRank": 44,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103332,6 +104874,7 @@
     "appearances": 1,
     "aggregatedRank": 1543,
     "countryRank": 210,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103393,6 +104936,7 @@
     "appearances": 1,
     "aggregatedRank": 1544,
     "countryRank": 45,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103454,6 +104998,7 @@
     "appearances": 1,
     "aggregatedRank": 1545,
     "countryRank": 46,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103515,6 +105060,7 @@
     "appearances": 1,
     "aggregatedRank": 1546,
     "countryRank": 47,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103576,6 +105122,7 @@
     "appearances": 1,
     "aggregatedRank": 1547,
     "countryRank": 3,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103637,6 +105184,7 @@
     "appearances": 1,
     "aggregatedRank": 1548,
     "countryRank": 6,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103696,6 +105244,7 @@
     "appearances": 1,
     "aggregatedRank": 1549,
     "countryRank": 13,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103755,6 +105304,7 @@
     "appearances": 1,
     "aggregatedRank": 1550,
     "countryRank": 4,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103816,6 +105366,7 @@
     "appearances": 1,
     "aggregatedRank": 1551,
     "countryRank": 7,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103877,6 +105428,7 @@
     "appearances": 1,
     "aggregatedRank": 1552,
     "countryRank": 8,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103936,6 +105488,7 @@
     "appearances": 1,
     "aggregatedRank": 1553,
     "countryRank": 83,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -103995,6 +105548,7 @@
     "appearances": 1,
     "aggregatedRank": 1554,
     "countryRank": 58,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104054,6 +105608,7 @@
     "appearances": 1,
     "aggregatedRank": 1555,
     "countryRank": 10,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104113,6 +105668,7 @@
     "appearances": 1,
     "aggregatedRank": 1556,
     "countryRank": 34,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104175,6 +105731,7 @@
     "appearances": 1,
     "aggregatedRank": 1557,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104236,6 +105793,7 @@
     "appearances": 1,
     "aggregatedRank": 1558,
     "countryRank": 6,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104295,6 +105853,7 @@
     "appearances": 1,
     "aggregatedRank": 1559,
     "countryRank": 25,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104356,6 +105915,7 @@
     "appearances": 1,
     "aggregatedRank": 1560,
     "countryRank": 8,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104417,6 +105977,7 @@
     "appearances": 1,
     "aggregatedRank": 1561,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104478,6 +106039,7 @@
     "appearances": 1,
     "aggregatedRank": 1562,
     "countryRank": 11,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104539,6 +106101,7 @@
     "appearances": 1,
     "aggregatedRank": 1563,
     "countryRank": 26,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104600,6 +106163,7 @@
     "appearances": 1,
     "aggregatedRank": 1564,
     "countryRank": 7,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104661,6 +106225,7 @@
     "appearances": 1,
     "aggregatedRank": 1565,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104722,6 +106287,7 @@
     "appearances": 1,
     "aggregatedRank": 1566,
     "countryRank": 62,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104781,6 +106347,7 @@
     "appearances": 1,
     "aggregatedRank": 1567,
     "countryRank": 25,
+    "countryTotal": 25,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104842,6 +106409,7 @@
     "appearances": 1,
     "aggregatedRank": 1568,
     "countryRank": 211,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104901,6 +106469,7 @@
     "appearances": 1,
     "aggregatedRank": 1569,
     "countryRank": 212,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -104962,6 +106531,7 @@
     "appearances": 1,
     "aggregatedRank": 1570,
     "countryRank": 213,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105023,6 +106593,7 @@
     "appearances": 1,
     "aggregatedRank": 1571,
     "countryRank": 43,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105084,6 +106655,7 @@
     "appearances": 1,
     "aggregatedRank": 1572,
     "countryRank": 214,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105145,6 +106717,7 @@
     "appearances": 1,
     "aggregatedRank": 1573,
     "countryRank": 48,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105206,6 +106779,7 @@
     "appearances": 1,
     "aggregatedRank": 1574,
     "countryRank": 49,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105267,6 +106841,7 @@
     "appearances": 1,
     "aggregatedRank": 1575,
     "countryRank": 50,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105328,6 +106903,7 @@
     "appearances": 1,
     "aggregatedRank": 1576,
     "countryRank": 51,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105389,6 +106965,7 @@
     "appearances": 1,
     "aggregatedRank": 1577,
     "countryRank": 21,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105450,6 +107027,7 @@
     "appearances": 1,
     "aggregatedRank": 1578,
     "countryRank": 199,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105511,6 +107089,7 @@
     "appearances": 1,
     "aggregatedRank": 1579,
     "countryRank": 44,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105572,6 +107151,7 @@
     "appearances": 1,
     "aggregatedRank": 1580,
     "countryRank": 52,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105633,6 +107213,7 @@
     "appearances": 1,
     "aggregatedRank": 1581,
     "countryRank": 1,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105694,6 +107275,7 @@
     "appearances": 1,
     "aggregatedRank": 1582,
     "countryRank": 5,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105755,6 +107337,7 @@
     "appearances": 1,
     "aggregatedRank": 1583,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105816,6 +107399,7 @@
     "appearances": 1,
     "aggregatedRank": 1584,
     "countryRank": 7,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105875,6 +107459,7 @@
     "appearances": 1,
     "aggregatedRank": 1585,
     "countryRank": 45,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105936,6 +107521,7 @@
     "appearances": 1,
     "aggregatedRank": 1586,
     "countryRank": 11,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -105997,6 +107583,7 @@
     "appearances": 1,
     "aggregatedRank": 1587,
     "countryRank": 3,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106058,6 +107645,7 @@
     "appearances": 1,
     "aggregatedRank": 1588,
     "countryRank": 9,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106117,6 +107705,7 @@
     "appearances": 1,
     "aggregatedRank": 1589,
     "countryRank": 3,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106178,6 +107767,7 @@
     "appearances": 1,
     "aggregatedRank": 1590,
     "countryRank": 8,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106239,6 +107829,7 @@
     "appearances": 1,
     "aggregatedRank": 1591,
     "countryRank": 3,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106298,6 +107889,7 @@
     "appearances": 1,
     "aggregatedRank": 1592,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106359,6 +107951,7 @@
     "appearances": 1,
     "aggregatedRank": 1593,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106418,6 +108011,7 @@
     "appearances": 1,
     "aggregatedRank": 1594,
     "countryRank": 7,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106477,6 +108071,7 @@
     "appearances": 1,
     "aggregatedRank": 1595,
     "countryRank": 8,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106536,6 +108131,7 @@
     "appearances": 1,
     "aggregatedRank": 1596,
     "countryRank": 46,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106595,6 +108191,7 @@
     "appearances": 1,
     "aggregatedRank": 1597,
     "countryRank": 22,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106656,6 +108253,7 @@
     "appearances": 1,
     "aggregatedRank": 1598,
     "countryRank": 23,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106717,6 +108315,7 @@
     "appearances": 1,
     "aggregatedRank": 1599,
     "countryRank": 24,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106778,6 +108377,7 @@
     "appearances": 1,
     "aggregatedRank": 1600,
     "countryRank": 25,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106839,6 +108439,7 @@
     "appearances": 1,
     "aggregatedRank": 1601,
     "countryRank": 26,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106898,6 +108499,7 @@
     "appearances": 1,
     "aggregatedRank": 1602,
     "countryRank": 200,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -106957,6 +108559,7 @@
     "appearances": 1,
     "aggregatedRank": 1603,
     "countryRank": 201,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107018,6 +108621,7 @@
     "appearances": 1,
     "aggregatedRank": 1604,
     "countryRank": 202,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107077,6 +108681,7 @@
     "appearances": 1,
     "aggregatedRank": 1605,
     "countryRank": 203,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107136,6 +108741,7 @@
     "appearances": 1,
     "aggregatedRank": 1606,
     "countryRank": 204,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107197,6 +108803,7 @@
     "appearances": 1,
     "aggregatedRank": 1607,
     "countryRank": 205,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107258,6 +108865,7 @@
     "appearances": 1,
     "aggregatedRank": 1608,
     "countryRank": 206,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107319,6 +108927,7 @@
     "appearances": 1,
     "aggregatedRank": 1609,
     "countryRank": 207,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107378,6 +108987,7 @@
     "appearances": 1,
     "aggregatedRank": 1610,
     "countryRank": 47,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107439,6 +109049,7 @@
     "appearances": 1,
     "aggregatedRank": 1611,
     "countryRank": 48,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107500,6 +109111,7 @@
     "appearances": 1,
     "aggregatedRank": 1612,
     "countryRank": 49,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107559,6 +109171,7 @@
     "appearances": 1,
     "aggregatedRank": 1613,
     "countryRank": 50,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107620,6 +109233,7 @@
     "appearances": 1,
     "aggregatedRank": 1614,
     "countryRank": 34,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107681,6 +109295,7 @@
     "appearances": 1,
     "aggregatedRank": 1615,
     "countryRank": 35,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107742,6 +109357,7 @@
     "appearances": 1,
     "aggregatedRank": 1616,
     "countryRank": 35,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107803,6 +109419,7 @@
     "appearances": 1,
     "aggregatedRank": 1617,
     "countryRank": 36,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107862,6 +109479,7 @@
     "appearances": 1,
     "aggregatedRank": 1618,
     "countryRank": 29,
+    "countryTotal": 29,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107921,6 +109539,7 @@
     "appearances": 1,
     "aggregatedRank": 1619,
     "countryRank": 12,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -107982,6 +109601,7 @@
     "appearances": 1,
     "aggregatedRank": 1620,
     "countryRank": 21,
+    "countryTotal": 21,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108041,6 +109661,7 @@
     "appearances": 1,
     "aggregatedRank": 1621,
     "countryRank": 101,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108102,6 +109723,7 @@
     "appearances": 1,
     "aggregatedRank": 1622,
     "countryRank": 215,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108161,6 +109783,7 @@
     "appearances": 1,
     "aggregatedRank": 1623,
     "countryRank": 216,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108222,6 +109845,7 @@
     "appearances": 1,
     "aggregatedRank": 1624,
     "countryRank": 217,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108283,6 +109907,7 @@
     "appearances": 1,
     "aggregatedRank": 1625,
     "countryRank": 51,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108344,6 +109969,7 @@
     "appearances": 1,
     "aggregatedRank": 1626,
     "countryRank": 208,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108403,6 +110029,7 @@
     "appearances": 1,
     "aggregatedRank": 1627,
     "countryRank": 18,
+    "countryTotal": 18,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108464,6 +110091,7 @@
     "appearances": 1,
     "aggregatedRank": 1628,
     "countryRank": 209,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108523,6 +110151,7 @@
     "appearances": 1,
     "aggregatedRank": 1629,
     "countryRank": 210,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108584,6 +110213,7 @@
     "appearances": 1,
     "aggregatedRank": 1630,
     "countryRank": 211,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108643,6 +110273,7 @@
     "appearances": 1,
     "aggregatedRank": 1631,
     "countryRank": 212,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108704,6 +110335,7 @@
     "appearances": 1,
     "aggregatedRank": 1632,
     "countryRank": 213,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108763,6 +110395,7 @@
     "appearances": 1,
     "aggregatedRank": 1633,
     "countryRank": 214,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108824,6 +110457,7 @@
     "appearances": 1,
     "aggregatedRank": 1634,
     "countryRank": 215,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108883,6 +110517,7 @@
     "appearances": 1,
     "aggregatedRank": 1635,
     "countryRank": 59,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -108942,6 +110577,7 @@
     "appearances": 1,
     "aggregatedRank": 1636,
     "countryRank": 216,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109001,6 +110637,7 @@
     "appearances": 1,
     "aggregatedRank": 1637,
     "countryRank": 217,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109060,6 +110697,7 @@
     "appearances": 1,
     "aggregatedRank": 1638,
     "countryRank": 218,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109119,6 +110757,7 @@
     "appearances": 1,
     "aggregatedRank": 1639,
     "countryRank": 219,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109178,6 +110817,7 @@
     "appearances": 1,
     "aggregatedRank": 1640,
     "countryRank": 220,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109237,6 +110877,7 @@
     "appearances": 1,
     "aggregatedRank": 1641,
     "countryRank": 221,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109296,6 +110937,7 @@
     "appearances": 1,
     "aggregatedRank": 1642,
     "countryRank": 222,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109355,6 +110997,7 @@
     "appearances": 1,
     "aggregatedRank": 1643,
     "countryRank": 53,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109416,6 +111059,7 @@
     "appearances": 1,
     "aggregatedRank": 1644,
     "countryRank": 102,
+    "countryTotal": 102,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109475,6 +111119,7 @@
     "appearances": 1,
     "aggregatedRank": 1645,
     "countryRank": 223,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109536,6 +111181,7 @@
     "appearances": 1,
     "aggregatedRank": 1646,
     "countryRank": 54,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109597,6 +111243,7 @@
     "appearances": 1,
     "aggregatedRank": 1647,
     "countryRank": 61,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109658,6 +111305,7 @@
     "appearances": 1,
     "aggregatedRank": 1648,
     "countryRank": 55,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109719,6 +111367,7 @@
     "appearances": 1,
     "aggregatedRank": 1649,
     "countryRank": 56,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109780,6 +111429,7 @@
     "appearances": 1,
     "aggregatedRank": 1650,
     "countryRank": 37,
+    "countryTotal": 37,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109839,6 +111489,7 @@
     "appearances": 1,
     "aggregatedRank": 1651,
     "countryRank": 224,
+    "countryTotal": 224,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109900,6 +111551,7 @@
     "appearances": 1,
     "aggregatedRank": 1652,
     "countryRank": 218,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -109961,6 +111613,7 @@
     "appearances": 1,
     "aggregatedRank": 1653,
     "countryRank": 219,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110022,6 +111675,7 @@
     "appearances": 1,
     "aggregatedRank": 1654,
     "countryRank": 41,
+    "countryTotal": 41,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110083,6 +111737,7 @@
     "appearances": 1,
     "aggregatedRank": 1655,
     "countryRank": 57,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110144,6 +111799,7 @@
     "appearances": 1,
     "aggregatedRank": 1656,
     "countryRank": 84,
+    "countryTotal": 84,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110205,6 +111861,7 @@
     "appearances": 1,
     "aggregatedRank": 1657,
     "countryRank": 58,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110266,6 +111923,7 @@
     "appearances": 1,
     "aggregatedRank": 1658,
     "countryRank": 10,
+    "countryTotal": 10,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110327,6 +111985,7 @@
     "appearances": 1,
     "aggregatedRank": 1659,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110386,6 +112045,7 @@
     "appearances": 1,
     "aggregatedRank": 1660,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110447,6 +112107,7 @@
     "appearances": 1,
     "aggregatedRank": 1661,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110508,6 +112169,7 @@
     "appearances": 1,
     "aggregatedRank": 1662,
     "countryRank": 26,
+    "countryTotal": 26,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110569,6 +112231,7 @@
     "appearances": 1,
     "aggregatedRank": 1663,
     "countryRank": 7,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110628,6 +112291,7 @@
     "appearances": 1,
     "aggregatedRank": 1664,
     "countryRank": 8,
+    "countryTotal": 8,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110687,6 +112351,7 @@
     "appearances": 1,
     "aggregatedRank": 1665,
     "countryRank": 6,
+    "countryTotal": 6,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110748,6 +112413,7 @@
     "appearances": 1,
     "aggregatedRank": 1666,
     "countryRank": 4,
+    "countryTotal": 4,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110809,6 +112475,7 @@
     "appearances": 1,
     "aggregatedRank": 1667,
     "countryRank": 7,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110868,6 +112535,7 @@
     "appearances": 1,
     "aggregatedRank": 1668,
     "countryRank": 8,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110927,6 +112595,7 @@
     "appearances": 1,
     "aggregatedRank": 1669,
     "countryRank": 9,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -110986,6 +112655,7 @@
     "appearances": 1,
     "aggregatedRank": 1670,
     "countryRank": 3,
+    "countryTotal": 3,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111045,6 +112715,7 @@
     "appearances": 1,
     "aggregatedRank": 1671,
     "countryRank": 52,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111104,6 +112775,7 @@
     "appearances": 1,
     "aggregatedRank": 1672,
     "countryRank": 1,
+    "countryTotal": 1,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111163,6 +112835,7 @@
     "appearances": 1,
     "aggregatedRank": 1673,
     "countryRank": 7,
+    "countryTotal": 7,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111222,6 +112895,7 @@
     "appearances": 1,
     "aggregatedRank": 1674,
     "countryRank": 36,
+    "countryTotal": 36,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111283,6 +112957,7 @@
     "appearances": 1,
     "aggregatedRank": 1675,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111342,6 +113017,7 @@
     "appearances": 1,
     "aggregatedRank": 1676,
     "countryRank": 9,
+    "countryTotal": 9,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111401,6 +113077,7 @@
     "appearances": 1,
     "aggregatedRank": 1677,
     "countryRank": 2,
+    "countryTotal": 2,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111460,6 +113137,7 @@
     "appearances": 1,
     "aggregatedRank": 1678,
     "countryRank": 13,
+    "countryTotal": 13,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111519,6 +113197,7 @@
     "appearances": 1,
     "aggregatedRank": 1679,
     "countryRank": 220,
+    "countryTotal": 220,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111580,6 +113259,7 @@
     "appearances": 1,
     "aggregatedRank": 1680,
     "countryRank": 63,
+    "countryTotal": 63,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111639,6 +113319,7 @@
     "appearances": 1,
     "aggregatedRank": 1681,
     "countryRank": 27,
+    "countryTotal": 27,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111700,6 +113381,7 @@
     "appearances": 1,
     "aggregatedRank": 1682,
     "countryRank": 60,
+    "countryTotal": 60,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111761,6 +113443,7 @@
     "appearances": 1,
     "aggregatedRank": 1683,
     "countryRank": 11,
+    "countryTotal": 11,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111820,6 +113503,7 @@
     "appearances": 1,
     "aggregatedRank": 1684,
     "countryRank": 59,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111881,6 +113565,7 @@
     "appearances": 1,
     "aggregatedRank": 1685,
     "countryRank": 53,
+    "countryTotal": 53,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -111942,6 +113627,7 @@
     "appearances": 1,
     "aggregatedRank": 1686,
     "countryRank": 60,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {
@@ -112003,6 +113689,7 @@
     "appearances": 1,
     "aggregatedRank": 1687,
     "countryRank": 61,
+    "countryTotal": 61,
     "insights": {
       "calculation": {
         "rawRanks": {

--- a/frontend/public/data/global-stats.json
+++ b/frontend/public/data/global-stats.json
@@ -26,7 +26,7 @@
   },
   "manualMappingsCount": 167,
   "autoMappingsCount": 7958,
-  "lastUpdated": "2026-01-21",
+  "lastUpdated": "2026-02-08",
   "disagreementDistribution": {
     "high-consensus": 37,
     "moderate-consensus": 96,

--- a/frontend/src/components/shared/UniversityCard.js
+++ b/frontend/src/components/shared/UniversityCard.js
@@ -65,6 +65,11 @@ const UniversityCard = ({ university, expanded, onToggle, globalStats, index }) 
               <MapPin size={13} className="text-muted-foreground/70" />
               {university.country}
             </span>
+            {university.countryRank && (
+              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-primary/5 border border-primary/10 text-[10px] font-semibold text-primary/80">
+                #{university.countryRank}{university.countryTotal ? ` of ${university.countryTotal}` : ''} nationally
+              </span>
+            )}
             <span className="hidden sm:inline-flex w-1 h-1 rounded-full bg-border" />
             <span className="font-mono text-xs">
               Score: <span className="text-foreground font-semibold">{university.aggregatedScore.toFixed(1)}</span>
@@ -142,6 +147,9 @@ const UniversityCard = ({ university, expanded, onToggle, globalStats, index }) 
                   <div className="p-4 rounded-xl bg-card border border-border/50">
                     <div className="text-xs text-muted-foreground mb-1 font-medium">National</div>
                     <div className="text-2xl font-bold font-space">#{university.countryRank}</div>
+                    {university.countryTotal && (
+                      <div className="text-[10px] text-muted-foreground mt-0.5">of {university.countryTotal} in {university.country}</div>
+                    )}
                   </div>
                   <div className="p-4 rounded-xl bg-card border border-border/50">
                     <div className="text-xs text-muted-foreground mb-1 font-medium">Consistency</div>

--- a/frontend/src/layouts/BentoDashboardLayout.js
+++ b/frontend/src/layouts/BentoDashboardLayout.js
@@ -175,9 +175,14 @@ const BentoDashboardLayout = ({ data, actions }) => {
                         </div>
                         <div className="min-w-0 flex-1">
                           <h3 className="font-bold text-base leading-snug">{uni.name}</h3>
-                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-1">
+                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-1 flex-wrap">
                             <MapPin size={11} />
                             <span>{uni.country}</span>
+                            {uni.countryRank && (
+                              <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded-md bg-primary/5 border border-primary/10 text-[10px] font-semibold text-primary/80">
+                                #{uni.countryRank}{uni.countryTotal ? ` of ${uni.countryTotal}` : ''} nationally
+                              </span>
+                            )}
                           </div>
                         </div>
                         <div className={`p-1.5 rounded-lg transition-colors ${isExpanded ? 'bg-primary/10 text-primary' : 'text-muted-foreground'}`}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "university-ranking-aggregator",
+  "name": "unirank",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "university-ranking-aggregator",
+      "name": "unirank",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/scripts/aggregation.js
+++ b/scripts/aggregation.js
@@ -126,6 +126,12 @@ function aggregateRankings(universitiesData, sourceWeights, sourceMaxRanks, tota
         university.countryRank = countryCounters[country];
     });
 
+    // Add total universities per country so frontend can display "# X of Y"
+    aggregatedResults.forEach(university => {
+        const country = university.country || 'Unknown';
+        university.countryTotal = countryCounters[country];
+    });
+
     return aggregatedResults;
 }
 


### PR DESCRIPTION
## Summary
Enhanced university ranking displays by adding national ranking context (e.g., "# X of Y nationally") to both the university cards and dashboard layout. This provides users with better perspective on how universities rank within their respective countries.

## Key Changes
- **Data Enhancement**: Updated aggregation script to calculate and include `countryTotal` for each university, enabling "X of Y" national ranking displays
- **UniversityCard Component**: 
  - Added inline national ranking badge in the header showing rank and total count
  - Enhanced expanded view to display country total alongside national rank
- **BentoDashboardLayout Component**: Added matching national ranking badge to university list items for consistency
- **Data Updates**: Refreshed aggregated rankings and global stats with latest data (updated to 2026-02-08)

## Implementation Details
- National ranking badges use consistent styling with primary color accents and subtle borders
- Conditional rendering ensures badges only display when `countryRank` data is available
- Layout adjustments (flex-wrap) accommodate the new badge in responsive designs
- The `countryTotal` is calculated during the aggregation phase and stored alongside existing ranking data

https://claude.ai/code/session_01UdmGJQmvDgeDD2voy9jTSg